### PR TITLE
Remove RequireJS requiring require

### DIFF
--- a/app/extensions/views/timeseries_graph/percentage_graph.js
+++ b/app/extensions/views/timeseries_graph/percentage_graph.js
@@ -1,8 +1,7 @@
 define([
-  'require',
   'extensions/views/graph/graph'
 ],
-function (require, Graph) {
+function (Graph) {
   var PercentageGraph = Graph.extend({
 
     getConfigNames: function () {


### PR DESCRIPTION
This was needed when this file contained a relative dependency, but isn't needed now.
