### PR TITLE
Fix asset digest in development

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -29,6 +29,15 @@ function (express, fs, path, winston) {
 
         if (environment === 'development') {
           global.logger.debug('Winston is logging in development');
+
+          // In development, overwrite the asset digest so that each value is equal to the key,
+          // because Sass will recompile itself to the non-cachebusted filename with each change.
+          var assetDigest = app.get('assetDigest');
+          _.each(assetDigest, function (value, key) {
+            assetDigest[key] = key;
+          });
+          app.set('assetDigest', assetDigest);
+
           app.use(express.errorHandler());
           app.use('/app', express['static'](path.join(rootDir, 'app')));
           app.get('/backdrop-stub/:service/:api_name', requirejs('./support/backdrop_stub/backdrop_stub_controller'));


### PR DESCRIPTION
I broke Sass compilation in development. Sorry.

Currently, development will use a cachebusted URL for CSS. However
when you make a change to a Sass file, Sass will only create a file
called spotlight.css which means you won't see the changes you've
just made (as your view is still using the old cachebusted file).

This change means that in development, the asset digest is still
used but the cachebusted filename is equal to the non-cachebusted
filename. So you can go and edit Sass files to your heart's content
and see the changes without restarting the server.

Happy New Year! :fireworks:
