### PR TITLE
Removed the dependency on supervisor as a global dependency.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,7 +206,7 @@ module.exports = function(grunt) {
           stdout: true,
           stderr: true
         },
-        command: 'supervisor -w app -i app/vendor -e "js|html" -n error app/server'
+        command: './node_modules/supervisor/lib/cli-wrapper.js -w app -i app/vendor -e "js|html" -n error app/server'
       }
     },
     // Runs development tasks concurrently

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "private": true,
   "scripts": {
-    "test": "grunt test:all"
+    "test": "grunt test:all",
+    "start": "grunt"
   },
   "dependencies": {
     "backbone": "1.1.0",
@@ -46,6 +47,7 @@
     "grunt-digest": "0.1.2",
     "grunt-jasmine-node-coverage": "0.1.6",
     "grunt-rcukes": "0.0.5",
-    "grunt-shell": "0.6.1"
+    "grunt-shell": "0.6.1",
+    "supervisor": "0.5.6"
   }
 }


### PR DESCRIPTION
This should make spinning up new dev vms easier as we no longer need to do 'npm install -g'

[Finishes #64890354]
