### PR TITLE
Update govuk_template to 0.4.0

### DIFF
--- a/app/common/templates/govuk_template.html
+++ b/app/common/templates/govuk_template.html
@@ -66,17 +66,17 @@
     </div>
 
     
-    <header role="banner" id="global-header">
+    <header role="banner" id="global-header" class="">
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="{{ assetPath }}images/gov.uk_logotype_crown.png" alt=""> <span>GOV&nbsp;<span>.</span>UK</span>
+              <img src="{{ assetPath }}images/gov.uk_logotype_crown.png" alt=""> GOV.UK
             </a>
           </div>
-
           {{{ insideHeader }}}
         </div>
+        
       </div>
     </header>
     <!--end header-->

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "d3": "3.3.7",
     "express": "3.4.7",
     "govuk_frontend_toolkit": "0.12.6",
-    "govuk_template_mustache": "0.3.7",
+    "govuk_template_mustache": "0.4.0",
     "jquery": "1.8.3",
     "jsdom": "0.8.6",
     "moment-timezone": "0.0.3",


### PR DESCRIPTION
- Removes the non-breaking space from the header.
- Improves propositional navigation.
- Crushes PNGs (with thanks to @jabley).

Diff: https://github.com/alphagov/govuk_template/compare/v0.3.7...v0.4.0
