### PR TITLE
Switch to HTTPS for 'Report a problem' links

### DIFF
--- a/app/process_request.js
+++ b/app/process_request.js
@@ -29,7 +29,7 @@ function (StagecraftApiClient) {
   };
 
   var getGovukUrl = function (req) {
-    return [req.protocol, "://", req.app.get('govukHost'), req.originalUrl].join('');
+    return ["https://", req.app.get('govukHost'), req.originalUrl].join('');
   };
 
   var setup = function (req, res, next) {

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -21,5 +21,5 @@ Then(/^I can report an error for the current page$/) do
 
   current_path = URI.parse(current_url).path
   page.should have_css('input#url', :visible => false)
-  page.find('input#url', :visible => false)['value'].should === "http://spotlight.test.gov.uk#{current_path}"
+  page.find('input#url', :visible => false)['value'].should === "https://spotlight.test.gov.uk#{current_path}"
 end

--- a/spec/server/spec.process_request.js
+++ b/spec/server/spec.process_request.js
@@ -128,7 +128,7 @@ function (processRequest, Model, Controller, View) {
           protocol: 'http',
           originalUrl: '/performance/foo'
         };
-        expect(processRequest.getGovukUrl(req)).toEqual('http://spotlight.dev.gov.uk/performance/foo');
+        expect(processRequest.getGovukUrl(req)).toEqual('https://spotlight.dev.gov.uk/performance/foo');
       });
     });
   });


### PR DESCRIPTION
`req.protocol` will be HTTP as the Node app itself doesn't know anything about HTTPS.

Development is the only environment where this would be HTTP, and this isn't something that we would ever use in dev - so let's just set it to be HTTPS all the time and be done with it.
