### PR TITLE
Show tooltip on hover for truncated links in lists

### DIFF
--- a/app/common/templates/visualisations/list.html
+++ b/app/common/templates/visualisations/list.html
@@ -1,7 +1,7 @@
 <ol>
   {{#items}}
   <li>
-    {{#link}}<a href="{{link}}">{{{label}}}</a>{{/link}}
+    {{#link}}<a href="{{link}}" title="{{{label}}}">{{{label}}}</a>{{/link}}
     {{^link}}{{{label}}}{{/link}}
   </li>
   {{/items}}


### PR DESCRIPTION
Using the `title` attribute.

Pivotal story: https://www.pivotaltracker.com/s/projects/911874/stories/66489706
