### PR TITLE
Fix lists not become 100% width when on mobile

### DIFF
--- a/styles/common/columns.scss
+++ b/styles/common/columns.scss
@@ -9,6 +9,11 @@
     margin-left: 30px / 960px * 100%;
   }
 
+  #content section.module.cols2 {
+    width: 480px / 960px * 100%;
+    margin-left: 0;
+  }
+
   .cols2:first-of-type,
   #content section.cols2:first-of-type,
   #content article.cols2:first-of-type {

--- a/styles/common/kpi.scss
+++ b/styles/common/kpi.scss
@@ -53,20 +53,3 @@
   }
 }
 
-@include media(desktop) {
-  #content .kpi {
-
-    &.cols2 {
-      width: 480px / 960px * 100%;
-      margin-left: 0;
-      float: left;
-      clear: none;
-      margin-right: 0;
-
-      &:nth-of-type(2) {
-        margin-top: 0;
-        border-top: 0;
-      }
-    }
-  }
-}

--- a/styles/common/layout.scss
+++ b/styles/common/layout.scss
@@ -31,9 +31,16 @@
     // For the first section on the page, reset the border and the margin.
     // Do the same for the 2nd section, providing it has a cols2 class.
     // Currently we only support 2-column modules at the top of the page.
-    &:nth-of-type(1), &:nth-of-type(2).cols2 {
+    &:nth-of-type(1) {
       border-top: 0;
       margin-top: 0;
+    }
+
+    @include media(desktop) {
+      &:nth-of-type(2).cols2 {
+        border-top: 0;
+        margin-top: 0;
+      }
     }
 
     &.half-width {

--- a/styles/common/list.scss
+++ b/styles/common/list.scss
@@ -28,15 +28,3 @@
   }
 
 }
-
-@include media(desktop) {
-  #content .list.cols2 {
-    width: 480px / 960px * 100%;
-    margin-left: 0;
-    float: left;
-    clear: none;
-    margin-right: 0;
-    padding-right: 20px / 960px * 100%;
-  }
-}
-

--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -1,11 +1,6 @@
 #content {
   section.module {
     min-height: 210px;
-
-    &.cols2 {
-      width: 50%;
-      margin-left: 0;
-    }
   }
 
   h2 {


### PR DESCRIPTION
There was an issue on production where the list module were not changing
to fill the complete width of page when the width was reduced.

It turns out that we had column code knocking around in a few places in
our scss codebase. I have collapsed them down to one set of styling
columns shared between the homepage and modules.
