### PR TITLE
Ensure KPIs fail gracefully for empty datasets.

### DIFF
--- a/app/common/views/visualisations/kpi.js
+++ b/app/common/views/visualisations/kpi.js
@@ -22,6 +22,10 @@ function (View, Formatters, template) {
         dateFormat.format = 'D MMM YYYY';
       }
 
+      if (!current) {
+        return {};
+      }
+
       var config = {
         hasValue: current.get(valueAttr) !== null && current.get(valueAttr) !== undefined,
         value: this.format(current.get(valueAttr), format),

--- a/spec/shared/common/views/visualisations/spec.kpi.js
+++ b/spec/shared/common/views/visualisations/spec.kpi.js
@@ -48,6 +48,18 @@ define([
         expect(dateKpi.$('.single-stat-headline').text()).toContain('24 Mar 2014 to 30 Mar 2014');
       });
 
+      it('fails gracefully if there is no data', function () {
+        var dateKpi = new KPIView({
+          model: new Model({
+            valueAttr: 'value',
+            format: 'currency'
+          }),
+          collection: new Collection([])
+        });
+        dateKpi.render();
+        expect(dateKpi.$('.single-stat-headline').text().trim()).toEqual('no data');
+      });
+
       it('loads property from model valueAttr', function () {
         kpi.collection.at(0).set('foo', 2);
         kpi.collection.at(1).set('foo', 2);


### PR DESCRIPTION
If there is no data in a dataset, ensure the KPI modules
do not crash and burn. Also update tests.

Pivotal story: https://www.pivotaltracker.com/s/projects/911874/stories/68903848
