### PR TITLE
Added Solihull local authority dashboard and modules

### DIFF
--- a/app/support/stagecraft_stub/responses/solihull-local-authority.json
+++ b/app/support/stagecraft_stub/responses/solihull-local-authority.json
@@ -1,0 +1,77 @@
+{
+  "slug": "solihull-local-authority",
+  "page-type": "dashboard",
+  "strapline": "Service dashboard",
+  "title": "Solihull missed waste collection",
+  "tagline": "Solihull Local Authority",
+  "related_pages_title": "Visit the site",
+  "related_pages": [
+    {
+      "title": "Report a missed waste collection",
+      "url": "https://ww2.solihull.gov.uk/iForms/MissedCollection/",
+      "metadata": ""
+    }
+  ],
+  "modules": [
+    {
+      "slug": "missed-collections-by-channel",
+      "module-type": "grouped_timeseries",
+      "title": "Transactions by channel",
+      "description": "Transactions by <span class=\"group0\">phone</span>, <span class=\"group1\">face to face</span> and <span class=\"group2\">other</span>.",
+      "data-group": "solihull-local-authority",
+      "data-type": "transactions-by-channel",
+      "category": "channel",
+      "period": "week",
+      "value-attr": "count:sum",
+      "show-line-labels": true,
+      "cumulative": false,
+      "info": [
+        "Data source: CSV extract",
+        "Shows the number of missed waste collections, broken down by channel"
+      ],
+      "series": [
+        { "id": "Phone", "title": "Phone" },
+        { "id": "FaceToFace", "title": "Face to face" },
+        { "id": "Other", "title": "Other" }
+      ]
+    },
+    {
+      "slug": "usage-breakdown",
+      "module-type": "grouped_timeseries",
+      "title": "Usage breakdown",
+      "description": "<span class=\"group0\">Digital</span> and <span class=\"group1\">Non Digital</span> transactions",
+      "data-group": "solihull-local-authority",
+      "data-type": "transactions-by-channel",
+      "category": "digital",
+      "period": "week",
+      "value-attr": "count:sum",
+      "show-line-labels": true,
+      "show-total-lines": true,
+      "cumulative": true,
+      "info": [
+        "Data source: CSV extract",
+        "Shows the number of digital and non digital transactions"
+      ],
+      "series": [
+        { "id": "Digital", "title": "Digital" },
+        { "id": "NonDigital", "title": "Non Digital" }
+      ]
+    },
+    {
+      "slug": "digital-takeup",
+      "module-type": "completion_rate",
+      "title": "Digital take-up",
+      "data-group": "solihull-local-authority",
+      "data-type": "transactions-by-channel",
+      "period": "week",
+      "info": [
+        "Data source: CSV update",
+        "Digital take-up measures digital transactions as a percentage of the total."
+      ],
+      "end-matcher": "^Digital$",
+      "start-matcher": ".*",
+      "matching-attribute": "digital",
+      "value-attribute": "count:sum"
+    }
+  ]
+}

--- a/app/support/stagecraft_stub/responses/solihull-local-authority/digital-takeup.json
+++ b/app/support/stagecraft_stub/responses/solihull-local-authority/digital-takeup.json
@@ -1,0 +1,19 @@
+{
+  "page-type": "module",
+  "dashboard-title": "Solihull missed waste collection",
+  "dashboard-strapline": "Solihull Local Authority",
+  "dashboard-slug": "solihull-local-authority",
+  "module-type": "completion_rate",
+  "title": "Digital take-up",
+  "data-group": "solihull-local-authority",
+  "data-type": "transactions-by-channel",
+  "period": "week",
+  "info": [
+    "Data source: CSV update",
+    "Digital take-up measures digital transactions as a percentage of the total."
+  ],
+  "end-matcher": "^Digital$",
+  "start-matcher": ".*",
+  "matching-attribute": "digital",
+  "value-attribute": "count:sum"
+}

--- a/app/support/stagecraft_stub/responses/solihull-local-authority/missed-collections-by-channel.json
+++ b/app/support/stagecraft_stub/responses/solihull-local-authority/missed-collections-by-channel.json
@@ -1,0 +1,25 @@
+{
+  "page-type": "module",
+  "dashboard-title": "Solihull missed waste collection",
+  "dashboard-strapline": "Solihull Local Authority",
+  "dashboard-slug": "solihull-local-authority",
+  "module-type": "grouped_timeseries",
+  "title": "Transactions by channel",
+  "description": "Transactions by <span class=\"group0\">phone</span>, <span class=\"group1\">face to face</span> and <span class=\"group2\">other</span>.",
+  "data-group": "solihull-local-authority",
+  "data-type": "transactions-by-channel",
+  "category": "channel",
+  "period": "week",
+  "value-attr": "count:sum",
+  "show-line-labels": true,
+  "cumulative": false,
+  "info": [
+    "Data source: CSV extract",
+    "Shows the number of missed waste collections, broken down by channel"
+  ],
+  "series": [
+    { "id": "Phone", "title": "Phone" },
+    { "id": "FaceToFace", "title": "Face to face" },
+    { "id": "Other", "title": "Other" }
+  ]
+}

--- a/app/support/stagecraft_stub/responses/solihull-local-authority/usage-breakdown.json
+++ b/app/support/stagecraft_stub/responses/solihull-local-authority/usage-breakdown.json
@@ -1,0 +1,25 @@
+{
+  "page-type": "module",
+  "dashboard-title": "Solihull missed waste collection",
+  "dashboard-strapline": "Solihull Local Authority",
+  "dashboard-slug": "solihull-local-authority",
+  "module-type": "grouped_timeseries",
+  "title": "Usage breakdown",
+  "description": "<span class=\"group0\">Digital</span> and <span class=\"group1\">Non Digital</span> transactions",
+  "data-group": "solihull-local-authority",
+  "data-type": "transactions-by-channel",
+  "category": "digital",
+  "period": "week",
+  "value-attr": "count:sum",
+  "show-line-labels": true,
+  "show-total-lines": true,
+  "cumulative": true,
+  "info": [
+    "Data source: CSV extract",
+    "Shows the number of digital and non digital transactions"
+  ],
+  "series": [
+    { "id": "Digital", "title": "Digital" },
+    { "id": "NonDigital", "title": "Non Digital" }
+  ]
+}


### PR DESCRIPTION
Basic dashboard based on the file upload provided by Solihull local authority for missed waste collection.
