### PR TITLE
Emit an event when the server has started and is listening

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -46,6 +46,12 @@ var app = requirejs('appBuilder').getApp(environment, rootDir, argv.REQUIRE_BASE
 
 var server = http.createServer(app).listen(app.get('port'), function () {
   global.logger.info('Express server listening on port ' + app.get('port'));
+  if (typeof process.send === 'function') {
+    process.send({
+      state: 'ready',
+      port: app.get('port')
+    });
+  }
 });
 
 exports = module.exports = server;


### PR DESCRIPTION
I'm working on some cheapseats code that spins up its own server as a child process. It needs to know when spotlight is ready to start receiving requests. By emitting an event to the parent process spotlight can inform cheapseats that it can start running its tests.
