### PR TITLE
Wrap entire realtime module in a paragraph tag

### DIFF
--- a/app/common/templates/visualisations/visitors-realtime.html
+++ b/app/common/templates/visualisations/visitors-realtime.html
@@ -1,4 +1,6 @@
 <% if (numberOfVisitors != null) { %>
-<p class="impact-number"><strong><%= numberOfVisitors %></strong></p>
-<p class="stat-description"><%= numberOfVisitors == 1 ? "user" : "users" %> online now</p>
+<p>
+  <span class="impact-number"><strong><%= numberOfVisitors %></strong></span>
+  <span class="stat-description"><%= numberOfVisitors == 1 ? "user" : "users" %> online now</span>
+</p>
 <% } %>

--- a/features/step_definitions/module_steps.rb
+++ b/features/step_definitions/module_steps.rb
@@ -4,7 +4,7 @@ def values
       'no-realistic-dashboard' => {
         title: 'Real-time usage',
         description: 'Real-time usage',
-        raw: "//p[@class='impact-number']/strong[text()='15']",
+        raw: "//span[@class='impact-number']/strong[text()='15']",
         info: true
       }
     },
@@ -60,7 +60,7 @@ def values
 end
 
 def find_section_for(identifier)
-  if page.has_css?("section##{identifier}") 
+  if page.has_css?("section##{identifier}")
     section = page.find("section##{identifier}")
   else
     section = page.find("section.#{identifier}")
@@ -94,4 +94,4 @@ Then(/^I should see other information for the "(.*?)" "(.*?)" module$/) do |serv
   if v[:info]
     find_section_for(display_module).should have_content('more info')
   end
-end 
+end

--- a/spec/shared/common/views/visualisations/spec.visitors-realtime.js
+++ b/spec/shared/common/views/visualisations/spec.visitors-realtime.js
@@ -13,9 +13,9 @@ function (VisitorsRealtimeView, Collection) {
 
       jasmine.renderView(view, function () {
         expect(view.$el.html()).toEqual(
-          '<p class="impact-number"><strong>10</strong></p><p class="stat-description">users online now</p>'
-        )
-      })
+          '<p>  <span class="impact-number"><strong>10</strong></span>  <span class="stat-description">users online now</span></p>'
+        );
+      });
     });
 
     it("renders singular if one user", function () {
@@ -26,10 +26,8 @@ function (VisitorsRealtimeView, Collection) {
       });
 
       jasmine.renderView(view, function () {
-        expect(view.$el.html()).toEqual(
-          '<p class="impact-number"><strong>1</strong></p><p class="stat-description">user online now</p>'
-        )
-      })
+        expect(view.$el.find('.stat-description').text()).toEqual('user online now');
+      });
     });
 
     describe('interpolating numbers', function () {
@@ -75,6 +73,6 @@ function (VisitorsRealtimeView, Collection) {
       jasmine.renderView(view, function () {
         expect(view.$el.html()).toEqual('');
       });
-    })
-  })
+    });
+  });
 });

--- a/styles/common/impact_number.scss
+++ b/styles/common/impact_number.scss
@@ -1,10 +1,10 @@
-p.impact-number {
-  margin-bottom: 4px;
+.impact-number {
+  margin-bottom: 0.25em;
 
   strong {
     color: $primary-colour;
     @include bold-80($tabular-numbers: true) ;
-    margin-bottom: -.1em;
+    margin-bottom: -0.1em;
     display: block;
 
     @media (max-width: 850px) {
@@ -42,6 +42,6 @@ p.impact-number {
   }
 }
 
-p.stat-description {
+.stat-description {
   margin-top: 0.1em;
 }


### PR DESCRIPTION
And then use spans to style the impact number.

This involves making the CSS matchers for `impact-number` and `stat-description` more loose, but I don't think that's a problem.
