### PR TITLE
Style overflow only if needed.

### DIFF
--- a/styles/common/table.scss
+++ b/styles/common/table.scss
@@ -12,7 +12,7 @@ table {
     tbody {
       display: block;
       max-height: 28em;
-      overflow: scroll;
+      overflow: auto;
     }
   }
 


### PR DESCRIPTION
With `overflow: scroll` we get this:

![](https://i.cloudup.com/OhEpOe8ytn-2000x2000.png)

with `overflow-y: scroll` we get this:

![](https://i.cloudup.com/M19XoJEdQo-3000x3000.png)

with `overflow: auto` we get this:

![](https://i.cloudup.com/5UFl01IBOo-3000x3000.png)

I think the last is best hence the PR
