### PR TITLE
To speed up the start time we're not hinting the code on server start just on tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -255,7 +255,6 @@ module.exports = function (grunt) {
   grunt.registerTask('build:common', [
     'copy:vendor',
     'copy:govuk_template',
-    'jshint',
     'clean',
     'copy:assets'
   ]);


### PR DESCRIPTION
As requested by @lennym and @alexmuller this will speed up grunt default task significantly.
