### PR TITLE
Increase font-size on callout arrow

### DIFF
--- a/styles/common/journey.scss
+++ b/styles/common/journey.scss
@@ -112,7 +112,7 @@
       -webkit-transform: scaleX(2);
       text-shadow: 0 0 3px rgba(0, 0, 0, 0.65);
       color: $grey-4;
-      font-size:20px;
+      font-size:23px;
 
       .inner-arrow {
         .no-textshadow & {


### PR DESCRIPTION
I can only imagine this fixes the issue because the govuk_template
is using a slightly different base font size to static.

Regardless, this does improve the display of the "Users at each stage"
module in Chrome, Firefox, Safari on OS X.
