### PR TITLE
Bump graph linelabel down by 30px

### DIFF
--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -8,7 +8,7 @@ function (Component) {
     offset: 20,
     linePaddingInner: 4,
     linePaddingOuter: 4,
-    overlapLabelTop: 10,
+    overlapLabelTop: 40,
     overlapLabelBottom: 20,
     labelOffset: 6,
 


### PR DESCRIPTION
Adding `margin-top` to the linelabel moves it down the page, which means it is included in the rectangle that screenshot-as-a-service uses and so the image will no longer be clipped.

This may cause space issues on graphs that have super busy linelabels, but fortunately we don't have any of those to support yet.
