### PR TITLE
Make directory for page-per-thing modules if it does not exist

### DIFF
--- a/tools/stagecraft_lint.js
+++ b/tools/stagecraft_lint.js
@@ -152,6 +152,11 @@ fs.readdir(stagecraftStubDirectory, function (err, files) {
             moduleOnDisk = JSON.parse(fs.readFileSync(moduleJsonPath, 'utf8'));
           }
 
+          if (!fs.existsSync(pagePerThingDirectory)) {
+            console.log('->', 'page-per-thing directory does not exist - creating', pagePerThingDirectory);
+            fs.mkdirSync(pagePerThingDirectory);
+          }
+
           delete module.slug;
           delete module['page-type'];
           module = _.extend(module, {


### PR DESCRIPTION
When creating a new dashboard, the linter/converter script errors out because the target dir does not exist.
Fix that.
