### PR TITLE
Fixing escaping on list labels.

### DIFF
--- a/app/common/templates/visualisations/list.html
+++ b/app/common/templates/visualisations/list.html
@@ -1,8 +1,8 @@
 <ol>
   {{#items}}
   <li>
-    {{#link}}<a href="{{link}}">{{label}}</a>{{/link}}
-    {{^link}}{{label}}{{/link}}
+    {{#link}}<a href="{{link}}">{{{label}}}</a>{{/link}}
+    {{^link}}{{{label}}}{{/link}}
   </li>
   {{/items}}
 </ol>

--- a/spec/shared/common/views/visualisations/spec.list.js
+++ b/spec/shared/common/views/visualisations/spec.list.js
@@ -39,6 +39,34 @@ function (ListView, ListCollection) {
 
     });
 
+    it('should escape labels properly', function() {
+
+      var collection = new ListCollection({
+        'data': [
+          { 'pageTitle': 'foo&#x27;',
+            'pagePath': '/foo' }
+        ]
+      }, {
+        'id': 'foo',
+        'title': 'foo',
+        'parse': 'true',
+        'labelAttr': 'pageTitle',
+        'linkAttr': 'pagePath'
+      });
+
+      var view = new ListView({
+        collection: collection
+      });
+
+      jasmine.renderView(view, function () {
+        var listItems = view.$el.find('li');
+
+        expect(listItems.length).toEqual(1);
+        expect(listItems.first().text().trim()).toEqual('foo\'');
+      });
+
+    });
+
     it('should show the urls with a url-root', function () {
 
       var collection = new ListCollection({


### PR DESCRIPTION
Backdrop returns data with HMTL entities in the strings. In order for
the list to display correctly we need to tell mustache not to try to
escape the labels.
