### PR TITLE
Fix bug in positioning of line labels.

### DIFF
--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -118,6 +118,7 @@ function (Component) {
       this.summaryHeight = 0;
 
       if (!this.showSummary) {
+        this.overlapLabelTop = 0;
         return;
       }
 


### PR DESCRIPTION
On line graphs where the top label is very near the top of
the graph, label positioning was odd.

This was because an extra margin of 40px was being applied,
even though this margin was only used for stacked graphs
with a summary legend in the top right corner.

Line graphs do not require the summary legend, so remove the
extra margin.

The best place to see the difference is the G-Cloud dashboard.
