### PR TITLE
Reorder tests to run in ascending order of speed.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,6 @@ module.exports = function (grunt) {
         specNameMatcher: 'spec.*', // load only specs containing specNameMatcher
         match: '.*',
         useRequireJs: 'spec/requirejs-setup.js',
-        forceExit: true,
         jUnit: {
           report: false,
           savePath : './build/reports/jasmine/',


### PR DESCRIPTION
Cucumber and jshint tests are slow, jasmine is fast, so run the fast ones first and we'll get failures quicker.
