### PR TITLE
Make related-pages links non-policy specific

### DIFF
--- a/app/common/templates/dashboard.html
+++ b/app/common/templates/dashboard.html
@@ -8,18 +8,15 @@
   {{# related_pages_title }}
     <aside class='related-pages'>
       <h3>{{ related_pages_title }}</h3>
-      {{! this could come from a relatively simple query to https://www.gov.uk/government/policies.json?keywords=&topics%5B%5D=housing&departments%5B%5D=all }}
-      {{! we'll pretend it comes from stagecraft for now }}
       <ol class="items">
         {{# related_pages }}
         <li>
-          <h3><a href="{{ url }}" rel="external" target="_blank">{{ title }}</a></h3>
-          <ul class="attributes">
-            <li>{{{ display_date_microformat }}}</li>
-            <li class="organisations">
-              {{{ organisations }}}
-            </li>
-          </ul>
+          <h3>
+            <a href="{{ url }}" rel="external" target="_blank">{{ title }}</a>
+          </h3>
+          {{# metadata }}
+          <span class="metadata">{{{ metadata }}}</span>
+          {{/ metadata }}
         </li>
         {{/ related_pages }}
       </ol>

--- a/app/support/stagecraft_stub/responses/housing.json
+++ b/app/support/stagecraft_stub/responses/housing.json
@@ -5,21 +5,27 @@
   "tagline": "",
   "copy": "The government is helping local councils and developers work with local communities to plan and build better places to live for everyone. This includes building affordable housing, improving the quality of rented housing, helping more people to buy a home and providing housing support for vulnerable people.",
   "related_pages_title": "Housing policies",
-  "related_pages":[
+  "related_pages": [
     {
-      "id":248188,
-      "type":"policy",
-      "display_type":"Policy",
-      "title":"Helping people to buy a home",
-      "url":"/government/policies/helping-people-to-buy-a-home",
-      "organisations":"<abbr title=\"Department for Communities and Local Government\">DCLG</abbr>, <abbr title=\"HM Treasury\">HMT</abbr> and <abbr title=\"Homes and Communities Agency\">HCA</abbr>",
-      "display_date_microformat":"<abbr class=\"public_timestamp\" title=\"2013-10-08T06:51:36+01:00\"> 8 October 2013</abbr>",
-      "public_timestamp":"2013-10-08T06:51:36+01:00",
-      "topics":"Housing"
+      "title": "Helping people to buy a home",
+      "url": "https://www.gov.uk/government/policies/helping-people-to-buy-a-home",
+      "metadata": "<time datetime=\"2013-10-08T06:51:36+01:00\" title=\"2013-10-08T06:51:36+01:00\">8 October 2013</time> from <abbr title=\"Department for Communities and Local Government\">DCLG</abbr>, <abbr title=\"HM Treasury\">HMT</abbr> and <abbr title=\"Homes and Communities Agency\">HCA</abbr>"
     },
-    {"id":228180,"type":"policy","display_type":"Policy","title":"Increasing the number of available homes","url":"/government/policies/increasing-the-number-of-available-homes","organisations":"<abbr title=\"Department for Communities and Local Government\">DCLG</abbr>","display_date_microformat":"<abbr class=\"public_timestamp\" title=\"2013-08-20T09:30:05+01:00\">20 August 2013</abbr>","public_timestamp":"2013-08-20T09:30:05+01:00","topics":"Housing"},
-    {"id":253008,"type":"policy","display_type":"Policy","title":"Improving the rented housing sector","url":"/government/policies/improving-the-rented-housing-sector--2","organisations":"<abbr title=\"Department for Communities and Local Government\">DCLG</abbr>","display_date_microformat":"<abbr class=\"public_timestamp\" title=\"2013-06-20T12:51:23+01:00\">20 June 2013</abbr>","public_timestamp":"2013-06-20T12:51:23+01:00","topics":"Housing"},
-    {"id":178393,"type":"policy","display_type":"Policy","title":"Providing housing support for older and vulnerable people","url":"/government/policies/providing-housing-support-for-older-and-vulnerable-people","organisations":"<abbr title=\"Department for Communities and Local Government\">DCLG</abbr>","display_date_microformat":"<abbr class=\"public_timestamp\" title=\"2013-04-09T14:23:04+01:00\"> 9 April 2013</abbr>","public_timestamp":"2013-04-09T14:23:04+01:00","topics":"Housing"}
+    {
+      "title": "Increasing the number of available homes",
+      "url": "https://www.gov.uk/government/policies/increasing-the-number-of-available-homes",
+      "metadata": "<time datetime=\"2013-08-20T09:30:05+01:00\" title=\"2013-08-20T09:30:05+01:00\">20 August 2013</time> from <abbr title=\"Department for Communities and Local Government\">DCLG</abbr>"
+    },
+    {
+      "title": "Improving the rented housing sector",
+      "url": "https://www.gov.uk/government/policies/improving-the-rented-housing-sector--2",
+      "metadata": "<time datetime=\"2013-06-20T12:51:23+01:00\" title=\"2013-06-20T12:51:23+01:00\">20 June 2013</time> from <abbr title=\"Department for Communities and Local Government\">DCLG</abbr>"
+    },
+    {
+      "title": "Providing housing support for older and vulnerable people",
+      "url": "https://www.gov.uk/government/policies/providing-housing-support-for-older-and-vulnerable-people",
+      "metadata": "<time datetime=\"2013-04-09T14:23:04+01:00\" title=\"2013-04-09T14:23:04+01:00\">9 April 2013</time> from <abbr title=\"Department for Communities and Local Government\">DCLG</abbr>"
+    }
   ],
   "modules": [
     {

--- a/styles/common/related_pages.scss
+++ b/styles/common/related_pages.scss
@@ -9,7 +9,7 @@
         margin: 0;
         padding-left: 0px;
 
-        li{
+        li {
           display: block;
           overflow: hidden;
           list-style: none;
@@ -23,17 +23,8 @@
             }
           }
 
-          ul.attributes{
+          .metadata {
             @include core-14;
-            padding-left: 0px;
-
-            li{
-              list-style: none;
-              display: block;
-              float: left;
-              padding: 0 10px 0 0;
-              margin: 0;
-            }
           }
         }
       }


### PR DESCRIPTION
This means that we can use related_pages on the G-Cloud dashboard.

This also fulfills the criteria of [#62544832] by removing the `<abbr>` tags from the Stagecraft stub provided for housing.
