### PR TITLE
Install cheapseats over HTTPS instead of git

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "uglify-js": "2.4.0"
   },
   "devDependencies": {
-    "cheapseats": "git://github.com/alphagov/cheapseats",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats",
     "grunt": "0.4.4",
     "grunt-concurrent": "0.5.0",
     "grunt-contrib-clean": "0.5.0",


### PR DESCRIPTION
The deployment machines don't have access on the port that the git protocol uses, so switch to a more normal TCP port.

We could use SSH for this too, but using HTTPS means that there's no SSH key exchange needed.
