### PR TITLE
Make "more info" sections accessible, using <details> tag

### DIFF
--- a/app/client/client_bootstrap.js
+++ b/app/client/client_bootstrap.js
@@ -4,6 +4,7 @@ define([
   'modernizr',
   './preprocessors/navigation',
   './preprocessors/popover',
+  './preprocessors/details_shim',
   './preprocessors/visualisation_fallback',
   './preprocessors/report_a_problem'
 ],

--- a/app/client/preprocessors/details_shim.js
+++ b/app/client/preprocessors/details_shim.js
@@ -1,0 +1,16 @@
+define([
+  'jquery'
+], function ($) {
+      
+  var setUpShim = function () {
+    
+    // Add conditional classname based on support
+    $('html').addClass($.fn.details.support ? 'details' : 'no-details');
+
+    // Emulate <details> where necessary.
+    $('details').details();
+
+  };
+  
+  return setUpShim;
+});

--- a/app/common/templates/module.html
+++ b/app/common/templates/module.html
@@ -6,14 +6,14 @@
 
 
 <% if (model.get('info')) { %>
-<aside class="more-info">
-  <span class="more-info-link popover-link">more info</span>
+<details class="more-info">
+  <summary class="more-info-link">more info</summary>
   <ul>
     <% _.each(model.get('info'), function (row) { %>
     <li><%= row %></li>
     <% }) %>
   </ul>
-</aside>
+</details>
 <% } %>
 <h1><%= model.get('title') %></h1>
 <% if (model.get('description')) { %>

--- a/app/config.js
+++ b/app/config.js
@@ -15,6 +15,7 @@ define(function (options) {
     // additional setup for client
     config.paths.jquery = 'vendor/jquery';
     config.paths.jqueryxdr = 'vendor/jquery.xdr';
+    config.paths.jquerydetails = 'vendor/jquery.details';
     config.paths.underscore = 'vendor/lodash';
     config.paths.backbone = 'vendor/backbone';
     config.paths.d3 = 'vendor/d3';
@@ -24,10 +25,14 @@ define(function (options) {
 
     config.shim = {
       backbone: {
-        deps: ['underscore', 'jqueryxdr'],
+        deps: ['underscore', 'jqueryxdr', 'jquerydetails'],
         exports: 'Backbone'
       },
       jqueryxdr: {
+        deps: ['jquery'],
+        exports: '$'
+      },
+      jquerydetails: {
         deps: ['jquery'],
         exports: '$'
       },

--- a/app/vendor/jquery.details.js
+++ b/app/vendor/jquery.details.js
@@ -1,0 +1,152 @@
+/*! http://mths.be/details v0.1.0 by @mathias | includes http://mths.be/noselect v1.0.3 */
+;(function(document, $) {
+
+	var proto = $.fn,
+	    details,
+	    // :'(
+	    isOpera = Object.prototype.toString.call(window.opera) == '[object Opera]',
+	    // Feature test for native `<details>` support
+	    isDetailsSupported = (function(doc) {
+	    	var el = doc.createElement('details'),
+	    	    fake,
+	    	    root,
+	    	    diff;
+	    	if (!('open' in el)) {
+	    		return false;
+	    	}
+	    	root = doc.body || (function() {
+	    		var de = doc.documentElement;
+	    		fake = true;
+	    		return de.insertBefore(doc.createElement('body'), de.firstElementChild || de.firstChild);
+	    	}());
+	    	el.innerHTML = '<summary>a</summary>b';
+	    	el.style.display = 'block';
+	    	root.appendChild(el);
+	    	diff = el.offsetHeight;
+	    	el.open = true;
+	    	diff = diff != el.offsetHeight;
+	    	root.removeChild(el);
+	    	if (fake) {
+	    		root.parentNode.removeChild(root);
+	    	}
+	    	return diff;
+	    }(document)),
+	    toggleOpen = function($details, $detailsSummary, $detailsNotSummary, toggle) {
+	    	var isOpen = $details.prop('open'),
+	    	    close = isOpen && toggle || !isOpen && !toggle;
+	    	if (close) {
+	    		$details.removeClass('open').prop('open', false).triggerHandler('close.details');
+	    		$detailsSummary.attr('aria-expanded', false);
+	    		$detailsNotSummary.hide();
+	    	} else {
+	    		$details.addClass('open').prop('open', true).triggerHandler('open.details');
+	    		$detailsSummary.attr('aria-expanded', true);
+	    		$detailsNotSummary.show();
+	    	}
+	    };
+
+	/* http://mths.be/noselect v1.0.3 */
+	proto.noSelect = function() {
+
+		// Since the string 'none' is used three times, storing it in a variable gives better results after minification
+		var none = 'none';
+
+		// onselectstart and ondragstart for WebKit & IE
+		// onmousedown for WebKit & Opera
+		return this.bind('selectstart dragstart mousedown', function() {
+			return false;
+		}).css({
+			'MozUserSelect': none,
+			'msUserSelect': none,
+			'webkitUserSelect': none,
+			'userSelect': none
+		});
+
+	};
+
+	// Execute the fallback only if there’s no native `details` support
+	if (isDetailsSupported) {
+
+		details = proto.details = function() {
+
+			return this.each(function() {
+				var $details = $(this),
+				    $summary = $('summary', $details).first();
+
+				$summary.attr({
+					"role": 'button',
+					"aria-expanded": $details.prop('open')
+				}).on('click', function() {
+					// the value of the `open` property is the old value
+					var close = $details.prop('open');
+					$summary.attr('aria-expanded', !close);
+					$details.triggerHandler((close ? 'close' : 'open') + '.details');
+				});
+			});
+
+		};
+
+		details.support = isDetailsSupported;
+
+	} else {
+
+		details = proto.details = function() {
+
+			// Loop through all `details` elements
+			return this.each(function() {
+
+				// Store a reference to the current `details` element in a variable
+				var $details = $(this),
+				    // Store a reference to the `summary` element of the current `details` element (if any) in a variable
+				    $detailsSummary = $('summary', $details).first(),
+				    // Do the same for the info within the `details` element
+				    $detailsNotSummary = $details.children(':not(summary)'),
+				    // This will be used later to look for direct child text nodes
+				    $detailsNotSummaryContents = $details.contents(':not(summary)');
+
+				// If there is no `summary` in the current `details` element…
+				if (!$detailsSummary.length) {
+					// …create one with default text
+					$detailsSummary = $('<summary>').text('Details').prependTo($details);
+				}
+
+				// Look for direct child text nodes
+				if ($detailsNotSummary.length != $detailsNotSummaryContents.length) {
+					// Wrap child text nodes in a `span` element
+					$detailsNotSummaryContents.filter(function() {
+						// Only keep the node in the collection if it’s a text node containing more than only whitespace
+						// http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#space-character
+						return this.nodeType == 3 && /[^ \t\n\f\r]/.test(this.data);
+					}).wrap('<span>');
+					// There are now no direct child text nodes anymore — they’re wrapped in `span` elements
+					$detailsNotSummary = $details.children(':not(summary)');
+				}
+
+				// Hide content unless there’s an `open` attribute
+				$details.prop('open', typeof $details.attr('open') == 'string');
+				toggleOpen($details, $detailsSummary, $detailsNotSummary);
+
+				// Add `role=button` and set the `tabindex` of the `summary` element to `0` to make it keyboard accessible
+				$detailsSummary.attr('role', 'button').noSelect().prop('tabIndex', 0).on('click', function() {
+					// Focus on the `summary` element
+					$detailsSummary.focus();
+					// Toggle the `open` and `aria-expanded` attributes and the `open` property of the `details` element and display the additional info
+					toggleOpen($details, $detailsSummary, $detailsNotSummary, true);
+				}).keyup(function(event) {
+					if (32 == event.keyCode || (13 == event.keyCode && !isOpera)) {
+						// Space or Enter is pressed — trigger the `click` event on the `summary` element
+						// Opera already seems to trigger the `click` event when Enter is pressed
+						event.preventDefault();
+						$detailsSummary.click();
+					}
+				});
+
+			});
+
+		};
+
+		details.support = isDetailsSupported;
+
+	}
+
+}(document, jQuery));

--- a/spec/client/preprocessors/spec.details_shim.js
+++ b/spec/client/preprocessors/spec.details_shim.js
@@ -1,0 +1,62 @@
+define([
+  'client/preprocessors/details_shim'
+], function (detailsShim) {
+  describe('Module actions', function() {
+    
+    var el;
+    var summaryLink;
+    var ul;
+    
+    beforeEach(function() {
+      var html = '<details class="more-info"><summary class="more-info-link">more info';
+      html += '</summary><ul><li>details</li></ul>';
+      html += '</div>';
+      el = $(html);
+      $('body').append(el);
+      summaryLink = $('summary');
+    });
+
+    afterEach(function() {
+      $('details').remove();
+    });
+    
+    describe('in browsers that support the details tag', function() {
+      
+      beforeEach(function() {
+        detailsShim();
+      });
+    
+      it('adds details class', function() {
+        expect($('html')).toHaveClass('details');
+      });
+    
+      it('adds expected attributes to details elements', function() {
+        var summary = $('summary');
+        expect(summary.attr('role')).toEqual('button');
+        expect(summary.attr('aria-expanded')).toEqual('false');
+      });
+    
+   });
+   
+    describe('non-touch behaviour', function() {
+      
+      beforeEach(function() {
+        var jQueryCopy = $;
+        jQueryCopy.fn.details.support = false;
+        detailsShim(jQueryCopy);
+      });
+    
+      it('adds no-details class if the browser does not support the details tag', function() {
+        expect($('html')).toHaveClass('no-details');
+      });
+      
+      it('adds expected attributes to details elements', function() {
+        var summary = $('summary');
+        expect(summary.attr('role')).toEqual('button');
+        expect(summary.attr('aria-expanded')).toEqual('false');
+      });
+    
+   });
+
+  });
+});

--- a/spec/shared/common/views/spec.module.js
+++ b/spec/shared/common/views/spec.module.js
@@ -46,14 +46,14 @@ function (ModuleView, Collection, Model, View) {
       model.set('description', 'Description');
       model.set('info', ['Info line 1', 'Info line 2']);
       moduleView.render();
-      expect(getContent()).toEqual('<section class="testclass"><aside class="more-info"><span class="more-info-link popover-link">more info</span><ul><li>Info line 1</li><li>Info line 2</li></ul></aside><h1>Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section class="testclass"><details class="more-info"><summary class="more-info-link">more info</summary><ul><li>Info line 1</li><li>Info line 2</li></ul></details><h1>Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
     });
 
     it("renders a module with description and info link", function () {
       model.set('description', 'Description');
       model.set('info', ['<a href="https://example.com/">Info line 1</a> with trailing text', 'Info line 2']);
       moduleView.render();
-      expect(getContent()).toEqual('<section class="testclass"><aside class="more-info"><span class="more-info-link popover-link">more info</span><ul><li><a href="https://example.com/">Info line 1</a> with trailing text</li><li>Info line 2</li></ul></aside><h1>Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section class="testclass"><details class="more-info"><summary class="more-info-link">more info</summary><ul><li><a href="https://example.com/">Info line 1</a> with trailing text</li><li>Info line 2</li></ul></details><h1>Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
     });
 
     it("renders an SVG-based module as a fallback element on the server", function () {

--- a/styles/common/module_more_info.scss
+++ b/styles/common/module_more_info.scss
@@ -1,18 +1,24 @@
 #content {
-  .more-info-link.popover-link {
+  .more-info-link {
     @include core-16($tabular-numbers: true);
     @include popover-link;
 
+    outline: none;
     float: right;
     margin: 0.2em 0 0 0;
     padding: 0;
     position: relative;
   }
 
+  details summary::-webkit-details-marker {
+    display: none;
+  }
+
   .more-info {
     @include core-16($tabular-numbers: true);
 
     position: relative;
+    display: block; 
 
     &:hover ul {
       @include popover-no-js-show-on-hover;
@@ -27,17 +33,12 @@
   }
 }
 
-body.js-enabled #content .more-info {
-  &:hover ul {
-    @include popover-js-hide-on-hover;
-  }
-  ul.js-clicked {
-    @include popover-js-show-on-click;
-  }
+.details #content .more-info ul { 
+  display: block;
 }
 
 @media (max-width: 640px) {
-	#content .more-info-link.popover-link {
+	#content .more-info-link {
 	  margin-top: 0.05em;
   }
 }

--- a/styles/common/raw.scss
+++ b/styles/common/raw.scss
@@ -20,7 +20,7 @@ body.raw {
   #content {
     h1,
     h2,
-    aside.more-info {
+    details.more-info {
       display: none;
     }
 


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/s/projects/911874/stories/61977978

Changes as follows: 
- Update HTML and CSS to use HTML5 tags
- Update module tests
- Add a shim for older browsers, from http://mathiasbynens.be/notes/html5-details-jquery
- Add tests for the shim 

Points to note: 
- I've tested this in Chrome and Safari (which support the <details> tag) and in Firefox and Opera (which don't). It also needs testing on IE9, IE8 and below, and on touch devices - I currently don't have a good way to do this locally. 
- I considered replacing the `.related-pages` sections with this too, but these are visible for screen readers, so it isn't a must-have. It might be nice since it would mean we could get rid of a lot of JavaScript popover code, but it's a little fiddly, for various reasons. 
- There's no longer a good way to test the visibility of the popovers following a click, since the tag makes no explicit CSS changes. I tried using tests like `expect(ul.css('height')).not.toBe('0px');`: these work in the browser, but not from the grunt command line. 
