### PR TITLE
Drop last links to old GOV.UK dashboard

### DIFF
--- a/app/common/templates/homepage.html
+++ b/app/common/templates/homepage.html
@@ -49,10 +49,9 @@
 
     <section class="cols2 service-listing">
       <h2>Activity on GOV.UK</h2>
-      <p>Web traffic on our site, including a look at how our content is being used.</p>
+      <p>Web traffic on our site, based on data from Google Analytics.</p>
       <ul>
-        <li><a href="/performance/dashboard">Activity on GOV.UK</a></li>
-        <li><a href="/performance/dashboard/government">Departments and policy</a></li>
+        <li><a href="/performance/site-activity">Activity on GOV.UK</a></li>
       </ul>
       <!-- GOV.UK realtime module goes here -->
     </section>


### PR DESCRIPTION
We are finally switching over to our new GOV.UK dashboard, so want no
reference to the old data-insight dashboard left.
