### PR TITLE
Remove black bullets from navigation

### DIFF
--- a/styles/common/navigation.scss
+++ b/styles/common/navigation.scss
@@ -93,7 +93,7 @@ span.alpha-tag {
       }
 
       li {
-
+        display: inline-block;
         float: left;
         padding: 0 15px 0 0;
         border-bottom: 0;


### PR DESCRIPTION
The li in the navigation have a default browser style of display: list-item;

Override that so that we don't get weird black bullets in the navigation.
