### PR TITLE
Make multiple small text edits on GOV.UK dashboard

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -3,13 +3,13 @@
   "page-type": "dashboard",
   "strapline": "Performance",
   "title": "Activity on GOV.UK",
-  "tagline": "Web traffic on <a href=\"https://www.gov.uk\">our site</a>, including a look at how our content is being used.",
+  "tagline": "Web traffic on <a href=\"https://www.gov.uk\">our site</a>, based on data from Google Analytics.",
   "modules": [
     {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Live service usage",
-      "description": "Live number of users on GOV.UK",
+      "description": "Number of users currently on GOV.UK",
       "info": [
         "Data source: Google Analytics",
         "Shows the estimated number of users currently accessing GOV.UK."
@@ -21,7 +21,7 @@
       "slug": "site-traffic",
       "module-type": "grouped_timeseries",
       "title": "Site traffic",
-      "description": "Unique visitors to GOV.UK over the last year",
+      "description": "Unique visitors to GOV.UK over the past year",
       "data-group": "govuk",
       "data-type": "visitors",
       "category": "dataType",
@@ -43,7 +43,7 @@
       "slug": "top-content",
       "module-type": "list",
       "title": "Top content",
-      "description": "Most unique pageviews",
+      "description": "Most pageviews in past seven days",
       "classes": ["cols2"],
       "data-group": "govuk",
       "data-type": "most_viewed",
@@ -56,8 +56,8 @@
     {
       "slug": "trending",
       "module-type": "list",
-      "title": "Trending",
-      "description": "Greatest increase in absolute unique pageviews",
+      "title": "Trending content",
+      "description": "Greatest increase in pageviews week-on-week",
       "classes": ["cols2"],
       "data-group": "govuk",
       "data-type": "trending",
@@ -70,8 +70,8 @@
     {
       "slug": "top-policies",
       "module-type": "list",
-      "title": "Top policies last week",
-      "description": "Most unique pageviews",
+      "title": "Top policies",
+      "description": "Most pageviews in past seven days",
       "classes": ["cols2"],
       "data-group": "govuk",
       "data-type": "most_viewed_policies",
@@ -82,10 +82,10 @@
       "link-attr": "pagePath"
     },
     {
-      "slug": "top-publications",
+      "slug": "top-announcements",
       "module-type": "list",
-      "title": "Top publications last week",
-      "description": "Most unique pageviews",
+      "title": "Top announcements",
+      "description": "Most pageviews in past seven days",
       "classes": ["cols2"],
       "data-group": "govuk",
       "data-type": "most_viewed_news",
@@ -110,7 +110,10 @@
       "show-line-labels": true,
       "one-hundred-percent": true,
       "use_stack": true,
-      "info": [ "Data source: Google Analytics" ],
+      "info": [
+        "Data source: Google Analytics",
+        "Desktop category includes traffic from desktops and laptops"
+      ],
       "series": [
          { "id": "desktop", "title": "Desktop" },
          { "id": "mobile", "title": "Mobile" },

--- a/app/support/stagecraft_stub/responses/site-activity/device-type.json
+++ b/app/support/stagecraft_stub/responses/site-activity/device-type.json
@@ -13,7 +13,10 @@
   "show-line-labels": true,
   "one-hundred-percent": true,
   "use_stack": true,
-  "info": [ "Data source: Google Analytics" ],
+  "info": [
+    "Data source: Google Analytics",
+    "Desktop category includes traffic from desktops and laptops"
+  ],
   "series": [
      { "id": "desktop", "title": "Desktop" },
      { "id": "mobile", "title": "Mobile" },

--- a/app/support/stagecraft_stub/responses/site-activity/live-service-usage.json
+++ b/app/support/stagecraft_stub/responses/site-activity/live-service-usage.json
@@ -2,7 +2,7 @@
   "page-type": "module",
   "module-type": "realtime",
   "title": "Live service usage",
-  "description": "Live number of users on GOV.UK",
+  "description": "Number of users currently on GOV.UK",
   "info": [
     "Data source: Google Analytics",
     "Shows the estimated number of users currently accessing GOV.UK."

--- a/app/support/stagecraft_stub/responses/site-activity/site-traffic.json
+++ b/app/support/stagecraft_stub/responses/site-activity/site-traffic.json
@@ -5,7 +5,7 @@
   "page-type": "module",
   "module-type": "grouped_timeseries",
   "title": "Site traffic",
-  "description": "Unique visitors to GOV.UK over the last year",
+  "description": "Unique visitors to GOV.UK over the past year",
   "data-group": "govuk",
   "data-type": "visitors",
   "category": "dataType",

--- a/app/support/stagecraft_stub/responses/site-activity/top-announcements.json
+++ b/app/support/stagecraft_stub/responses/site-activity/top-announcements.json
@@ -1,7 +1,11 @@
 {
   "module-type": "list",
-  "title": "Top publications last week",
-  "description": "Most unique pageviews",
+  "title": "Top announcements",
+  "description": "Most pageviews in past seven days",
+  "info": [
+    "Data source: Google Analytics",
+    "The press releases and news on GOV.UK with the most pageviews in the past seven days."
+  ],
   "data-group": "govuk",
   "data-type": "most_viewed_news",
   "sort-by": "pageviews:descending",

--- a/app/support/stagecraft_stub/responses/site-activity/top-content.json
+++ b/app/support/stagecraft_stub/responses/site-activity/top-content.json
@@ -1,7 +1,11 @@
 {
   "module-type": "list",
   "title": "Top content",
-  "description": "Most unique pageviews",
+  "description": "Most pageviews in past seven days",
+  "info": [
+    "Data source: Google Analytics",
+    "The content on GOV.UK with the most pageviews in the past seven days."
+  ],
   "data-group": "govuk",
   "data-type": "most_viewed",
   "sort-by": "pageviews:descending",

--- a/app/support/stagecraft_stub/responses/site-activity/top-policies.json
+++ b/app/support/stagecraft_stub/responses/site-activity/top-policies.json
@@ -1,7 +1,11 @@
 {
   "module-type": "list",
-  "title": "Top policies last week",
-  "description": "Most unique pageviews",
+  "title": "Top policies",
+  "description": "Most pageviews in past seven days",
+  "info": [  
+    "Data source: Google Analytics",
+    "The policies on GOV.UK with the most pageviews in the past seven days."
+  ],
   "data-group": "govuk",
   "data-type": "most_viewed_policies",
   "sort-by": "pageviews:descending",

--- a/app/support/stagecraft_stub/responses/site-activity/trending.json
+++ b/app/support/stagecraft_stub/responses/site-activity/trending.json
@@ -1,7 +1,12 @@
 {
   "module-type": "list",
   "title": "Trending",
-  "description": "Greatest increase in absolute unique pageviews",
+  "description": "Greatest increase in pageviews week-on-week",
+  "info": [
+    "Data source: Google Analytics",
+    "Based on percentage increase between total pageviews in past seven days and total pageviews in previous seven days. Low pageviews in either period are rounded up to a set threshold.",
+    "Excludes search results, help pages, the Service Design Manual, the Performance Platform, policies, and transformation projects."
+  ],
   "data-group": "govuk",
   "data-type": "trending",
   "sort-by": "percent_change:descending",


### PR DESCRIPTION
Multiple text changes to Stagecraft stubs, including overall dashboard strapline, and "more info" sections for a number of modules. 

Text has been agreed with Cliff. 

All tasks from https://www.pivotaltracker.com/s/projects/911874/stories/66490214
