### PR TITLE
Show quarterly ticks on x-axis for monthly data over long timeframe.

### DIFF
--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -285,19 +285,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
       day: scaleByEndDate,
       week: scaleByEndDate,
       quarter: scaleByEndDate,
-      month: {
-        getXPos: function(groupIndex, modelIndex) {
-          return modelIndex;
-        },
-        calcXScale: function () {
-          var start, end, xScale;
-          var total = this.collection.first().get('values');
-          xScale = this.d3.scale.linear();
-          xScale.domain([0, total.length - 1]);
-          xScale.range([0, this.innerWidth]);
-          return xScale;
-        }
-      },
+      month: scaleByEndDate, 
       
       ymin: { 
         initialize: function() {

--- a/app/extensions/views/graph/xaxis.js
+++ b/app/extensions/views/graph/xaxis.js
@@ -117,17 +117,25 @@ function (Axis) {
       },
       month: {
         getTick: function (model, index) {
-          return index;
+          return this.getMoment(model.get('_end_at')).subtract(1, 'days').toDate();
         },
         tickFormat: function () {
-          var period = this.collection.query.get('period');
-          var values = this.collection.first().get('values');
-          return function (d, index) {
-            return values.at(index).get('_start_at').format('MMM');
-          };
+          return _.bind(function (d, index) {
+            var val = this.getMoment(d).format('MMM');
+            if (d.getMonth() === 0) {
+              val += " " + this.getMoment(d).format('YYYY');
+            }
+            return val;
+          }, this);
         },
         tickValues: function () {
-          return this.collection.first().get('values').map(_.bind(this.getTick, this));
+          var tickVals = this.collection.first().get('values').map(_.bind(this.getTick, this));
+          if (tickVals.length > 15) {
+            tickVals = _.filter(tickVals, function(d) {
+              return ((d.getMonth() % 3) === 0);
+            });
+          }
+          return tickVals;
         }
       }
     }

--- a/spec/client/extensions/views/graph/spec.xaxis.js
+++ b/spec/client/extensions/views/graph/spec.xaxis.js
@@ -16,10 +16,12 @@ function (XAxis, Collection) {
     });
 
     function viewForConfig(config, startDate, endDate, useEllipses) {
+      
       var collection = new Collection();
       var start = collection.getMoment(startDate);
       var end = collection.getMoment(endDate);
       var values = [];
+
       for (var date = start.clone(); +date < +end; date.add(1, config + 's')) {
         values.push({
           _end_at: date.clone()
@@ -73,6 +75,22 @@ function (XAxis, Collection) {
         expect(d3.select(ticks[1]).text()).toEqual('17 Mar');
         expect(d3.select(ticks[2]).text()).toEqual('24 Mar');
         expect(d3.select(ticks[3]).text()).toEqual('31 Mar');
+      });
+    });
+    
+    describe("'month' configuration", function () {
+      it("shows tick and label each month, or quarter if appropriate", function () {
+        var view = viewForConfig('month', '2012-01-05T00:00:00+00:00', '2013-12-05T00:00:00+01:00');
+        view.render();
+        
+        var ticks = wrapper.selectAll('.tick')[0];
+        
+        expect(wrapper.selectAll('.tick')[0].length).toEqual(8);
+        expect(d3.select(ticks[0]).text()).toEqual('Jan 2012');
+        expect(d3.select(ticks[1]).text()).toEqual('Apr');
+        expect(d3.select(ticks[2]).text()).toEqual('July');
+        expect(d3.select(ticks[3]).text()).toEqual('Oct');
+        expect(d3.select(ticks[4]).text()).toEqual('Jan 2013');
       });
     });
     


### PR DESCRIPTION
When we have monthly data going back more than 15 months, use quarterly ticks.

I've over-written the "month" config in graph.js. We don't seem to be using
this anywhere in the live app, or testing it, so I think it's OK to overwrite.
But I'd be grateful if someone with more Spotlight experience could check.

Part of the G-Cloud designs: https://www.pivotaltracker.com/s/projects/911874/stories/62377934
