### PR TITLE
Return an array of an array from tickValues on conversion graph.

### DIFF
--- a/app/common/views/visualisations/conversion-graph/xaxis.js
+++ b/app/common/views/visualisations/conversion-graph/xaxis.js
@@ -5,7 +5,7 @@ function (XAxis) {
   var ConversionXAxis = XAxis.extend({
     useEllipses: true,
     tickValues: function () {
-      return _.range(this.collection.at(0).get('values').length);
+      return [_.range(this.collection.at(0).get('values').length)];
     },
     tickSize: 0,
     tickPadding: 0,


### PR DESCRIPTION
In commit cf5dabaa5edff06db0e8c6f321def0b7e4be209a we started using
.apply to allow us to pass multiple values to D3 functions. In this case
we want to treat the results of tickValues as a single argument, not as
multiple values to be passed. Hence, return an array of an array.

Discussed this with Tom Booth and we think this is the least-worst fix.

Fixes http://www.pivotaltracker.com/story/show/65707396
