### PR TITLE
Availablility collection should use correct period

### DIFF
--- a/app/common/collections/availability.js
+++ b/app/common/collections/availability.js
@@ -6,7 +6,7 @@ function (MatrixCollection) {
 
     queryParams: function () {
       var params = {
-        period: 'day',
+        period: this.options.period || 'day',
         collect: ['downtime:sum', 'uptime:sum', 'unmonitored:sum', 'avgresponse:mean']
       };
       params.end_at = this.options.endAt || null;

--- a/spec/shared/common/collections/spec.availability.js
+++ b/spec/shared/common/collections/spec.availability.js
@@ -41,6 +41,21 @@ define([
         expect(params.end_at).toEqual('2012-04-01T00:00:00+00:00');
       });
 
+      it('should be created with correct query parameters, if period set', function () {
+        var collection =
+          new AvailiabilityCollection(null, {
+            checkName: 'mycheck',
+            'data-group': 'something-something-fco',
+            'data-type': 'monitoring',
+            'endAt': '2012-04-01T00:00:00+00:00',
+            'period': 'hour'
+          });
+        var params = collection.queryParams();
+        expect(params.period).toEqual('hour');
+        expect(params.collect).toEqual(['downtime:sum', 'uptime:sum', 'unmonitored:sum', 'avgresponse:mean']);
+        expect(params.end_at).toEqual('2012-04-01T00:00:00+00:00');
+      });
+
       it('should provide percentage of uptime for all models', function () {
         var collection = new AvailiabilityCollection(availabilityData, options);
         var fractionOfUptime = collection.getFractionOfUptime();


### PR DESCRIPTION
It was hardcoded on day, whereas we want it to vary as the options
change.
