### PR TITLE
Fix print styles.

### DIFF
--- a/app/common/templates/head.html
+++ b/app/common/templates/head.html
@@ -1,4 +1,4 @@
-<link href="<%= assetPath %>stylesheets/<%= assetDigest['spotlight.css'] %>" media="screen" rel="stylesheet" type="text/css">
+<link href="<%= assetPath %>stylesheets/<%= assetDigest['spotlight.css'] %>" media="all" rel="stylesheet" type="text/css">
 
 <script id="ga-params" type="text/javascript">
   var GOVUK = GOVUK || {};

--- a/spec/server/common/views/spec.govuk.js
+++ b/spec/server/common/views/spec.govuk.js
@@ -38,7 +38,7 @@ function (GovUkView, View, Model) {
       expect(view.html).toEqual('rendered');
 
       var context = view.template.argsForCall[0][0];
-      expect(context.head.trim().indexOf('<link href="/testAssetPath/stylesheets/spotlight-cachebust.css" media="screen" rel="stylesheet" type="text/css">')).not.toBe(-1);
+      expect(context.head.trim().indexOf('<link href="/testAssetPath/stylesheets/spotlight-cachebust.css" media="all" rel="stylesheet" type="text/css">')).not.toBe(-1);
       expect(context.head.trim().indexOf('google-analytics.com')).not.toBe(-1);
       expect(context.bodyEnd).toEqual('body_end');
       expect(context.pageTitle).toEqual('Performance - GOV.UK');


### PR DESCRIPTION
Pivotal story:
https://www.pivotaltracker.com/s/projects/911874/stories/66047406

Setting media='all' rather than media='screen' carries our graph
styles through to the print stylesheet.

Also update tests.
