### PR TITLE
Remove duplicate tab slugs

### DIFF
--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -126,7 +126,7 @@
       "title": "Monthly sales by company size",
       "tabs": [
         {
-          "slug": "contracts-awarded",
+          "slug": "total-spend",
           "module-type": "grouped_timeseries",
           "title": "Total-spend",
           "description": "Total sales each month, showing the division between SMEs and larger enterprises",


### PR DESCRIPTION
These were causing a duplicate id of "monthly-sales-by-company-size-contracts-awarded" and so breaking tests.
