### PR TITLE
Position realtime text properly in raw view

### DIFF
--- a/styles/common/raw.scss
+++ b/styles/common/raw.scss
@@ -39,4 +39,9 @@ body.raw {
   .multi_stats .sparkline-graph figure.graph .graph-wrapper {
     width: 180px;
   }
+
+  .sparkline .sparkline-title {
+    top: 98px;
+    right: 90px;
+  }
 }


### PR DESCRIPTION
I'm not totally happy with positioning this absolutely, but for the time being I think this is the best way to fix the clipped PNG fallback.
