### PR TITLE
Adding display:block to #content for Opera

### DIFF
--- a/styles/common/layout.scss
+++ b/styles/common/layout.scss
@@ -9,6 +9,8 @@
 }
 
 #content {
+  // Opera requires display:block for max-width to work...
+  display: block;
   margin: 0 auto;
   max-width: 1020px;
   padding: 0 0 1em 0;


### PR DESCRIPTION
Adding display:block to #content for Opera support (no <main> element support yet)
