### PR TITLE
Remove trailing cruft from GOV.UK announcements.

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -92,7 +92,7 @@
       "sort-by": "pageviews:descending",
       "limit": 10,
       "label-attr": "pageTitle",
-      "label-regex": "^(.*)\\s-[^-]+$",
+      "label-regex": "^(.*?)(?:\\s-\\s(?:News stories\\s-\\s|Press releases\\s-\\s|Policy\\s-\\s)?GOV.UK)?$",
       "link-attr": "pagePath"
     },
     {

--- a/app/support/stagecraft_stub/responses/site-activity/top-announcements.json
+++ b/app/support/stagecraft_stub/responses/site-activity/top-announcements.json
@@ -11,7 +11,7 @@
   "sort-by": "pageviews:descending",
   "limit": 10,
   "label-attr": "pageTitle",
-  "label-regex": "^(.*)\\s-[^-]+$",
+  "label-regex": "^(.*?)(?:\\s-\\s(?:News stories\\s-\\s|Press releases\\s-\\s|Policy\\s-\\s)?GOV.UK)?$",
   "link-attr": "pagePath",
   "page-type": "module",
   "dashboard-title": "Activity on GOV.UK",


### PR DESCRIPTION
Amend our regex to exclude "- Policy", "- Press releases" and
"- News stories" from the list of top GOV.UK announcements.

Pivotal story: https://www.pivotaltracker.com/s/projects/911874/stories/66489736
