### PR TITLE
Add travis_retry to Travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - node_js: "0.11"
 before_install:
   - rvm use 1.9.3
-  - gem install bundler
+  - travis_retry gem install bundler
 install:
-  - bundle install
-  - npm install -g grunt-cli@0.1.9
-  - npm install
+  - travis_retry bundle install
+  - travis_retry npm install -g grunt-cli@0.1.9
+  - travis_retry npm install
 notifications:
   email: false
 cache:


### PR DESCRIPTION
Do it for things that use the network to install things.

This blog post is from May 2013 but we're still seeing issues in March 2014 and it's starting to get annoying enough that I'm considering running branch builds on our own CI stuff instead.

http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/
