### PR TITLE
Add Business Link stats to site traffic graph

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -32,7 +32,8 @@
       "series": [
          { "id": "govuk_visitors", "title": "GOV.UK" },
          { "id": "govuk_visitors", "title": "GOV.UK", "timeshift": 12 },
-         { "id": "directgov_visitors", "title": "directgov", "timeshift": 12 }
+         { "id": "directgov_visitors", "title": "Directgov", "timeshift": 12 },
+         { "id": "businesslink_visitors", "title": "Business Link", "timeshift": 12 }
       ]
     },
     {

--- a/app/support/stagecraft_stub/responses/site-activity/site-traffic.json
+++ b/app/support/stagecraft_stub/responses/site-activity/site-traffic.json
@@ -17,6 +17,7 @@
   "series": [
     { "id": "govuk_visitors", "title": "GOV.UK" },
     { "id": "govuk_visitors", "title": "GOV.UK", "timeshift": 12 },
-    { "id": "directgov_visitors", "title": "Directgov", "timeshift": 12 }
+    { "id": "directgov_visitors", "title": "Directgov", "timeshift": 12 },
+    { "id": "businesslink_visitors", "title": "Business Link", "timeshift": 12 }
   ]
 }


### PR DESCRIPTION
Do we want to display this info on the GOV.UK site traffic graph, @pnb1000?
