### PR TITLE
Fix bug in live-service-usage graph rendering.

### DIFF
--- a/app/common/templates/visualisations/visitors-realtime.html
+++ b/app/common/templates/visualisations/visitors-realtime.html
@@ -1,4 +1,3 @@
-<% if (numberOfVisitors != null) { %>
 <p>
   <div class="stat">
     <div class="impact-number"><strong>&nbsp;</strong></div>
@@ -11,4 +10,3 @@
   </div>
 
 </p>
-<% } %>

--- a/app/common/views/visualisations/visitors-realtime.js
+++ b/app/common/views/visualisations/visitors-realtime.js
@@ -82,18 +82,6 @@ function (View, SparklineView, template) {
       }
     },
 
-    templateContext: function () {
-      var numberOfVisitors = null;
-      if (this.currentVisitors) {
-        numberOfVisitors = Math.round(this.currentVisitors);
-      }
-
-      return _.extend(
-        View.prototype.templateContext.apply(this, arguments),
-        { numberOfVisitors: numberOfVisitors }
-      );
-    },
-
     views: function () {
       var views = {};
       if (this.collection && this.collection.length && this.collection.first().get('values').length > 1 && this.sparkline) {


### PR DESCRIPTION
We were checking for the existence of the collection before
rendering the template HTML for live-service-usage graphs.

Unfortunately, this got us into an occasional race condition
between templateContext and initialize, so sometimes the
graphs weren't rendering.

The template check isn't really useful anyway, because we
don't have error handling in the collection yet, so the
graphs will probably break before this point if there is
no data in the collection. Instead, we should address this
as part of our general error handling story. 

So: remove this check from the template, and remove
templateContext from the view.
