### PR TITLE
Reenable Travis on node.js 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
+  - "0.11"
   - "0.10"
+matrix:
+  allow_failures:
+    - node_js: "0.11"
 install:
   - npm install -g grunt-cli@0.1.9
   - npm install


### PR DESCRIPTION
Reverted from 041605eb533edbefda28941e71dc1115ad6cb2da

[Let's wait and make sure it passes](https://travis-ci.org/alphagov/spotlight/builds/15637961) before merging this.
