### PR TITLE
Amend Gruntfile to only lint application JS.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,7 @@ module.exports = function (grunt) {
     },
     // Lints our JavaScript
     jshint: {
-      files: ['**'],
+      files: ['app/**/*.js', 'app/**/*.json', 'spec/**/*.js'],
       options: {
         reporter: require('jshint-stylish'),
         jshintrc: true


### PR DESCRIPTION
We don't need to lint node modules etc, and this change makes jshint
run much faster.
