### PR TITLE
Update popover event handling for new ARIA main role

### DIFF
--- a/app/client/preprocessors/popover.js
+++ b/app/client/preprocessors/popover.js
@@ -9,7 +9,7 @@ define([
     } else {
       eventName = 'click';
     }
-    $('section').on(eventName, '.popover-link', function(e) {
+    $('section, main').on(eventName, '.popover-link', function(e) {
       var close = function(e) {
         item.removeClass('js-clicked');
         $('body').off(eventName, close);


### PR DESCRIPTION
Fixes Alex's first comment here: https://github.com/alphagov/spotlight/pull/140#issuecomment-32285176

The `related-links` section is now inside `<main>`, not `<section>`. 
