### PR TITLE
Change rounding thresholds

### DIFF
--- a/app/extensions/views/view.js
+++ b/app/extensions/views/view.js
@@ -257,9 +257,9 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
        * as 500,000 and formatted as 0.50m.
        */
       var magnitudeOf = function(number) {
-        if (Math.abs(number) >= 499500000) return View.prototype.magnitudes.billion;
-        if (Math.abs(number) >= 499500) return View.prototype.magnitudes.million;
-        if (Math.abs(number) >= 499.5) return View.prototype.magnitudes.thousand;
+        if (Math.abs(number) >= 999500000) return View.prototype.magnitudes.billion;
+        if (Math.abs(number) >= 999500) return View.prototype.magnitudes.million;
+        if (Math.abs(number) >= 999.5) return View.prototype.magnitudes.thousand;
         return View.prototype.magnitudes.unit;
       };
 

--- a/spec/shared/extensions/views/spec.view.js
+++ b/spec/shared/extensions/views/spec.view.js
@@ -345,7 +345,7 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(null)).toBe(null);
       });
 
-      it("should display entire numbers from 0 to 499", function() {
+      it("should display entire numbers from 0 to 999", function() {
         expect(formatNumericLabel(0)).toBe('0');
         expect(formatNumericLabel(1)).toBe('1');
         expect(formatNumericLabel(9)).toBe('9');
@@ -354,6 +354,9 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(100)).toBe('100');
         expect(formatNumericLabel(398)).toBe('398');
         expect(formatNumericLabel(499)).toBe('499');
+        expect(formatNumericLabel(500)).toBe('500');
+        expect(formatNumericLabel(777)).toBe('777');
+        expect(formatNumericLabel(999)).toBe('999');
       });
 
       it("should display real numbers from 0 to 9.99 with two decimal digits", function() {
@@ -370,29 +373,20 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(99.96)).toBe('100');
       });
 
-      it("should display numbers from 500 to 499499 as fractions of 1k", function() {
-        expect(formatNumericLabel(500)).toBe('0.50k');
-        expect(formatNumericLabel(777)).toBe('0.78k');
-        expect(formatNumericLabel(994)).toBe('0.99k');
-        expect(formatNumericLabel(995)).toBe('1.00k');
-        expect(formatNumericLabel(996)).toBe('1.00k');
-        expect(formatNumericLabel(999)).toBe('1.00k');
+      it("should display numbers from 1000 to 999499 as fractions of 1k", function() {
         expect(formatNumericLabel(1000)).toBe('1.00k');
         expect(formatNumericLabel(1005)).toBe('1.01k');
         expect(formatNumericLabel(1006)).toBe('1.01k');
         expect(formatNumericLabel(100000)).toBe('100k');
         expect(formatNumericLabel(234568)).toBe('235k');
-        expect(formatNumericLabel(499499)).toBe('499k');
+        expect(formatNumericLabel(500000)).toBe('500k');
+        expect(formatNumericLabel(777777)).toBe('778k');
+        expect(formatNumericLabel(999499)).toBe('999k');
       });
 
-      it("should display numbers from 499500 and above as fractions of 1m", function() {
-        expect(formatNumericLabel(499500)).toBe('0.50m');
-        expect(formatNumericLabel(500000)).toBe('0.50m');
-        expect(formatNumericLabel(777777)).toBe('0.78m');
-        expect(formatNumericLabel(994499)).toBe('0.99m');
-        expect(formatNumericLabel(994999)).toBe('0.99m');
-        expect(formatNumericLabel(995000)).toBe('1.00m');
-        expect(formatNumericLabel(995001)).toBe('1.00m');
+      it("should display numbers from 999500 and above as fractions of 1m", function() {
+        expect(formatNumericLabel(999500)).toBe('1.00m');
+        expect(formatNumericLabel(999501)).toBe('1.00m');
         expect(formatNumericLabel(999900)).toBe('1.00m');
         expect(formatNumericLabel(1000000)).toBe('1.00m');
         expect(formatNumericLabel(1005000)).toBe('1.01m');
@@ -403,11 +397,10 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(9099000)).toBe('9.10m');
         expect(formatNumericLabel(100000000)).toBe('100m');
         expect(formatNumericLabel(234568234)).toBe('235m');
-        expect(formatNumericLabel(499499499)).toBe('499m');
+        expect(formatNumericLabel(999499499)).toBe('999m');
       });
 
-      it("should display numbers from 500000000 and above as fractions of 1b", function() {
-        expect(formatNumericLabel(500000000)).toBe('0.50b');
+      it("should display numbers from 999500000 and above as fractions of 1b", function() {
         expect(formatNumericLabel(1000000000)).toBe('1.00b');
         expect(formatNumericLabel(25250000000)).toBe('25.3b');
       });
@@ -421,39 +414,33 @@ function (View, Model, Backbone, _) {
         expect(formatNumericLabel(-1234)).toBe('-1.23k');
       });
 
-      describe("generative tests", function() {
-        var createTests = function(start, end, increment, format) {
+      describe("generative tests", function () {
+        var createTests = function (start, end, increment, format) {
           it("should correctly format numbers in the range " + start + "-" + end, function() {
             for (var i = start; i < end; i+=increment) {
               createExpectation(i, format(i));
             }
           });
-        },
-        createExpectation = function(i, expectation) {
+        };
+
+        var createExpectation = function (i, expectation) {
           expect(formatNumericLabel(i)).toBe(expectation);
         };
 
         createTests(0,   20,   1, function(i) { return i.toString(); });
-        createTests(500, 600,  1, function(i) { return "0." + Math.round(i / 10) + "k"; });
-        createTests(980, 995,  1, function(i) { return "0." + Math.round(i / 10) + "k"; });
-        createTests(995, 1000, 1, function(i) {
-          var expected = "1." + (Math.round(i / 10) - 100);
-          if (expected.length < 4) {
-            expected += "0";
-          }
-          return expected + "k";
-        });
+        createTests(500, 600,  1, function(i) { return i.toString(); });
+        createTests(980, 999,  1, function(i) { return i.toString(); });
         createTests(1000,   1100,    1,    function(i) { return (Math.round(i / 10) / 100).toPrecision(3) + "k"; });
         createTests(9400,   10000,   10,   function(i) { return (Math.round(i / 10) / 100).toPrecision(3) + "k"; });
         createTests(10000,  11500,   10,   function(i) { return (Math.round(i / 100) / 10).toPrecision(3) + "k"; });
         createTests(50450,  50500,   10,   function(i) { return (Math.round(i / 100) / 10).toPrecision(3) + "k"; });
         createTests(100000, 101000,  10,   function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
         createTests(499000, 499500,  100,  function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
-        createTests(499500, 500000,  100,  function(i) { return (Math.round(i / 10000) / 100).toPrecision(2) + "m"; });
-        createTests(504500, 506000,  150,  function(i) { return (Math.round(i / 10000) / 100).toPrecision(2) + "m"; });
-        createTests(700000, 800000,  150,  function(i) { return (Math.round(i / 10000) / 100).toPrecision(2) + "m"; });
-        createTests(994499, 995000,  150,  function(i) { return (Math.round(i / 10000) / 100).toPrecision(2) + "m"; });
-        createTests(995000, 999999,  150,  function(i) { return (Math.round(i / 10000) / 100).toPrecision(3) + "m"; });
+        createTests(499500, 500000,  100,  function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
+        createTests(504500, 506000,  150,  function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
+        createTests(700000, 800000,  150,  function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
+        createTests(994499, 999500,  150,  function(i) { return Math.round(i / 1000).toPrecision(3) + "k"; });
+        createTests(999500, 999999,  150,   function(i) { return (Math.round(i / 10000) / 100).toPrecision(3) + "m"; });
         createTests(999999, 1999999, 10000, function(i) { return (Math.round(i / 10000) / 100).toPrecision(3) + "m"; });
       });
     });


### PR DESCRIPTION
This pull request changes values displayed on the Performance Platform, eg 0.84m is now 842k. This can/will affect all the numbers we display.

I'd like to have a conversation with whoever is interested about how we display data, specifically whether we should show data to a certain number of significant figures, whether we should pad with zeros and what assertions that means we're making about the data. I'm on 2nd line until the 8th of January but I've made a note to have a chat then.
