### PR TITLE
Our graphs throw a javascript exception if you mouse outside of the graph.

### DIFF
--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -30,7 +30,7 @@ figure.graph {
   .graph-wrapper {
     position:relative;
 
-    .inner {
+    .inner, .hover {
       padding:0;
       position:absolute;
       top: 20px;
@@ -179,17 +179,6 @@ figure.graph {
     stroke: #444;
     stroke-width: 1px;
     shape-rendering: crispEdges;
-  }
-
-  .hover {
-    position: absolute;
-    z-index: 1;
-    left:0;
-    top:0;
-    right:0;
-    bottom:0;
-    opacity:0;
-    background:white;
   }
 
   .legend {


### PR DESCRIPTION
This fix just sets the available hover region to be exactly that of the graph.
[Finishes #64655760]
