### PR TITLE
Pass href to linelabel on grouped_timeseries

### DIFF
--- a/app/common/collections/grouped_timeseries.js
+++ b/app/common/collections/grouped_timeseries.js
@@ -63,7 +63,8 @@ function (MatrixCollection) {
 
                         return _.extend({
                           id: series.categoryId,
-                          title: series.label
+                          title: series.label,
+                          href: series.href
                         }, {
                           values: dataSeries.values
                         });


### PR DESCRIPTION
This was broken as part of the work on refactoring how series and axes are defined in JSON. The bug manifests itself as the `<a>` elements in linelabels having no `href` attribute, because it's not being passed along to the linelabel.
