### PR TITLE
Switch off tabular numbers in headings

### DIFF
--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -3,7 +3,7 @@ body {
 }
 
 h2 {
-  @include core-19($tabular-numbers: true);
+  @include core-19;
 }
 
 p {
@@ -18,24 +18,20 @@ a[rel="external"] {
 
 #content {
   h1 {
-    @include bold-24($tabular-numbers: true);
+    @include bold-24;
   }
 
   h2 {
     margin-top:0;
-    @include core-16($tabular-numbers: true);
+    @include core-16;
   }
 
   section {
     margin-top:1em;
     margin-bottom:1.5em;
 
-    h1 {
-      @include bold-24($tabular-numbers: true);
-    }
-
-    h2 {
-      @include bold-24($tabular-numbers: true);
+    h1, h2 {
+      @include bold-24;
     }
 
     h2.dashboard, h3 {
@@ -47,5 +43,3 @@ a[rel="external"] {
     }
   }
 }
-
-  


### PR DESCRIPTION
Using tabular numbers means that Chrome calculates the text width
wrongly, resulting in a weird display of our heading links.

We don't really need tabular numbers in headings, because we shouldn't
really have any numbers in headings. So let's switch them off.

This is a workaround for https://code.google.com/p/chromium/issues/detail?id=344347
