### PR TITLE
Enhancement/hyphen rage

### DIFF
--- a/app/common/views/visualisations/kpi.js
+++ b/app/common/views/visualisations/kpi.js
@@ -1,9 +1,8 @@
 define([
   'extensions/views/view',
-  'extensions/mixins/formatters',
   'stache!common/templates/visualisations/kpi'
 ],
-function (View, Formatters, template) {
+function (View, template) {
 
   return View.extend({
 
@@ -52,9 +51,7 @@ function (View, Formatters, template) {
       }
 
       return config;
-    },
-
-    format: Formatters.format
+    }
 
   });
 

--- a/app/extensions/mixins/formatters.js
+++ b/app/extensions/mixins/formatters.js
@@ -58,10 +58,18 @@ define([
     },
 
     percent: function (value, options) {
+      if (isNaN(Number(value))) {
+        return value;
+      }
       _.defaults(options, {
-        dps: 0
+        dps: 0,
+        sign: false
       });
-      return formatters.number(value * 100, options) + '%';
+      var formatted = formatters.number(value * 100, options) + '%';
+      if (options.sign && value > 0) {
+        formatted = '+' + formatted;
+      }
+      return formatted;
     },
 
     integer: function (value, options) {

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -1,8 +1,7 @@
 define([
-  './view',
-  'extensions/mixins/formatters'
+  './view'
 ],
-function (View, Formatters) {
+function (View) {
 
   var TableView = View.extend({
     initialize: function (options) {
@@ -139,8 +138,6 @@ function (View, Formatters) {
     }
 
   });
-
-  _.extend(TableView.prototype, Formatters);
 
   return TableView;
 });

--- a/app/extensions/views/view.js
+++ b/app/extensions/views/view.js
@@ -1,11 +1,12 @@
 define([
   'backbone',
   'extensions/mixins/date-functions',
+  'extensions/mixins/formatters',
   'modernizr',
   'jquery',
   'lodash'
 ],
-function (Backbone, DateFunctions, Modernizr, $, _) {
+function (Backbone, DateFunctions, Formatters, Modernizr, $, _) {
   var View = Backbone.View.extend({
 
     modernizr: Modernizr,
@@ -318,21 +319,12 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
     },
 
     formatPercentage: function (fraction, numDecimals, showSigns) {
-      if (isNaN(fraction) || !_.isNumber(fraction)) {
-        return fraction;
-      }
-      numDecimals = numDecimals || 0;
-      showSigns = showSigns || false;
-      var value = Math.abs(100 * fraction).toFixed(numDecimals);
-      if (showSigns) {
-        if (fraction > 0) {
-          value = '+' + value;
-        } else if (fraction < 0) {
-          value = '-' + value;
-        }
-      }
-      value += '%';
-      return value;
+      return this.format(fraction, {
+        type: 'percent',
+        fixed: numDecimals,
+        dps: numDecimals || 0,
+        sign: showSigns
+      });
     },
 
     formatPeriod: function (model, period) {
@@ -440,6 +432,7 @@ function (Backbone, DateFunctions, Modernizr, $, _) {
   });
 
   _.extend(View.prototype, DateFunctions);
+  _.extend(View.prototype, Formatters);
 
   return View;
 });

--- a/spec/shared/common/views/visualisations/single_stat_item/spec.delta.js
+++ b/spec/shared/common/views/visualisations/single_stat_item/spec.delta.js
@@ -46,7 +46,7 @@ function (DeltaView, Model, Collection) {
     it('renders sample data', function () {
 
       jasmine.renderView(view, function () {
-        expect(view.$el.find('.change')).toHaveText('−50.00%');
+        expect(view.$el.find('.change')).toHaveText('-50.00%');
         expect(view.$el.text()).toContain('Sep 2012');
       });
 
@@ -140,7 +140,7 @@ function (DeltaView, Model, Collection) {
     it('does show a delta if the numerator is zero', function () {
       collection.first().get('values').last().set('a', 0);
       jasmine.renderView(view, function () {
-        expect(view.$el.find('.change').text()).toContain('−100.00%');
+        expect(view.$el.find('.change').text()).toContain('-100.00%');
       });
     });
 
@@ -182,7 +182,7 @@ function (DeltaView, Model, Collection) {
       });
 
       jasmine.renderView(testView, function () {
-        expect(testView.$el.find('.change')).toHaveText('−50.00%');
+        expect(testView.$el.find('.change')).toHaveText('-50.00%');
         expect(testView.$el.text()).toContain('Sep 2012');
       });
 
@@ -227,7 +227,7 @@ function (DeltaView, Model, Collection) {
       });
 
       jasmine.renderView(testView, function () {
-        expect(testView.$el.find('.change')).toHaveText('−50.00%');
+        expect(testView.$el.find('.change')).toHaveText('-50.00%');
         expect(testView.$el.text()).toContain('Aug 2013');
       });
 

--- a/spec/shared/extensions/views/spec.view.js
+++ b/spec/shared/extensions/views/spec.view.js
@@ -477,7 +477,12 @@ function (View, Model, Backbone, _) {
     });
 
     describe('formatPercentage', function () {
-      var format = View.prototype.formatPercentage;
+      var format;
+
+      beforeEach(function () {
+        var view = new View();
+        format = view.formatPercentage.bind(view);
+      });
 
       it('formats a number as percentage string with no decimals', function () {
         expect(format(0.011)).toEqual('1%');
@@ -492,7 +497,7 @@ function (View, Model, Backbone, _) {
       it('formats signed input with the correct sign', function () {
         expect(format(0.011, 2, false)).toEqual('1.10%');
         expect(format(1, 2, true)).toEqual('+100.00%');
-        expect(format(-1, 0, true)).toEqual('−100%');
+        expect(format(-1, 0, true)).toEqual('-100%');
         expect(format(0, 3, true)).toEqual('0.000%');
       });
 


### PR DESCRIPTION
Went a little further than I expected, but the basic crux is that I wanted percentages to be prefixed with a `-` instead of a `−` for the sake of being able to write remotely sane tests/code.

In doing so, I ported `View#formatPercentage` to use standard formatters, and made sure that the standard formatters could pass `formatPercentage`'s unit tests.
