### PR TITLE
Add WAI-ARIA attributes to graph elements

### DIFF
--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -44,14 +44,14 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
 
 
   var Graph = View.extend({
-    
+
     d3: d3,
-    
+
     valueAttr: '_count',
 
     minYDomainExtent: 6,
     numYTicks: 7,
-    
+
     sharedComponents: {
       xaxis: XAxis,
       yaxis: YAxis,
@@ -65,14 +65,14 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
 
     initialize: function (options) {
       View.prototype.initialize.apply(this, arguments);
-      
+
       var collection = this.collection = options.collection;
       collection.on('reset add remove sync', this.render, this);
-      
+
       this.prepareGraphArea();
-      
+
       this.currency = options.currency;
-      
+
       this.scales = {};
       this.margin = {};
 
@@ -88,7 +88,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
         $(window).on('resize', _.bind(this.render, this));
       }
     },
-    
+
     /**
      * Defines default options that get passed to all graph components.
      * This object will be extended with component-specific options.
@@ -105,7 +105,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
         scales: this.scales
       };
     },
-    
+
     showLineLabels: function () {
       return this.model && this.model.get('show-line-labels');
     },
@@ -122,13 +122,20 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
 
       this.innerEl = $('<div class="inner"></div>');
       this.innerEl.appendTo(graphWrapper);
-      
+
       var svg = this.svg = this.d3.select(graphWrapper[0]).append('svg');
-      
+
+      // Apply attributes to SVGs so that they're ignored by screenreaders.
+      // The WAI-ARIA 1.0 spec says that authors MAY use aria-hidden only
+      // if they're hiding content to improve the experience for users
+      // of assistive technologies.
+      svg.attr('role', 'presentation');
+      svg.attr('aria-hidden', 'true');
+
       this.wrapper = svg.append('g')
         .classed('wrapper', true);
     },
-    
+
     /**
      * Calculates current factor between size in displayed pixels and logical
      * size.
@@ -136,12 +143,12 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
     scaleFactor: function () {
       return $(this.svg.node()).width() / this.width;
     },
-    
+
     // Not implemented; override in configuration or subclass
     calcXScale: function () {
       throw('No x scale defined.');
     },
-    
+
     // Not implemented; override in configuration or subclass
     calcYScale: function () {
       throw('No y scale defined.');
@@ -249,7 +256,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
         callout.removeClass('performance-hidden');
       }
     },
-    
+
     /**
      * Applies current configuration, then renders components in defined order
      */
@@ -273,7 +280,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
 
       this.scales.x = this.calcXScale();
       this.scales.y = this.calcYScale();
-      
+
       _.each(this.componentInstances, function (component) {
         _.each(configNames, function(configName) {
           component.applyConfig(configName);
@@ -287,12 +294,12 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
       day: scaleByEndDate,
       week: scaleByEndDate,
       quarter: scaleByEndDate,
-      month: scaleByEndDate, 
-      
-      ymin: { 
+      month: scaleByEndDate,
+
+      ymin: {
         initialize: function() {
           var d3 = this.d3;
-          var valueAttr = this.valueAttr;      
+          var valueAttr = this.valueAttr;
           var min = d3.min(this.collection.models, function (group) {
             return d3.min(group.get('values').models, function (value) {
               return value.get(valueAttr);
@@ -340,7 +347,7 @@ function (View, d3, XAxis, YAxis, Line, Stack, LineLabel, Hover, Callout, Toolti
           if (this.outStack) {
             stack.out(_.bind(this.outStack, this));
           }
-            
+
           this.layers = stack(this.collection.models.slice().reverse());
         },
         getYPos: function (groupIndex, modelIndex) {

--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -45,6 +45,10 @@ function (Component) {
       this.figcaption = wrapper.selectAll('figcaption').data(['one-figcaption']);
       this.figcaption.enter().insert('figcaption', '.graph-wrapper').attr('class', 'legend');
 
+      // Hide elements from assistive technology to improve their experience
+      this.figcaption.attr('role', 'presentation');
+      this.figcaption.attr('aria-hidden', 'true');
+
       this.renderSummary();
       this.renderLabels();
       this.renderLines();

--- a/spec/client/extensions/views/graph/spec.graph.js
+++ b/spec/client/extensions/views/graph/spec.graph.js
@@ -31,10 +31,10 @@ function (Graph, Collection, Model, d3) {
         style = null;
       }
     });
-      
-    
+
+
     describe("initialize", function() {
-      
+
       var collection, TestGraph, testComponent1, testComponent2;
       beforeEach(function() {
         collection = new Collection();
@@ -65,7 +65,7 @@ function (Graph, Collection, Model, d3) {
         spyOn(TestGraph.prototype, "render");
         spyOn(TestGraph.prototype, "prepareGraphArea");
       });
-      
+
       it("re-renders when collection resets", function() {
         var graph = new TestGraph({
           collection: collection
@@ -81,7 +81,7 @@ function (Graph, Collection, Model, d3) {
         collection.trigger('sync');
         expect(graph.render).toHaveBeenCalled();
       });
-      
+
       it("re-renders when item is added to collection", function() {
         var graph = new TestGraph({
           collection: collection
@@ -89,7 +89,7 @@ function (Graph, Collection, Model, d3) {
         collection.trigger('add');
         expect(graph.render).toHaveBeenCalled();
       });
-      
+
       it("re-renders when items is removed from collection", function() {
         var graph = new TestGraph({
           collection: collection
@@ -97,14 +97,14 @@ function (Graph, Collection, Model, d3) {
         collection.trigger('remove');
         expect(graph.render).toHaveBeenCalled();
       });
-      
-      it("prepare graph area", function() {
+
+      it("prepares the graph area", function() {
         var graph = new TestGraph({
           collection: collection
         });
         expect(graph.prepareGraphArea).toHaveBeenCalled();
       });
-      
+
       it("initialises components", function() {
         var graph = new TestGraph({
           collection: collection
@@ -121,20 +121,20 @@ function (Graph, Collection, Model, d3) {
         expect(graph.componentInstances[1] instanceof testComponent2).toBe(true);
       });
     });
-    
+
     describe("prepareGraphArea", function() {
-      
+
       var graph, el, TestGraph;
       beforeEach(function() {
         el = $('<div id="jasmine-playground"></div>').appendTo($('body'));
-        
+
         TestGraph = Graph.extend();
         graph = new TestGraph({
           el: el,
           collection: new Collection()
         });
       });
-      
+
       afterEach(function() {
         el.remove();
       });
@@ -147,7 +147,13 @@ function (Graph, Collection, Model, d3) {
         var svg = graph.el.find('svg');
         expect(svg.length).toEqual(1);
       });
-      
+
+      it('renders an SVG element with correct WAI-ARIA attributes', function () {
+        var svg = graph.el.find('svg');
+        expect(svg.attr('role')).toEqual('presentation');
+        expect(svg.attr('aria-hidden')).toEqual('true');
+      });
+
       it("creates wrapper element", function() {
         var wrapper = graph.el.find('svg g.wrapper');
         expect(wrapper.length).toEqual(1);
@@ -194,7 +200,7 @@ function (Graph, Collection, Model, d3) {
         expect(pxToValue(false)).toEqual(null);
       });
     });
-    
+
     describe("resize", function () {
 
       var graph, el, wrapper;
@@ -265,7 +271,7 @@ function (Graph, Collection, Model, d3) {
         expect(svg.css('max-height')).toEqual('75px');
         expect(svg.css('display')).toEqual('block');
       });
-      
+
       it("calculates inner dimensions and margin", function() {
         wrapper.css({
           width: '150px',
@@ -289,9 +295,9 @@ function (Graph, Collection, Model, d3) {
         expect(graph.margin.bottom).toEqual(3);
         expect(graph.margin.left).toEqual(4);
       });
-      
+
     });
-    
+
     describe("render", function() {
 
       var graph;
@@ -326,7 +332,7 @@ function (Graph, Collection, Model, d3) {
           graph.render();
         }).toThrow();
       });
-      
+
       it("requires x and y scale implementation s", function() {
         graph.getConfigNames = function () {
           return [];
@@ -342,7 +348,7 @@ function (Graph, Collection, Model, d3) {
         expect(graph.scales.x).toEqual('test x scale');
         expect(graph.scales.y).toEqual('test y scale');
       });
-      
+
       it("renders component instances", function() {
         graph.getConfigNames = function () {
           return [];
@@ -361,7 +367,7 @@ function (Graph, Collection, Model, d3) {
         expect(component2.render).toHaveBeenCalled();
       });
     });
-    
+
     describe("scaleFactor", function () {
       var el, TestGraph;
       beforeEach(function() {
@@ -373,11 +379,11 @@ function (Graph, Collection, Model, d3) {
           });
           withGraphStyle();
       });
-      
+
       afterEach(function() {
           el.remove();
       });
-      
+
       it("calculates the scale factor when the graph is not resized", function() {
           el.width(600);
           graph = new TestGraph({
@@ -386,7 +392,7 @@ function (Graph, Collection, Model, d3) {
           });
           expect(graph.scaleFactor()).toEqual(1);
       });
-      
+
       it("calculates the scale factor when the graph is resized", function() {
           el.width(300);
           graph = new TestGraph({
@@ -396,7 +402,7 @@ function (Graph, Collection, Model, d3) {
           expect(graph.scaleFactor()).toEqual(0.5);
       });
     });
-    
+
     describe("configs", function () {
 
       var collection, graph, el;
@@ -487,7 +493,7 @@ function (Graph, Collection, Model, d3) {
         graph.innerWidth = 444;
         graph.innerHeight = 333;
       });
-      
+
       afterEach(function() {
         el.remove();
       });
@@ -541,7 +547,7 @@ function (Graph, Collection, Model, d3) {
             expect(graph.getMoment(domain[0]).format()).toEqual('2013-03-13T00:00:00+00:00');
             expect(graph.getMoment(domain[1]).format()).toEqual('2013-03-13T23:00:00+00:00');
           });
-          
+
           it("scales range to inner width", function() {
             expect(graph.calcXScale().range()).toEqual([0, 444]);
           });
@@ -560,18 +566,18 @@ function (Graph, Collection, Model, d3) {
             collection.at(1).get('values').each(function (model) { model.set('_count', 1); });
             collection.at(2).get('values').each(function (model) { model.set('_count', 1); });
             expect(graph.calcYScale().domain()).toEqual([0, 6]);
-            
+
             collection.at(0).get('values').each(function (model) { model.set('_count', 2); });
             collection.at(1).get('values').each(function (model) { model.set('_count', 2); });
             collection.at(2).get('values').each(function (model) { model.set('_count', 2); });
             expect(graph.calcYScale().domain()).toEqual([0, 6]);
-            
+
             collection.at(0).get('values').each(function (model) { model.set('_count', 5); });
             collection.at(1).get('values').each(function (model) { model.set('_count', 5); });
             collection.at(2).get('values').each(function (model) { model.set('_count', 5); });
             expect(graph.calcYScale().domain()).toEqual([0, 6]);
           });
-          
+
           it("scales domain from 0 to nice value above max value by default", function() {
             expect(graph.calcYScale().domain()).toEqual([0, 120]);
           });
@@ -580,13 +586,13 @@ function (Graph, Collection, Model, d3) {
             graph.valueAttr = 'alternativeValue';
             expect(graph.calcYScale().domain()).toEqual([0, 500]);
           });
-          
+
           it("scales domain from 0 to nice value above maximum sum of point in time when an alternative value attribute is used", function () {
             graph.valueAttr = 'alternativeValue';
             graph.applyConfig('stack');
             expect(graph.calcYScale().domain()).toEqual([0, 700]);
           });
-          
+
           it("scales range to inner height", function() {
             expect(graph.calcYScale().range()).toEqual([333, 0]);
           });
@@ -628,7 +634,7 @@ function (Graph, Collection, Model, d3) {
             };
 
             graph.applyConfig('stack');
-            
+
             expect(graph.layers.length).toEqual(3);
             expect(graph.layers[0].get('values').at(0).yCustom0).toEqual(0);
             expect(graph.layers[0].get('values').at(0).yCustom).toEqual(2);
@@ -654,12 +660,12 @@ function (Graph, Collection, Model, d3) {
           it("scales domain from 0 to nice value above max value", function() {
             expect(graph.calcYScale().domain()).toEqual([0, 140]);
           });
-          
+
           it("scales domain from 0 to nice value above max value when an alternative value attribute is used", function () {
             graph.valueAttr = 'alternativeValue';
             expect(graph.calcYScale().domain()).toEqual([0, 700]);
           });
-          
+
           it("scales range to inner height", function() {
             expect(graph.calcYScale().range()).toEqual([333, 0]);
           });

--- a/spec/client/extensions/views/graph/spec.linelabel.js
+++ b/spec/client/extensions/views/graph/spec.linelabel.js
@@ -75,6 +75,13 @@ function (LineLabel, Collection) {
           expect(lines[0].length).toEqual(2);
         });
 
+        it('renders a label with correct WAI-ARIA attributes', function () {
+          lineLabel.render();
+          var lineLabelElement = lineLabel.$el.find('figcaption');
+          expect(lineLabelElement.attr('role')).toEqual('presentation');
+          expect(lineLabelElement.attr('aria-hidden')).toEqual('true');
+        });
+
         it("renders a label with squares", function () {
           lineLabel.showSquare = true;
           lineLabel.render();


### PR DESCRIPTION
This commit adds `role=presentation` and `aria-hidden=true` to all SVG elements and figcaptions used for linelabels.

This prevents screenreaders from reading out the text parts of those elements and all their children.

As noted in the comment, [the WAI-ARIA 1.0 spec](http://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden) says we may do this to improve the experience for assistive technologies:

> Authors MAY, with caution, use aria-hidden to hide visibly rendered content from assistive technologies only if the act of hiding this content is intended to improve the experience for users of assistive technologies by removing redundant or extraneous content.

The spec follows on by saying:

> Authors using aria-hidden to hide visible content from screen readers MUST ensure that identical or equivalent meaning and functionality is exposed to assistive technologies.

Which we'll do as part of this sprint by providing a tabular representation of graph data, which will be better for screen readers than our graphs could ever be.

The story only specified the `role` attribute. We need to use `aria-hidden` too in order to stop screen readers from speaking the contents of the children of the SVG element.
