### PR TITLE
Exec start-app.sh to avoid orphans

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -4,4 +4,4 @@ echo "Installing Node.js and Ruby dependencies..."
 npm install --quiet
 bundle install --quiet
 
-NODE_ENV=development_bowl_vm grunt
+NODE_ENV=development_bowl_vm exec grunt


### PR DESCRIPTION
When foreman signals `start-app.sh`, children do not receive the message.
Instead the bash process running `start-app.sh` exits and the subprocess
becomes an orphan, getting reparented to init. The result is that servers
don't get stopped correctly and have to be killed manually which is an error
prone process.

This bug is related to alphagov/pp-development#48 and the fix in this commit
is necessary but not sufficient to close it.
