### PR TITLE
Make sure bundler is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   allow_failures:
     - node_js: "0.11"
 before_install: 
+  - rvm use 1.9.3
   - gem install bundler
 install:
   - npm install -g grunt-cli@0.1.9


### PR DESCRIPTION
Travis seems to have forgotten about installing bundler in our latest
builds, causing them to fail. We should probably just ensure it has
always been installed before we start trying to install gems. This
shouldn't affect the build if Travis decides to reinstate bundler.
