### PR TITLE
Move related pages below initial para on small screens

### DIFF
--- a/app/common/templates/dashboard.html
+++ b/app/common/templates/dashboard.html
@@ -4,6 +4,7 @@
     {{ title }}
     {{# tagline }}<span class="tagline">{{ tagline }}</span>{{/ tagline }}
   </h1>
+  {{# copy }}<p class="explanatory">{{ copy }}</p>{{/ copy }}
   {{# related_pages_title }}
     <aside class='related-pages'>
       <h3>{{ related_pages_title }}</h3>
@@ -24,7 +25,6 @@
       </ol>
     </aside>
   {{/ related_pages_title }}
-  {{# copy }}<p class="explanatory">{{ copy }}</p>{{/ copy }}
 </header>
 
 {{{ modules }}}

--- a/styles/common/layout.scss
+++ b/styles/common/layout.scss
@@ -31,11 +31,10 @@
       }
     }
 
-
-
     p.explanatory {
       @include core-19;
-      width: 75%;
+      width: 60%;   
+      float: left;
     }
   }
 
@@ -73,6 +72,11 @@
   @media (max-width: 640px) {
 
     padding: 0;
+
+    header p.explanatory {
+      width: 90%;   
+      float: none;
+    }
 
     section {
       &.half-width {

--- a/styles/common/related_pages.scss
+++ b/styles/common/related_pages.scss
@@ -41,7 +41,7 @@
       @media (max-width: 640px) {
         float: none;
         margin-left: 0;
-        width: 75%;
+        width: 90%;
       }
     }
   }


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/s/projects/911874/stories/62545960

I haven't made the major redesign suggested by Michael, so we should keep the ticket open by now, but I have made sure that the related policies are below the initial para on screens below 640px. 
