### PR TITLE
Changed 'Service performance' to 'Service dashboard'

### DIFF
--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Carer's Allowance",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Carer’s Allowance is a benefit to help people who care for a disabled person for 35 hours or more each week. The person who's cared for must be in receipt of a qualifying benefit, eg Personal Independence Payment, Disability Living Allowance at the middle or highest rate or Armed Forces Independence Payment.",
   "modules": [
     {
@@ -24,7 +24,7 @@
       "data-group": "carers-allowance",
       "data-type": "weekly-claims",
       "dashboard-title": "Carer's Allowance",
-      "dashboard-strapline": "Service performance",
+      "dashboard-strapline": "Service dashboard",
       "category": "key",
       "period": "week",
       "value-attr": "value:sum",

--- a/app/support/stagecraft_stub/responses/carers-allowance/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance/completion-rate.json
@@ -4,7 +4,7 @@
   "module-type": "completion_rate",
   "title": "Completion rate",
   "dashboard-title": "Carer's Allowance",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "carers-allowance",
   "data-group": "carers-allowance",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/carers-allowance/journey.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance/journey.json
@@ -9,7 +9,7 @@
     "Number of users is measured using the count of unique events from each stage."
   ],
   "dashboard-title": "Carer's Allowance",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "carers-allowance",
   "data-group": "carers-allowance",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/carers-allowance/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance/live-service-usage.json
@@ -8,7 +8,7 @@
     "Shows the estimated number of users currently accessing the service on GOV.UK."
   ],
   "dashboard-title": "Carer's Allowance",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "carers-allowance",
   "data-group": "carers-allowance",
   "data-type": "realtime"

--- a/app/support/stagecraft_stub/responses/carers-allowance/service-availability.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Carer's Allowance",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "carers-allowance",
   "data-group": "carers-allowance",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/carers-allowance/weekly-by-channel.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance/weekly-by-channel.json
@@ -7,7 +7,7 @@
   "data-group": "carers-allowance",
   "data-type": "weekly-claims",
   "dashboard-title": "Carer's Allowance",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "carers-allowance",
   "category": "key",
   "period": "week",

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Deposit foreign marriage or civil partnership certificates",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK in the UK for the service to pay the Foreign & Commonwealth Office (FCO) to deposit a foreign marriage or civil partnership certificate at the General Registry Office.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage/completion-rate.json
@@ -3,7 +3,7 @@
   "module-type": "completion_rate",
   "title": "Completion rate",
   "dashboard-title": "Deposit foreign marriage or civil partnership certificates",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "deposit-foreign-marriage",
   "description": "",
   "data-group": "deposit-foreign-marriage",

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage/completion_numbers.json
@@ -3,7 +3,7 @@
   "module-type": "completion_numbers",
   "title": "Completed applications",
   "dashboard-title": "Deposit foreign marriage or civil partnership certificates",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "deposit-foreign-marriage",
   "description": "",
   "data-group": "deposit-foreign-marriage",

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage/journey.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Deposit foreign marriage or civil partnership certificates",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "deposit-foreign-marriage",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Deposit foreign marriage or civil partnership certificates",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "deposit-foreign-marriage",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage/service-availability.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Deposit foreign marriage or civil partnership certificates",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "deposit-foreign-marriage",
   "data-group": "deposit-foreign-marriage",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Payment for certificates to get married abroad",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK in the UK for the service to pay the Foreign & Commonwealth Office (FCO) for documents you need to get married abroad.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/completion-rate.json
@@ -4,7 +4,7 @@
   "title": "Completion rate",
   "description": "",
   "dashboard-title": "Payment for certificates to get married abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-foreign-marriage-certificates",
   "data-group": "pay-foreign-marriage-certificates",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/completion_numbers.json
@@ -3,7 +3,7 @@
   "module-type": "completion_numbers",
   "title": "Completed applications",
   "dashboard-title": "Payment for certificates to get married abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-foreign-marriage-certificates",
   "description": "",
   "data-group": "pay-foreign-marriage-certificates",

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/journey.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Payment for certificates to get married abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-foreign-marriage-certificates",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Payment for certificates to get married abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-foreign-marriage-certificates",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/service-availability.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Payment for certificates to get married abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-foreign-marriage-certificates",
   "data-group": "pay-foreign-marriage-certificates",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Pay to legalise documents using the premium service",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK for the service to pay the Foreign & Commonwealth Office (FCO) to use the premium service to get a UK public document 'legalised' – this means a signature, seal or stamp made by a UK public official on the document is confirmed as genuine by the UK government. This premium service is only available for registered businesses.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/completion-rate.json
@@ -4,7 +4,7 @@
   "title": "Completion rate",
   "description": "",
   "dashboard-title": "Pay to legalise documents using the premium service",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-drop-off",
   "data-group": "pay-legalisation-drop-off",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/completion_numbers.json
@@ -4,7 +4,7 @@
   "title": "Completed applications",
   "description": "",
   "dashboard-title": "Pay to legalise documents using the premium service",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-drop-off",
   "data-group": "pay-legalisation-drop-off",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/journey.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Pay to legalise documents using the premium service",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-drop-off",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Pay to legalise documents using the premium service",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-drop-off",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/service-availability.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Pay to legalise documents using the premium service",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-drop-off",
   "data-group": "pay-legalisation-drop-off",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Pay to get documents legalised by post",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK for the service to pay the Foreign & Commonwealth Office (FCO) to get a UK public document 'legalised' – this means a signature, seal or stamp made by a UK public official on the document is confirmed as genuine by the UK government.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post/completion-rate.json
@@ -4,7 +4,7 @@
   "title": "Completion rate",
   "description": "",
   "dashboard-title": "Pay to get documents legalised by post",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-post",
   "data-group": "pay-legalisation-post",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post/completion_numbers.json
@@ -4,7 +4,7 @@
   "title": "Completed applications",
   "description": "",
   "dashboard-title": "Pay to get documents legalised by post",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-post",
   "data-group": "pay-legalisation-post",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post/journey.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Pay to get documents legalised by post",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-post",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Pay to get documents legalised by post",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-post",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post/service-availability.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Pay to get documents legalised by post",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-legalisation-post",
   "data-group": "pay-legalisation-post",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Payment to register a birth abroad in the UK",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK in the UK for the service to pay the Foreign & Commonwealth Office (FCO) if you're eligible to register the birth of a British national abroad.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad/completion-rate.json
@@ -4,7 +4,7 @@
   "title": "Completion rate",
   "description": "",
   "dashboard-title": "Payment to register a birth abroad in the UK",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-birth-abroad",
   "data-group": "pay-register-birth-abroad",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad/completion_numbers.json
@@ -4,7 +4,7 @@
   "title": "Completed applications",
   "description": "",
   "dashboard-title": "Payment to register a birth abroad in the UK",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-birth-abroad",
   "data-group": "pay-register-birth-abroad",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad/journey.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Payment to register a birth abroad in the UK",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-birth-abroad",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Payment to register a birth abroad in the UK",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-birth-abroad",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad/service-availability.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Payment to register a death abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-death-abroad",
   "data-group": "pay-register-death-abroad",
   "data-type": "monitoring",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
@@ -1,7 +1,7 @@
 {
   "page-type": "dashboard",
   "title": "Payment to register a death abroad",
-  "strapline": "Service performance",
+  "strapline": "Service dashboard",
   "tagline": "Figures for applications processed on GOV.UK in the UK for the service to pay the Foreign & Commonwealth Office (FCO) if you register the death of a British national abroad.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad/completion-rate.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad/completion-rate.json
@@ -4,7 +4,7 @@
   "title": "Completion rate",
   "description": "",
   "dashboard-title": "Payment to register a death abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-death-abroad",
   "data-group": "pay-register-death-abroad",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad/completion_numbers.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad/completion_numbers.json
@@ -4,7 +4,7 @@
   "title": "Completed applications",
   "description": "",
   "dashboard-title": "Payment to register a death abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-death-abroad",
   "data-group": "pay-register-death-abroad",
   "data-type": "journey",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad/journey.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad/journey.json
@@ -4,7 +4,7 @@
   "title": "Users at each stage",
   "description": "Number of users who completed important stages of the transaction last week",
   "dashboard-title": "Payment to register a death abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-death-abroad",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad/live-service-usage.json
@@ -4,7 +4,7 @@
   "title": "Live service usage",
   "description": "Live number of users on any page within the service",
   "dashboard-title": "Payment to register a death abroad",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-death-abroad",
   "info": [
     "Data source: Google Analytics",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad/service-availability.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad/service-availability.json
@@ -3,7 +3,7 @@
   "module-type": "availability",
   "title": "Service availability",
   "dashboard-title": "Payment to register a birth abroad in the UK",
-  "dashboard-strapline": "Service performance",
+  "dashboard-strapline": "Service dashboard",
   "dashboard-slug": "pay-register-birth-abroad",
   "data-group": "pay-register-birth-abroad",
   "data-type": "monitoring",


### PR DESCRIPTION
The grey text at the top of the page indicates the format.
The page is a _dashboard_, not a _performance_. That's something that happens at a theatre.
