### PR TITLE
Discard any data over 24 hours old in realtime view.

### DIFF
--- a/app/common/views/visualisations/visitors-realtime.js
+++ b/app/common/views/visualisations/visitors-realtime.js
@@ -23,6 +23,18 @@ function (View, SparklineView, template) {
 
       this.changeOnSelected = options.changeOnSelected || this.changeOnSelected;
 
+      // If we have more than 24 hours' worth of data, crop the excess.
+      if (this.collection && this.collection.length && this.collection.first().get('values').length) {
+        var latestDate = this.collection.first().get('values').first().get('_timestamp');
+        var startDate = this.collection.first().get('values').last().get('_timestamp');
+        if (startDate.diff(latestDate, 'hours') > 24) {
+          var values = this.collection.first().get('values').filter(function (i) {
+            return (i.get('_timestamp').diff(latestDate, 'hours') <= 24);
+          });
+          this.collection.first().get('values').reset(values);
+        }
+      }
+
       if (this.changeOnSelected) {
         this.listenTo(this.collection, 'change:selected', this.onChangeSelected, this);
       }

--- a/spec/shared/common/views/visualisations/spec.visitors-realtime.js
+++ b/spec/shared/common/views/visualisations/spec.visitors-realtime.js
@@ -39,6 +39,45 @@ function (VisitorsRealtimeView, Collection) {
 
     describe('initialize', function () {
 
+      it('discards data that is more than 24 hours old', function () {
+
+        var testView, testCollection;
+        testCollection = new Collection();
+        var testData = [
+          {
+            '_timestamp': collection.getMoment('2002-03-01T00:00:00+00:00'),
+            'unique_visitors': 3
+          },
+          {
+            '_timestamp': collection.getMoment('2002-03-01T00:03:00+00:00'),
+            'unique_visitors': 1
+          },
+          {
+            '_timestamp': collection.getMoment('2002-03-02T00:12:00+00:00'),
+            'unique_visitors': 1
+          },
+          {
+            '_timestamp': collection.getMoment('2002-03-02T01:06:00+00:00'),
+            'unique_visitors': 1
+          }
+        ];
+        testCollection.reset([ {
+          id: 'test',
+          title: 'test',
+          values: new Collection(testData)
+        } ]);
+        testView = new VisitorsRealtimeView({
+          collection: testCollection
+        });
+        jasmine.serverOnly(function () {
+          testView.sparkline = false;
+        });
+
+        jasmine.renderView(testView, function () {
+          expect(testCollection.first().get('values').length).toEqual(3);
+        });
+      });
+
       describe('collection events', function () {
 
         describe('onChangeSelected', function () {


### PR DESCRIPTION
Some of our realtime views show 25 or 26 hours' worth
of data. This is because our realtime collections inherit
from the list collection, and so we return the latest N
data points, with no control over how old these are. If
the realtime collectors have been down at any point in the
last 24 hours, the data returned can go back further in
time.

So: add a small fix in the realtime view to discard any
data that is more than 24 hours older than the most
recent data point. This will stop the confusing messages
about there being 25 hours' worth of data.

We have a story for a proper fix, which is to convert
the realtime collections to use timestamps, rather than
inherit from the list collection. However, this fix will
work in the short term.

Pivotal bug: https://www.pivotaltracker.com/s/projects/911874/stories/66658940

Pivotal story for proper fix: https://www.pivotaltracker.com/s/projects/911874/stories/65897896
