### PR TITLE
Remove related links from cucumber tests

### DIFF
--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -21,9 +21,7 @@ def section_values
     "related-pages" => {
       "no-realistic-dashboard" => [
         "Helping people to buy a home",
-        "Increasing the number of available homes",
-        "Improving the rented housing sector",
-        "Providing housing support for older and vulnerable people"
+        "Increasing the number of available homes"
       ]
     }
   }


### PR DESCRIPTION
Dashboards now only contain two related links.
#294 removed two of the related links from the no-realistic-dashboard, which were being looked for by the cucumber tests.

Updated cucumber steps to reflect this.
