### PR TITLE
Reduce heading levels within module sections, for accessibility

### DIFF
--- a/app/common/templates/module.html
+++ b/app/common/templates/module.html
@@ -15,9 +15,15 @@
   </ul>
 </details>
 <% } %>
-<h1 id="<%= this.ariaId() %>"><%= model.get('title') %></h1>
+
+<% if (model.get('page-type') === 'module') { %><h1 id="<%= this.ariaId() %>"><% } else { %><h2 id="<%= this.ariaId() %>"><% } %>
+<%= model.get('title') %>
+<% if (model.get('page-type') === 'module') { %></h1><% } else { %></h2><% } %>
+
 <% if (model.get('description')) { %>
-  <h2><%= model.get('description') %></h2>
+	<% if (model.get('page-type') === 'module') { %><h2 class="dashboard"><% } else { %><h3><% } %>
+	<%= model.get('description') %>
+	<% if (model.get('page-type') === 'module') { %></h2><% } else { %></h3><% } %>
 <% } %>
 
 <% if (fallback) { %>

--- a/spec/server/common/views/spec.module_standalone.js
+++ b/spec/server/common/views/spec.module_standalone.js
@@ -55,6 +55,34 @@ function (StandaloneView, Collection, Model, View) {
           expect(content).toContain('<div class="visualisation-fallback" data-src="/testurl.png"><noscript><img src="/testurl.png" /></noscript></div>');
         });
       });
+
+      it("renders h1 and h2 elements as required for accessibility", function () {
+        jasmine.serverOnly(function () {
+          var Visualisation = View.extend({
+            render: function () {
+              this.$el.html('test content');
+            }
+          });
+          var model = new Model();
+          model.set('page-type', 'module');
+          model.set('description', 'my description')
+          var collection = new Collection();
+          var standaloneView = new StandaloneView({
+            visualisationClass: Visualisation,
+            className: 'testclass',
+            requiresSvg: true,
+            url: '/testurl',
+            collection: collection,
+            model: model
+          });
+
+          var content = standaloneView.getContent();
+          content = content.replace(/>\s+?</g, '><');
+          expect(content).toContain('<h1 id="undefined-heading"></h1>');
+          expect(content).toContain('<h2 class="dashboard">my description</h2>');
+        });
+      });
+
     });
 
     describe("getPageTitle", function () {

--- a/spec/shared/common/views/spec.module.js
+++ b/spec/shared/common/views/spec.module.js
@@ -33,27 +33,27 @@ function (ModuleView, Collection, Model, View) {
 
     it("renders a module", function () {
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h1 id="A-Title-heading">A Title</h1><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h2 id="A-Title-heading">A Title</h2><div class="visualisation">test content</div></section>');
     });
 
     it("renders a module with description", function () {
       model.set('description', 'Description');
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h1 id="A-Title-heading">A Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h2 id="A-Title-heading">A Title</h2><h3>Description</h3><div class="visualisation">test content</div></section>');
     });
 
     it("renders a module with description and info", function () {
       model.set('description', 'Description');
       model.set('info', ['Info line 1', 'Info line 2']);
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><details class="more-info" role="complementary"><summary class="more-info-link">more info</summary><ul><li>Info line 1</li><li>Info line 2</li></ul></details><h1 id="A-Title-heading">A Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><details class="more-info" role="complementary"><summary class="more-info-link">more info</summary><ul><li>Info line 1</li><li>Info line 2</li></ul></details><h2 id="A-Title-heading">A Title</h2><h3>Description</h3><div class="visualisation">test content</div></section>');
     });
 
     it("renders a module with description and info link", function () {
       model.set('description', 'Description');
       model.set('info', ['<a href="https://example.com/">Info line 1</a> with trailing text', 'Info line 2']);
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><details class="more-info" role="complementary"><summary class="more-info-link">more info</summary><ul><li><a href="https://example.com/">Info line 1</a> with trailing text</li><li>Info line 2</li></ul></details><h1 id="A-Title-heading">A Title</h1><h2>Description</h2><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><details class="more-info" role="complementary"><summary class="more-info-link">more info</summary><ul><li><a href="https://example.com/">Info line 1</a> with trailing text</li><li>Info line 2</li></ul></details><h2 id="A-Title-heading">A Title</h2><h3>Description</h3><div class="visualisation">test content</div></section>');
     });
 
     it("renders an SVG-based module as a fallback element on the server", function () {
@@ -68,7 +68,7 @@ function (ModuleView, Collection, Model, View) {
           .replace('&gt;', '>')
           .replace(' />', '/>');
 
-        expect(content).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h1 id="A-Title-heading">A Title</h1><div class="visualisation-fallback" data-src="/test/url.png"><noscript><img src="/test/url.png"/></noscript></div></section>');
+        expect(content).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h2 id="A-Title-heading">A Title</h2><div class="visualisation-fallback" data-src="/test/url.png"><noscript><img src="/test/url.png"/></noscript></div></section>');
       });
     });
 
@@ -76,20 +76,20 @@ function (ModuleView, Collection, Model, View) {
       jasmine.clientOnly(function () {
         moduleView.requiresSvg = true;
         moduleView.render();
-        expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h1 id="A-Title-heading">A Title</h1><div class="visualisation">test content</div></section>');
+        expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h2 id="A-Title-heading">A Title</h2><div class="visualisation">test content</div></section>');
       });
     });
 
     it("renders a module with classes module-banner and restricted-data-banner when Stagecraft sets restricted_data to true", function () {
       model.set('restricted_data', true);
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass module-banner restricted-data-banner"><div class="module-banner-text"><p>This section contains <strong>commercially licensed data</strong>. Do not share or redistribute outside government.</p></div><h1 id="A-Title-heading">A Title</h1><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass module-banner restricted-data-banner"><div class="module-banner-text"><p>This section contains <strong>commercially licensed data</strong>. Do not share or redistribute outside government.</p></div><h2 id="A-Title-heading">A Title</h2><div class="visualisation">test content</div></section>');
     });
 
     it("renders a module without classes module-banner and restricted-data-banner when Stagecraft returns restricted_data false", function () {
       model.set('restricted_data', false);
       moduleView.render();
-      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h1 id="A-Title-heading">A Title</h1><div class="visualisation">test content</div></section>');
+      expect(getContent()).toEqual('<section aria-labelledby="A-Title-heading" role="region" class="testclass"><h2 id="A-Title-heading">A Title</h2><div class="visualisation">test content</div></section>');
     });
   });
 });

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -48,8 +48,15 @@ a[rel="external"][target="_blank"]:after {
     }
 
     h2 {
-      margin-top:0;
+      @include bold-24($tabular-numbers: true);
+    }
+
+    h2.dashboard {
       @include core-16($tabular-numbers: true);
+    }
+
+    h3 {
+     @include core-16($tabular-numbers: true);
     }
   }
 }


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/s/projects/911874/stories/61977694

Reduce heading levels contextually, depending on whether this is a module or a standalone dashboard. 

Update styles and tests. 
