### PR TITLE
Remove border-top from the first section in a dashboard

### DIFF
--- a/styles/common/layout.scss
+++ b/styles/common/layout.scss
@@ -50,6 +50,11 @@
 
     border-top: 1px solid $grey-2;
 
+    &:first-of-type {
+      border-top: 0;
+      margin-top: 0;
+    }
+
     &.half-width {
       width:48.5%;
       margin-left:3%;


### PR DESCRIPTION
Pivotal https://www.pivotaltracker.com/s/projects/911874

Done with `:first-of-type` selector, so will have no effect in IE8 and below. 
