### PR TITLE
Display page load time in seconds

### DIFF
--- a/app/common/templates/visualisations/availability.html
+++ b/app/common/templates/visualisations/availability.html
@@ -1,8 +1,10 @@
 <div class="double-decker-graph">
   <nav id="availability-nav"></nav>
+
   <h3>Page load time</h3>
   <p class="impact-number response-time"></p>
   <div class="timeseries-graph response-time-graph"></div>
+
   <h3>Uptime</h3>
   <p class="impact-number uptime"></p>
   <div class="timeseries-graph uptime-graph"></div>

--- a/app/common/views/visualisations/availability/response-time-graph.js
+++ b/app/common/views/visualisations/availability/response-time-graph.js
@@ -17,7 +17,7 @@ function (Graph) {
         { view: this.sharedComponents.yaxis, options: {
             tickFormat: function () {
               return function (d) {
-                return ResponseTimeGraph.prototype.formatDuration(d, 4);
+                return ResponseTimeGraph.prototype.formatDuration(d, 's', 2);
               };
             }
           }
@@ -33,7 +33,7 @@ function (Graph) {
           view: this.sharedComponents.tooltip,
           options: {
             formatValue: function (value) {
-              return this.formatDuration(value, 4);
+              return this.formatDuration(value, 's', 2);
             }
           }
         },

--- a/app/common/views/visualisations/availability/response-time-number.js
+++ b/app/common/views/visualisations/availability/response-time-number.js
@@ -41,7 +41,7 @@ function (SingleStatView) {
       if (averageResponse === null) {
         return "<span class='no-data'>(no data)</span>";
       } else {
-        return this.formatDuration(Math.round(averageResponse), 4);
+        return this.formatDuration(Math.round(averageResponse), 's', 2);
       }
     },
 
@@ -50,7 +50,7 @@ function (SingleStatView) {
       if (responseTime === null) {
         return "<span class='no-data'>(no data)</span>";
       } else {
-        return this.formatDuration(responseTime, 4);
+        return this.formatDuration(responseTime, 's', 2);
       }
     },
 

--- a/app/extensions/views/view.js
+++ b/app/extensions/views/view.js
@@ -7,9 +7,9 @@ define([
 ],
 function (Backbone, DateFunctions, Modernizr, $, _) {
   var View = Backbone.View.extend({
-    
+
     modernizr: Modernizr,
-  
+
     initialize: function (options) {
       _.extend(this, options);
       this.viewInstances = {};
@@ -27,7 +27,7 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
       }
       this.renderSubviews(options);
     },
-    
+
     templateContext: function () {
       var context = {
         model: this.model,
@@ -53,7 +53,7 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
     },
 
     renderSubviews: function (options) {
-      
+
       var viewsDefinition = this.views;
       if (_.isFunction(viewsDefinition)) {
         viewsDefinition = viewsDefinition.call(this);
@@ -65,13 +65,13 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
           console.warn('No element found for ' + selector);
           return;
         }
-        
+
         var view,
             options = this.defaultSubviewOptions();
 
         $el.empty();
         options.$el = $el;
-        
+
         if (typeof definition === 'function') {
           view = definition.call(this);
         } else if (_.isObject(definition)) {
@@ -92,7 +92,7 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
         });
       }, this);
     },
-    
+
     /*
      *  Subviews definition. Override in subclasses.
      *
@@ -126,11 +126,11 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
      *  No wrapper element is created for subviews.
      */
     views: {},
-    
+
     keys: {
       escape: 27
     },
-    
+
     magnitudes: {
         billion:  {value: 1e9, threshold: 499500000, suffix:"b"},
         million:  {value: 1e6, threshold: 499500, suffix:"m"},
@@ -171,7 +171,7 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
       } else {
         decimalPlaces = values.every(isAnExactMultipleOf(magnitude.value))? 0 : 1;
       }
-      
+
       var format = this.format;
       return function(value) {
         if (value === 0) return "0";
@@ -299,9 +299,9 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
       if (showSigns) {
         if (fraction > 0) {
           value = "+" + value;
-        } else if (fraction < 0) { 
+        } else if (fraction < 0) {
           value = "−" + value;
-        } 
+        }
       }
       value += "%";
       return value;
@@ -350,39 +350,44 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
       }
     },
 
-    formatDuration: function (milliseconds, maxLength) {
+    /**
+     * Formats a number of milliseconds as a given unit of time
+     * @param {Number} milliseconds Duration in milliseconds
+     * @param {String} unit Unit to format as (either ms or s)
+     * @param {Number} precision Number of significant figures to format to
+     */
+    formatDuration: function (milliseconds, unit, precision) {
+
+      var formattedNumber, formatString;
 
       var millisecondsToSeconds = function (t) {
         return t/1000;
       };
 
-      var roundWithPrecision = function (x,p) {
-        var a = [1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000,10000000000];
-        return Math.round(x*a[p])/a[p];
-      };
-
-      var visualLength = function (item) {
-        return item.toString().length;
+      var roundToSignificantFigures = function (value, sigFigs) {
+        if (value === 0) {
+          return 0;
+        } else {
+          var exponent = sigFigs - Math.floor(Math.log(value) / Math.LN10) - 1;
+          var magnitude = Math.pow(10, exponent);
+          return Math.round(value * magnitude) / magnitude;
+        }
       };
 
       milliseconds = Math.round(milliseconds);
 
-      if(visualLength(milliseconds) > maxLength){
-        var seconds = millisecondsToSeconds(milliseconds);
-        var secondsWithPrecision = roundWithPrecision(seconds, 1);
-        if(visualLength(secondsWithPrecision) > maxLength){
-          return Math.round(seconds) + 's';        
-        }
-        else{
-          return secondsWithPrecision + 's';
-        }
-      }
-      else{
-        return milliseconds + 'ms';
+      if (unit === 's') {
+        formattedNumber = roundToSignificantFigures(millisecondsToSeconds(milliseconds), precision);
+        formatString = 's';
+      } else {
+        formattedNumber = roundToSignificantFigures(milliseconds, precision);
+        formatString = 'ms';
       }
 
+      return formattedNumber + formatString;
+
     },
-  
+
     /**
      * Convenience method, gets object property or method result. The method
      * is passed no arguments and is executed in the object context.

--- a/spec/shared/extensions/views/spec.view.js
+++ b/spec/shared/extensions/views/spec.view.js
@@ -76,13 +76,13 @@ function (View, Model, Backbone, _) {
     });
 
     describe("renderSubviews / removeSubviews", function() {
-      
+
       var model, SubViewA, SubViewB, CustomView;
       beforeEach(function() {
         model = new Model({
           foo: 'bar'
         });
-          
+
         SubViewA = View.extend({
           template: function () {
             return 'foo';
@@ -95,13 +95,13 @@ function (View, Model, Backbone, _) {
           },
           remove: jasmine.createSpy()
         });
-        
+
         CustomView = View.extend({
           views: {
             '.a': { view: SubViewA },
             '#b': { view: SubViewB }
           },
-          
+
           template: function () {
             return "<div class='a'></div><div id='b'></div>";
           }
@@ -109,7 +109,7 @@ function (View, Model, Backbone, _) {
       });
 
       describe('render default options', function () {
-        
+
         it("renders subviews with default options into their selectors", function() {
           var parent = new CustomView({
             model: model
@@ -126,7 +126,7 @@ function (View, Model, Backbone, _) {
           expect(b.$el.html()).toEqual('bar');
           expect(b.model).toBe(parent.model);
         });
-      
+
         it("renders sub views with custom options into their selectors", function() {
 
           CustomView.prototype.views = {
@@ -174,28 +174,32 @@ function (View, Model, Backbone, _) {
         });
       });
     });
-    
 
-    describe("formatDuration", function() {
-      describe("when there are more than threshold rounded milliseconds", function() {
-        it("should return the number of milliseconds to seconds to two decimal places with s", function() {
+    describe('formatDuration', function () {
+      describe('milliseconds', function () {
+        it('should return the number of milliseconds to a given precision followed by ms', function () {
           var view = View.prototype;
-          expect(view.formatDuration(1000,3)).toBe("1s");
-          expect(view.formatDuration(10000,4)).toBe("10s");
-          expect(view.formatDuration(10600,4)).toBe("10.6s");
-          expect(view.formatDuration(10670,4)).toBe("10.7s");
-          expect(view.formatDuration(10470,4)).toBe("10.5s");
-          expect(view.formatDuration(100470,4)).toBe("100s");
-          expect(view.formatDuration(100670,4)).toBe("101s");
+          expect(view.formatDuration(0, 'ms', 4)).toBe('0ms');
+          expect(view.formatDuration(2594, 'ms', 3)).toBe('2590ms');
+          expect(view.formatDuration(2594, 'ms', 4)).toBe('2594ms');
+          expect(view.formatDuration(2594, 'ms', 5)).toBe('2594ms');
         });
       });
-      describe("when there are fewer than threshold rounded milliseconds", function() {
-        it("should return the number of milliseconds with ms", function() {
+
+      describe('seconds', function () {
+        it('should return the number of seconds to a given precision followed by s', function () {
           var view = View.prototype;
-          expect(view.formatDuration(1000,4)).toBe("1000ms");
+          expect(view.formatDuration(0, 's', 3)).toBe('0s');
+          expect(view.formatDuration(246, 's', 3)).toBe('0.246s');
+          expect(view.formatDuration(358, 's', 2)).toBe('0.36s');
+          expect(view.formatDuration(4628, 's', 3)).toBe('4.63s');
+          expect(view.formatDuration(8849, 's', 2)).toBe('8.8s');
+          expect(view.formatDuration(372956, 's', 2)).toBe('370s');
+          expect(view.formatDuration(15428, 's', 3)).toBe('15.4s');
+          expect(view.formatDuration(15428, 's', 6)).toBe('15.428s');
         });
       });
-    })
+    });
 
     describe("numberListFormatter", function() {
       describe("when all label are lower than 1000", function() {
@@ -204,7 +208,7 @@ function (View, Model, Backbone, _) {
           expect(formatter(50)).toBe("50");
         });
       });
-      
+
       describe("when all label are lower than 1,000,000", function() {
         it("should format all labels as thousands", function() {
           var formatter = View.prototype.numberListFormatter([0, 1000, 2000, 3000]);
@@ -217,7 +221,7 @@ function (View, Model, Backbone, _) {
           expect(formatter(1000)).toBe("1.0k");
           expect(formatter(1500)).toBe("1.5k");
         });
-        
+
         it("should format with decimals when the max value matches the magnitude", function() {
           var formatter = View.prototype.numberListFormatter([0, 1000]);
           expect(formatter(200)).toBe("0.2k");
@@ -283,7 +287,7 @@ function (View, Model, Backbone, _) {
         it("should decrease the number of ticks if it allows nicer ticks", function() {
           var extent = [0, 4000];
           var ticks = View.prototype.calculateLinearTicks(extent, 7);
-          expect(ticks.values).toEqual([0, 1000, 2000, 3000, 4000])
+          expect(ticks.values).toEqual([0, 1000, 2000, 3000, 4000]);
         });
       });
 
@@ -334,13 +338,13 @@ function (View, Model, Backbone, _) {
     });
 
     describe("formatNumericLabel", function() {
-      
+
       var formatNumericLabel = View.prototype.formatNumericLabel;
 
       it("should handle null input, when missing data", function() {
         expect(formatNumericLabel(null)).toBe(null);
-      }),
-      
+      });
+
       it("should display entire numbers from 0 to 499", function() {
         expect(formatNumericLabel(0)).toBe('0');
         expect(formatNumericLabel(1)).toBe('1');
@@ -397,7 +401,7 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(234568234)).toBe('235m');
         expect(formatNumericLabel(499499499)).toBe('499m');
       });
-      
+
       it("should display numbers from 500000000 and above as fractions of 1b", function() {
         expect(formatNumericLabel(500000000)).toBe('0.50b');
         expect(formatNumericLabel(1000000000)).toBe('1.00b');
@@ -419,7 +423,7 @@ function (View, Model, Backbone, _) {
             for (var i = start; i < end; i+=increment) {
               createExpectation(i, format(i));
             }
-          })
+          });
         },
         createExpectation = function(i, expectation) {
           expect(formatNumericLabel(i)).toBe(expectation);
@@ -460,7 +464,7 @@ function (View, Model, Backbone, _) {
           expect(formatNumericLabel(1010000)).toBe("1.01m");
           expect(formatNumericLabel(9099000)).toBe("9.10m");
           expect(formatNumericLabel(1009900)).toBe("1.01m");
-        })
+        });
       });
     });
 
@@ -476,7 +480,7 @@ function (View, Model, Backbone, _) {
         expect(format(0.011, 2)).toEqual('1.10%');
         expect(format(1, 2)).toEqual('100.00%');
       });
-      
+
       it("formats signed input with the correct sign", function () {
         expect(format(0.011, 2, false)).toEqual('1.10%');
         expect(format(1, 2, true)).toEqual('+100.00%');
@@ -594,7 +598,7 @@ function (View, Model, Backbone, _) {
         view.testProp = { foo: 'bar' };
         expect(view.prop('testProp')).toEqual({ foo: 'bar' });
       });
-      
+
       it("retrieves an object method result", function() {
         var view = new View();
         view.otherProp = { foo: 'bar' };
@@ -603,7 +607,7 @@ function (View, Model, Backbone, _) {
         };
         expect(view.prop('testProp')).toEqual({ foo: 'bar' });
       });
-      
+
       it("retrieves property from another object", function() {
         var view = new View();
         var anotherObject = {
@@ -611,7 +615,7 @@ function (View, Model, Backbone, _) {
         };
         expect(view.prop('testProp', anotherObject)).toEqual({ foo: 'bar' });
       });
-      
+
       it("retrieves method result from another object", function() {
         var view = new View();
         var anotherObject = {


### PR DESCRIPTION
Change `formatDuration` method to use a given unit.

Previously we relied on the visual length (number of characters) of a string to determine what unit it was output as. I think we should be able to specify the unit (milliseconds or seconds) in the method signature.

Allows formatting to a given number of significant figures.
