### PR TITLE
Add configurable option for 'total' lines on time series graphs

### DIFF
--- a/app/common/collections/grouped_timeseries.js
+++ b/app/common/collections/grouped_timeseries.js
@@ -14,8 +14,38 @@ function (MatrixCollection) {
     },
 
     parse: function (response) {
-      var data = response.data;
-          category = this.options.category;
+      var data = response.data,
+        category = this.options.category,
+        valueAttr = this.options.valueAttr;
+
+      if (this.options.showTotalLines) {
+
+        var totalSeries = {};
+        totalSeries[category] = "Total";
+        totalSeries[valueAttr] = 0.0;
+
+        var totalValues = [];
+        var tmp = {};
+
+        _.each(response.data, function(d) {
+          _.each(d.values, function (obj) {
+            if (tmp[obj._start_at]) {
+              tmp[obj._start_at][valueAttr] += (valueAttr in obj) ? obj[valueAttr] : 0;
+            } else {
+              tmp[obj._start_at] = {_end_at: obj._end_at};
+              tmp[obj._start_at][valueAttr] = (valueAttr in obj) ? obj[valueAttr] : 0;
+            }
+          });
+        });
+        _.each(tmp, function (v, i) {
+            var t = {_start_at: i, _end_at: v._end_at};
+            t[valueAttr] = v[valueAttr];
+            totalValues.push(t);
+        });
+
+        totalSeries.values = totalValues;
+        data.push(totalSeries);
+      }
 
       return _.map(this.options.seriesList, function (series) {
         var dataSeries = _.find(data, function (d) {
@@ -29,6 +59,6 @@ function (MatrixCollection) {
     }
 
   });
-  
+
   return CategoriesCollection;
 });

--- a/app/common/modules/grouped_timeseries.js
+++ b/app/common/modules/grouped_timeseries.js
@@ -19,7 +19,8 @@ function (ModuleController, GroupedTimeseriesCollection, GroupedTimeseriesView) 
         period: this.model.get("period"),
         currency: this.model.get("currency"),
         seriesList: this.model.get("series"),
-        filterBy: this.model.get("filter-by")
+        filterBy: this.model.get("filter-by"),
+        showTotalLines: this.model.get("show-total-lines")
       };
     }
 

--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -31,6 +31,7 @@
         "Source: TBA"
       ],
       "series": [
+         { "id": "Total", "title": "Total" },
          { "id": "Small and medium enterprises", "title": "Small and medium enterprises" },
          { "id": "Large enterprises", "title": "Large enterprises" },
          { "id": "Unknown", "title": "Not yet classified" }
@@ -40,7 +41,8 @@
         {"id": "cumulative_spend:sum", "name": "Total spend", "currency": "gbp"},
         {"id": "cumulative_count:sum", "name": "Contracts awarded", "currrency": null}
       ],
-      "tabbed_attr": "collect"
+      "tabbed_attr": "collect",
+      "show-total-lines": true
     },
     {
       "slug": "proportion-smes",
@@ -81,13 +83,15 @@
         "Source: TBA"
       ],
       "series": [
+         { "id": "Total", "title": "Total" },
          { "id": "Central government", "title": "Central government" },
          { "id": "Other wider public sector", "title": "Other wider public sector" },
          { "id": "Local government", "title": "Local government" },
          { "id": "Unknown", "title": "Not yet classified" },
          { "id": "Not for profit", "title": "Not for profit" }
        ],
-      "show-line-labels": true
+      "show-line-labels": true,
+      "show-total-lines": true
     },
     {
       "slug": "spend-by-lot",

--- a/app/support/stagecraft_stub/responses/g-cloud/division-of-procurement.json
+++ b/app/support/stagecraft_stub/responses/g-cloud/division-of-procurement.json
@@ -18,6 +18,7 @@
     "Source: TBA"
   ],
   "series": [
+    { "id": "Total", "title": "Total" },
     { "id": "Small and medium enterprises", "title": "Small and medium enterprises" },
     { "id": "Large enterprises", "title": "Large enterprises" },
     { "id": "Unknown", "title": "Not yet classified" }
@@ -27,5 +28,6 @@
     {"id": "cumulative_spend:sum", "name": "Total spend"},
     {"id": "cumulative_count:sum", "name": "Contracts awarded"}
   ],
-  "tabbed_attr": "collect"
+  "tabbed_attr": "collect",
+  "show-total-lines": true
 }

--- a/app/support/stagecraft_stub/responses/g-cloud/who-is-using.json
+++ b/app/support/stagecraft_stub/responses/g-cloud/who-is-using.json
@@ -18,11 +18,13 @@
     "Source: TBA"
   ],
   "series": [
+    { "id": "Total", "title": "Total" },
     { "id": "Central government", "title": "Central government" },
     { "id": "Other wider public sector", "title": "Other wider public sector" },
     { "id": "Local government", "title": "Local government" },
     { "id": "Unknown", "title": "Not yet classified" },
     { "id": "Not for profit", "title": "Not for profit" }
    ],
-  "show-line-labels": true
+  "show-line-labels": true,
+  "show-total-lines": true
 }

--- a/spec/shared/common/collections/spec.grouped_timeseries.js
+++ b/spec/shared/common/collections/spec.grouped_timeseries.js
@@ -6,50 +6,50 @@ function (VolumetricsCollection) {
     var response = {
   "data": [
     {
-      "some:value": 5, 
+      "some:value": 5,
       "values": [
         {
-          "_end_at": "2012-09-01T00:00:00+00:00", 
+          "_end_at": "2012-09-01T00:00:00+00:00",
           "some:value": 3,
           "_start_at": "2012-08-01T00:00:00+00:00"
-        }, 
+        },
         {
-          "_end_at": "2012-10-01T00:00:00+00:00", 
+          "_end_at": "2012-10-01T00:00:00+00:00",
           "_start_at": "2012-09-01T00:00:00+00:00"
         }
-      ], 
+      ],
       "some-category": "xyz"
-    }, 
+    },
     {
-      "some:value": 7, 
+      "some:value": 7,
       "values": [
         {
-          "_end_at": "2012-09-01T00:00:00+00:00", 
+          "_end_at": "2012-09-01T00:00:00+00:00",
           "some:value": 3,
           "_start_at": "2012-08-01T00:00:00+00:00"
-        }, 
+        },
         {
-          "_end_at": "2012-10-01T00:00:00+00:00", 
+          "_end_at": "2012-10-01T00:00:00+00:00",
           "some:value": 4,
           "_start_at": "2012-09-01T00:00:00+00:00"
         }
-      ], 
+      ],
       "some-category": "abc"
-    }, 
+    },
     {
-      "some:value": 16, 
+      "some:value": 16,
       "values": [
         {
-          "_end_at": "2012-09-01T00:00:00+00:00", 
+          "_end_at": "2012-09-01T00:00:00+00:00",
           "some:value": 6,
           "_start_at": "2012-08-01T00:00:00+00:00"
-        }, 
+        },
         {
-          "_end_at": "2012-10-01T00:00:00+00:00", 
+          "_end_at": "2012-10-01T00:00:00+00:00",
           "some:value": 10,
           "_start_at": "2012-09-01T00:00:00+00:00"
         }
-      ], 
+      ],
       "some-category": "def"
     }
   ]
@@ -61,12 +61,12 @@ function (VolumetricsCollection) {
         "title": "ABC",
         "values": [
           {
-            "_end_at": "2012-09-01T00:00:00+00:00", 
+            "_end_at": "2012-09-01T00:00:00+00:00",
             "some:value": 3,
             "_start_at": "2012-08-01T00:00:00+00:00"
-          }, 
+          },
           {
-            "_end_at": "2012-10-01T00:00:00+00:00", 
+            "_end_at": "2012-10-01T00:00:00+00:00",
             "some:value": 4,
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
@@ -77,33 +77,53 @@ function (VolumetricsCollection) {
         "title": "DEF",
         "values": [
           {
-            "_end_at": "2012-09-01T00:00:00+00:00", 
+            "_end_at": "2012-09-01T00:00:00+00:00",
             "some:value": 6,
             "_start_at": "2012-08-01T00:00:00+00:00"
-          }, 
+          },
           {
-            "_end_at": "2012-10-01T00:00:00+00:00", 
+            "_end_at": "2012-10-01T00:00:00+00:00",
             "some:value": 10,
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
         ]
-      }, 
+      },
       {
         "id": "xyz",
         "title": "XYZ",
         "values": [
           {
-            "_end_at": "2012-09-01T00:00:00+00:00", 
+            "_end_at": "2012-09-01T00:00:00+00:00",
             "some:value": 3,
             "_start_at": "2012-08-01T00:00:00+00:00"
-          }, 
+          },
           {
-            "_end_at": "2012-10-01T00:00:00+00:00", 
+            "_end_at": "2012-10-01T00:00:00+00:00",
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
         ]
       }
     ];
+
+    var totalSeries = [
+      {
+        "id": "Total",
+        "title": "Total",
+        "values": [
+          {
+            "_start_at": "2012-08-01T00:00:00+00:00",
+            "_end_at": "2012-09-01T00:00:00+00:00",
+            "some:value": 12
+          },
+          {
+            "_start_at": "2012-09-01T00:00:00+00:00",
+            "_end_at": "2012-10-01T00:00:00+00:00",
+            "some:value": 14
+          }
+        ]
+      }
+    ];
+    var expectedWithTotal = totalSeries.concat(expected);
 
     var collection;
     beforeEach(function (){
@@ -117,7 +137,7 @@ function (VolumetricsCollection) {
           { id: "abc", title: "ABC" },
           { id: "def", title: "DEF" },
           { id: "xyz", title: "XYZ" }
-        ]         
+        ]
       });
       collection.backdropUrl = '//testdomain/{{ data-group }}/{{ data-type }}';
     });
@@ -149,6 +169,28 @@ function (VolumetricsCollection) {
       it("parses the response", function () {
         var parsed = collection.parse(response);
         expect(JSON.stringify(parsed)).toEqual(JSON.stringify(expected));
+      });
+
+      it("calculates total lines if specified", function () {
+        totalCollection = new VolumetricsCollection([], {
+          'data-type': "some-type",
+          'data-group': "some-group",
+          valueAttr: "some:value",
+          category: "some-category",
+          period: "month",
+          seriesList: [
+            { id: "Total", title: "Total" },
+            { id: "abc", title: "ABC" },
+            { id: "def", title: "DEF" },
+            { id: "xyz", title: "XYZ" }
+          ],
+          'show-total-lines': true
+        });
+        totalCollection.options.showTotalLines = true;
+
+        var parsed = totalCollection.parse(response);
+        expect(JSON.stringify(parsed)).toEqual(JSON.stringify(expectedWithTotal));
+
       });
     });
   });


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/s/projects/911874/stories/63885814

Add a new configurable option in Stagecraft stubs called "show-total-lines". If it is set, create a "total" series when parsing data. 

Some assumptions: 
- The parse method assumes that data objects have a `_start_at` property. 
- The Stagecraft stubs assume that you will hard-code a "total" object in "series", as well as setting the `show-total-lines` option. I think that's OK since we're already hard-coding the names of the series in these stubs. 
