### PR TITLE
Update govuk_template_mustache to v0.3.4

### DIFF
--- a/app/common/templates/govuk_template.html
+++ b/app/common/templates/govuk_template.html
@@ -71,7 +71,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="{{ assetPath }}images/gov.uk_logotype-2x.png" alt="GOV.UK">
+              <img src="{{ assetPath }}images/gov.uk_logotype_crown.png" alt=""> <span>GOV&nbsp;<span>.</span>UK</span>
             </a>
           </div>
 
@@ -81,6 +81,8 @@
     </header>
     <!--end header-->
     
+
+    {{{ afterHeader }}}
 
     <div id="global-cookie-message">
       

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jsdom": "0.8.6",
     "xmlhttprequest": "1.6.0",
     "d3": "3.3.7",
-    "govuk_template_mustache": "0.2.2",
+    "govuk_template_mustache": "0.3.4",
     "govuk_frontend_toolkit": "0.12.6",
     "moment-timezone": "0.0.3",
     "winston": "0.7.2"


### PR DESCRIPTION
Diff: https://github.com/alphagov/govuk_template/compare/v0.2.2...v0.3.4

The GOV.UK header has changed on preview, indicating that we should probably be keeping up.

However, I would imagine this won't be deployed until after Christmas.
