### PR TITLE
Remove NTA Tabular Numbers in header/footer links

### DIFF
--- a/styles/common/related_pages.scss
+++ b/styles/common/related_pages.scss
@@ -9,11 +9,11 @@
   .related-pages {
 
     h3 {
-      @include core-16($tabular-numbers: true);
+      @include core-16;
     }
 
     .related-transaction a {
-      @include bold-24($tabular-numbers: true);
+      @include bold-24;
     }
 
     .related-other {
@@ -33,11 +33,11 @@
           line-height: 1;
 
           a {
-            @include bold-16($tabular-numbers: true);
+            @include bold-16;
           }
 
           .metadata {
-            @include core-14($tabular-numbers: true);
+            @include core-14;
           }
         }
       }
@@ -60,7 +60,7 @@
         margin-top: 10px;
 
         a {
-          @include bold-16($tabular-numbers: true);
+          @include bold-16;
         }
       }
 


### PR DESCRIPTION
Chrome on Windows doesn't link it.

https://code.google.com/p/chromium/issues/detail?id=344347
