### PR TITLE
Add-digital-channel-to-missed-collections-by-channel

### DIFF
--- a/app/support/stagecraft_stub/responses/solihull-local-authority.json
+++ b/app/support/stagecraft_stub/responses/solihull-local-authority.json
@@ -42,6 +42,11 @@
       "axes": {
         "y": [
           {
+            "label": "Digital",
+            "categoryId": "Digital",
+            "format": "integer"
+          },
+          {
             "label": "Phone",
             "categoryId": "Phone",
             "format": "integer"


### PR DESCRIPTION
Add Digital channel data series to Missed Collections by Channel graph
to provide complete 'picture' of reported missed colelctions
NOTE: this channel only covers webform based requests - social media and
mobile app requests are handled manually and so classed as 'other'
