### PR TITLE
Amend font size on user satisfaction module.

### DIFF
--- a/styles/common/user_satisfaction.scss
+++ b/styles/common/user_satisfaction.scss
@@ -3,11 +3,11 @@
   overflow: hidden;
   position: relative;
 
-  .stat { 
+  .stat {
     float: left;
   }
 
-  .delta { 
+  .delta {
     position: absolute;
     bottom: 5px;
     left: 12em;
@@ -19,18 +19,18 @@
 
   @media(max-width: 850px) {
 
-	  .delta { 
+	  .delta {
 	    left: 9em;
 	  }
-	
+
   }
 
   @media(max-width: 640px) {
 
-	  .delta { 
+	  .delta {
 	    left: 8em;
 	    bottom: 2px;
 	  }
-	
+
   }
 }


### PR DESCRIPTION
Requested by Michael - this should match font size on existing SORN
and tax disc user satisfaction pages.

Also tidy up whitespace.

Replaces: https://github.com/alphagov/spotlight/pull/266
