### PR TITLE
Fixed issue between swipe and tap.

### DIFF
--- a/app/extensions/views/graph/hover.js
+++ b/app/extensions/views/graph/hover.js
@@ -13,7 +13,9 @@ function (Component) {
     events: function () {
       if (this.modernizr.touch) {
         return {
-          'touchstart .hover': 'onTouchStart'
+          'touchstart .hover' : 'onTouchStart',
+          'touchend .hover'   : 'onTouchEnd',
+          'touchmove .hover'  : 'onTouchMove'
         };
       } else {
         return {
@@ -59,17 +61,29 @@ function (Component) {
     },
 
     onTouchStart: function (e) {
-      var touch = e.originalEvent.touches[0];
-      var offset = this.graph.graphWrapper.offset();
-      var scaleFactor = this.graph.scaleFactor();
-      var x = (touch.pageX - offset.left) / scaleFactor - this.margin.left;
-      var y = (touch.pageY - offset.top) / scaleFactor - this.margin.top;
+      var touch = e.originalEvent.targetTouches ? e.originalEvent.targetTouches[0] : e;
+      this.startX = this.endX = touch.pageX;
+      this.startY = this.endY = touch.pageY;
+    },
 
-      this.attachBodyListener('touchstart');
-      this.selectPoint(x, y, {
-        toggle: true
-      });
-      return false;
+    onTouchMove: function (e) {
+      var touch = e.originalEvent.targetTouches ? e.originalEvent.targetTouches[0] : e;
+      this.endX = touch.pageX;
+      this.endY = touch.pageY;
+    },
+
+    onTouchEnd: function () {
+      if ((this.startX === this.endX) && this.startY === this.endY) {
+        var offset = this.graph.graphWrapper.offset();
+        var scaleFactor = this.graph.scaleFactor();
+        var x = (this.endX - offset.left) / scaleFactor - this.margin.left;
+        var y = (this.endY - offset.top) / scaleFactor - this.margin.top;
+
+        this.attachBodyListener('touchstart');
+        this.selectPoint(x, y, {
+          toggle: true
+        });
+      }
     },
 
     /**


### PR DESCRIPTION
We can now see the difference between a swipe and tap.
We have more events listening if you're on a touch device.
Listen at the start and check the difference for the end and either move the point on a graph or do nothing.

Pivotal story: https://www.pivotaltracker.com/story/show/65320718

![](http://media.giphy.com/media/10wne2JZXvIeVa/200.gif)
