### PR TITLE
Drop link to D+P specific page.

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -3,7 +3,7 @@
   "page-type": "dashboard",
   "strapline": "Performance",
   "title": "Activity on GOV.UK",
-  "tagline": "Web traffic on <a href=\"https://www.gov.uk\">our site</a>, including a look at how our content is being used. You can also see activity on the <a href=\"/performance/dashboard/government\">departments and policy</a> section of GOV.UK.",
+  "tagline": "Web traffic on <a href=\"https://www.gov.uk\">our site</a>, including a look at how our content is being used.",
   "modules": [
     {
       "slug": "live-service-usage",


### PR DESCRIPTION
This is a hangover from datainsight and should be removed.
