### PR TITLE
Add rightHandGracePixels to hover.js

### DIFF
--- a/app/extensions/views/graph/hover.js
+++ b/app/extensions/views/graph/hover.js
@@ -2,12 +2,14 @@ define([
   'extensions/views/graph/component'
 ],
 function (Component) {
-  
+
   /**
    * Graph component that intercepts and normalises user interaction events
    */
   var Hover = Component.extend({
-    
+
+    rightHandGracePixels: 16,
+
     events: function () {
       if (this.modernizr.touch) {
         return {
@@ -19,14 +21,14 @@ function (Component) {
         };
       }
     },
-    
+
     dispose: function () {
       if (this.modernizr.touch) {
         $('body').off('touchstart', this.onTouchStartBody);
       }
       Component.prototype.dispose.apply(this, arguments);
     },
-    
+
     render: function () {
       if (!this.hoverEl) {
         this.hoverEl = $('<div></div>').addClass('hover').appendTo(this.graph.graphWrapper);
@@ -44,18 +46,18 @@ function (Component) {
         that.collection.selectItem(null, null);
       });
     },
-    
+
     onMouseMove: function (e) {
       var offset = this.graph.graphWrapper.offset();
       var scaleFactor = this.graph.scaleFactor();
       var x = (e.pageX - offset.left) / scaleFactor - this.margin.left;
       var y = (e.pageY - offset.top) / scaleFactor - this.margin.top;
-      
+
       this.attachBodyListener('mousemove');
       this.selectPoint(x, y);
       return false;
     },
-    
+
     onTouchStart: function (e) {
       var touch = e.originalEvent.touches[0];
       var offset = this.graph.graphWrapper.offset();
@@ -69,7 +71,7 @@ function (Component) {
       });
       return false;
     },
-    
+
     /**
      * Triggers a graph 'hover' event for a specific coordinate.
      */
@@ -81,7 +83,7 @@ function (Component) {
         slice: slice
       }, options));
     },
-    
+
     /**
      * Finds 'slice' of the graph for a specific coordinate.
      * The graph area is divided into 9 slices counted in reading direction:
@@ -90,10 +92,10 @@ function (Component) {
      * The main graph area therefore is slice 4.
      */
     getSlice: function (x, y) {
-      return (y >= this.graph.innerHeight ? 6 : y < 0 ? 0 : 3) + 
-             (x >= this.graph.innerWidth ? 2 : x < 0 ? 0 : 1);
+      return (y >= this.graph.innerHeight ? 6 : y < 0 ? 0 : 3) +
+             (x >= (this.graph.innerWidth + this.rightHandGracePixels) ? 2 : x < 0 ? 0 : 1);
     }
-    
+
   });
 
   return Hover;

--- a/spec/client/extensions/views/graph/spec.hover.js
+++ b/spec/client/extensions/views/graph/spec.hover.js
@@ -13,7 +13,7 @@ function (Hover) {
           spyOn(Hover.prototype, "onMouseMove");
           spyOn(Hover.prototype, "onTouchStart");
       });
-      
+
       it("listens to mousemove events in mouse environments", function () {
           var component = new Hover({
           modernizr: { touch: false },
@@ -25,14 +25,14 @@ function (Hover) {
         });
         graphWrapper.appendTo(component.$el);
         component.render();
-        
+
         jasmine.renderView(component, function () {
           component.graph.graphWrapper.find('.hover').trigger('mousemove');
           expect(component.onMouseMove).toHaveBeenCalled();
           expect(component.onTouchStart).not.toHaveBeenCalled();
         });
       });
-      
+
       it("listens to touchstart events in touch environments", function () {
         var component = new Hover({
           modernizr: { touch: true },
@@ -45,7 +45,7 @@ function (Hover) {
         });
         graphWrapper.appendTo(component.$el);
         component.render();
-        
+
         jasmine.renderView(component, function () {
           component.$el.find('.hover').trigger('touchstart');
           expect(component.onTouchStart).toHaveBeenCalled();
@@ -53,7 +53,7 @@ function (Hover) {
         });
       });
     });
-    
+
     describe("event handlers", function () {
       var component, scaleFactor, graphWrapper;
 
@@ -76,7 +76,7 @@ function (Hover) {
           }
         });
       });
-      
+
       describe("onMouseMove", function () {
         it("calculates the mouse move position when the graph is not scaled", function () {
           spyOn(graphWrapper, "offset").andReturn({
@@ -102,7 +102,7 @@ function (Hover) {
           expect(component.selectPoint).toHaveBeenCalledWith(90, 80);
         });
       });
-      
+
       describe("onTouchStart", function () {
         it("calculates the touch position when the graph is not scaled", function () {
           spyOn(graphWrapper, "offset").andReturn({
@@ -136,63 +136,91 @@ function (Hover) {
           expect(component.selectPoint).toHaveBeenCalledWith(90, 80, { toggle: true });
         });
       });
-      
+
       describe("getSlice", function () {
         var component;
-        beforeEach(function() {
-          component = new Hover({
-            collection: { on: jasmine.createSpy() },
-            graph: {
-              innerWidth: 300,
-              innerHeight: 200
-            }
-          })
+
+        describe("with no grace pixels", function () {
+
+          beforeEach(function() {
+            component = new Hover({
+              rightHandGracePixels: 0,
+              collection: { on: jasmine.createSpy() },
+              graph: {
+                innerWidth: 300,
+                innerHeight: 200
+              }
+            });
+          });
+
+          it("returns 0 for points in the upper left corner", function () {
+            expect(component.getSlice(-1, -1)).toEqual(0);
+          });
+
+          it("returns 1 for points in the upper centre", function () {
+            expect(component.getSlice(0, -1)).toEqual(1);
+            expect(component.getSlice(299, -1)).toEqual(1);
+          });
+
+          it("returns 2 for points in the upper right corner", function () {
+            expect(component.getSlice(300, -1)).toEqual(2);
+          });
+
+          it("returns 3 for points in the left centre", function () {
+            expect(component.getSlice(-1, 0)).toEqual(3);
+            expect(component.getSlice(-1, 199)).toEqual(3);
+          });
+
+          it("returns 4 for points in the central graphing area", function () {
+            expect(component.getSlice(0, 0)).toEqual(4);
+            expect(component.getSlice(0, 199)).toEqual(4);
+            expect(component.getSlice(299, 0)).toEqual(4);
+            expect(component.getSlice(299, 199)).toEqual(4);
+          });
+
+          it("returns 5 for points in the right centre", function () {
+            expect(component.getSlice(300, 0)).toEqual(5);
+            expect(component.getSlice(300, 199)).toEqual(5);
+          });
+
+          it("returns 6 for points in the lower left corner", function () {
+            expect(component.getSlice(-1, 200)).toEqual(6);
+          });
+
+          it("returns 7 for points in the lower centre", function () {
+            expect(component.getSlice(0, 200)).toEqual(7);
+            expect(component.getSlice(299, 200)).toEqual(7);
+          });
+
+          it("returns 8 for points in the lower right corner", function () {
+            expect(component.getSlice(300, 200)).toEqual(8);
+          });
+
         });
-        
-        it("returns 0 for points in the upper left corner", function () {
-          expect(component.getSlice(-1, -1)).toEqual(0);
+
+        describe('with a few grace pixels on the right hand side', function () {
+          beforeEach(function() {
+            component = new Hover({
+              rightHandGracePixels: 20,
+              collection: { on: jasmine.createSpy() },
+              graph: {
+                innerWidth: 300,
+                innerHeight: 200
+              }
+            });
+          });
+
+          it('returns 1 for the top middle segment if inside the grace pixels', function () {
+            expect(component.getSlice(310, -1)).toEqual(1);
+          });
+
+          it('returns 2 for the top right segment if outside the grace pixels', function () {
+            expect(component.getSlice(321, -1)).toEqual(2);
+          });
         });
-        
-        it("returns 1 for points in the upper centre", function () {
-          expect(component.getSlice(0, -1)).toEqual(1);
-          expect(component.getSlice(299, -1)).toEqual(1);
-        });
-        
-        it("returns 2 for points in the upper right corner", function () {
-          expect(component.getSlice(300, -1)).toEqual(2);
-        });
-        
-        it("returns 3 for points in the left centre", function () {
-          expect(component.getSlice(-1, 0)).toEqual(3);
-          expect(component.getSlice(-1, 199)).toEqual(3);
-        });
-        
-        it("returns 4 for points in the central graphing area", function () {
-          expect(component.getSlice(0, 0)).toEqual(4);
-          expect(component.getSlice(0, 199)).toEqual(4);
-          expect(component.getSlice(299, 0)).toEqual(4);
-          expect(component.getSlice(299, 199)).toEqual(4);
-        });
-        
-        it("returns 5 for points in the right centre", function () {
-          expect(component.getSlice(300, 0)).toEqual(5);
-          expect(component.getSlice(300, 199)).toEqual(5);
-        });
-        
-        it("returns 6 for points in the lower left corner", function () {
-          expect(component.getSlice(-1, 200)).toEqual(6);
-        });
-        
-        it("returns 7 for points in the lower centre", function () {
-          expect(component.getSlice(0, 200)).toEqual(7);
-          expect(component.getSlice(299, 200)).toEqual(7);
-        });
-        
-        it("returns 8 for points in the lower right corner", function () {
-          expect(component.getSlice(300, 200)).toEqual(8);
-        });
+
       });
-      
+
     });
   });
 });


### PR DESCRIPTION
These few pixels increase the size of the hover area for the middle
section of a graph with linelabels to the right.

Before: as soon as you move from the final date value of the graph
into the linelabel, the hover disappears.

Now: the first few leftmost columns of pixels of the linelabel are
assumed to be hovering on the graph still.
