### PR TITLE
Remove section padding on mobile

### DIFF
--- a/styles/common/module_banners.scss
+++ b/styles/common/module_banners.scss
@@ -60,9 +60,6 @@
 @media (max-width: 640px) {
   #content {
     section {
-      padding-right: 12px;
-      padding-left: 12px;
-
       &.module-banner {
         padding-top: 96px;
 


### PR DESCRIPTION
[Finishes #64142914]

The old dashboards (limelight) doesn't have section padding when on
mobile and the designers don't want it, so we should nuke it.
