### PR TITLE
Use supervisor instead of nodemon for development server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -179,6 +179,14 @@ module.exports = function(grunt) {
         tasks: ['jasmine:spotlight:build']
       }
     },
+    shell: {
+      supervisor: {
+        options: {
+          stdout: true
+        },
+        command: 'supervisor -w app app/server'
+      }
+    },
     nodemon: {
       dev: {
         options: {
@@ -192,7 +200,7 @@ module.exports = function(grunt) {
     },
     concurrent: {
       dev: {
-        tasks: ['nodemon', 'watch'],
+        tasks: ['shell:supervisor', 'watch'],
         options: {
           logConcurrentOutput: true
         }
@@ -210,7 +218,7 @@ module.exports = function(grunt) {
     'grunt-rcukes',
     'grunt-contrib-copy',
     'grunt-contrib-watch',
-    'grunt-nodemon',
+    'grunt-shell',
     'grunt-concurrent'
   ].forEach(function (task) {
     grunt.loadNpmTasks(task);

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Install dependencies:
 ```bash
 bundle install
 sudo npm install -g grunt-cli@0.1.9
+sudo npm install -g supervisor@0.5.6
 npm install
 ```
 
@@ -41,10 +42,10 @@ NODE_ENV=development_no_vm grunt
 This will create a development build of the assets and then run the app at
 `http://localhost:3057`.
 
-The app uses [grunt-nodemon][] and [grunt-contrib-watch][] to monitor changes,
+The app uses [node-supervisor][] and [grunt-contrib-watch][] to monitor changes,
 automatically restart the server and recompile Sass.
 
-[grunt-nodemon]: https://github.com/ChrisWren/grunt-nodemon
+[node-supervisor]: https://github.com/isaacs/node-supervisor
 [grunt-contrib-watch]: https://github.com/gruntjs/grunt-contrib-watch
 
 If you want to test with png rendering run the [screenshot-as-a-service][] app first in the appropriate environment.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "grunt-contrib-watch": "0.5.3",
     "grunt-concurrent": "0.4.1",
     "backbone": "1.1.0",
-    "underscore": "1.5.2"
+    "underscore": "1.5.2",
+    "grunt-shell": "~0.6.1"
   }
 }


### PR DESCRIPTION
nodemon was not detecting changes because of a misconfiguration.
However, it is also unstable in use on our development vm.
The vm system time gets out of sync with the host system time.
nodemon seems to use the modified date of files to detect changes
and when the times get out of sync, nodemon continuously restarts
the app.
