### PR TITLE
Feature flag tables

### DIFF
--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -84,7 +84,10 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Cal
       this.scales = {};
       this.margin = {};
 
-      this.table = new Table(_.extend(options, {$el: this.figure}));
+      // temporary feature flag around tables
+      if (isClient && window.location.search === '?tables') {
+        this.table = new Table(_.extend(options, {$el: this.figure}));
+      }
 
       // initialize graph components
       var componentInstances = this.componentInstances = [];


### PR DESCRIPTION
We would like to be able to deploy Spotlight with tables only being
paritially done. This will stop the creation and binding of a table
unless a querystring of ?tables is there.
