### PR TITLE
Render a message in place of a graph when no data is available

### DIFF
--- a/app/extensions/collections/matrix.js
+++ b/app/extensions/collections/matrix.js
@@ -231,6 +231,12 @@ function (require, Collection, Group) {
       this.each(function (model) {
         model.get('values').sortByAttr(attr, descending, options);
       });
+    },
+
+    isEmpty: function () {
+      return this.all(function (model) {
+        return model.get('values').isEmpty();
+      });
     }
 
   });

--- a/app/extensions/templates/missing-data.html
+++ b/app/extensions/templates/missing-data.html
@@ -1,0 +1,3 @@
+<p class="impact-number">
+  <span class="no-data">(no data)</span>
+</p>

--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -10,9 +10,10 @@ define([
   './hover',
   './callout',
   './tooltip',
+  './missing-data',
   'extensions/views/graph/table'
 ],
-function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Callout, Tooltip, GraphTable) {
+function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Callout, Tooltip, MissingData, GraphTable) {
 
   var scaleFromStartAndEndDates = {
 
@@ -280,6 +281,13 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Cal
      */
     render: function () {
       if (isServer || !this.isVisible()) {
+        return;
+      }
+      if (this.collection.isEmpty()) {
+        this.missingData = new MissingData({
+          el: this.figure
+        });
+        this.missingData.render();
         return;
       }
 

--- a/app/extensions/views/graph/missing-data.js
+++ b/app/extensions/views/graph/missing-data.js
@@ -1,0 +1,11 @@
+define([
+  'extensions/views/view',
+  'stache!extensions/templates/missing-data'
+],
+  function (View, Template) {
+    return View.extend({
+
+      template: Template
+
+    });
+  });

--- a/spec/client/extensions/views/graph/spec.graph.js
+++ b/spec/client/extensions/views/graph/spec.graph.js
@@ -347,10 +347,11 @@ function (Graph, GraphTable, Collection, Model, View, d3) {
 
       var graph;
       beforeEach(function () {
-        spyOn(Graph.prototype, 'prepareGraphArea');
+        spyOn(Graph.prototype, 'prepareGraphArea').andCallThrough();
         graph = new Graph({
           collection: new Collection()
         });
+        spyOn(graph.collection, 'isEmpty').andReturn(false);
         spyOn(graph, 'resizeWithCalloutHidden');
       });
 
@@ -422,6 +423,13 @@ function (Graph, GraphTable, Collection, Model, View, d3) {
         expect(component1.render).toHaveBeenCalled();
         expect(component2.render).toHaveBeenCalled();
       });
+
+      it('renders a "no data" message if no data is provided', function () {
+        graph.collection.isEmpty.andReturn(true);
+        graph.render();
+        expect(graph.figure.text()).toContain('(no data)');
+      });
+
     });
 
     describe('remove', function () {

--- a/spec/shared/extensions/collections/spec.matrix.js
+++ b/spec/shared/extensions/collections/spec.matrix.js
@@ -510,5 +510,30 @@ function (MatrixCollection, Collection, Group) {
 
     });
 
+    describe('isEmpty', function () {
+
+      var collection;
+      beforeEach(function () {
+        collection = new MatrixCollection([{}, {}]);
+        collection.at(0).set('values', new Collection([]));
+        collection.at(1).set('values', new Collection([]));
+      });
+
+      it('returns true if all of the child collections are empty', function () {
+        expect(collection.isEmpty()).toEqual(true);
+      });
+
+      it('returns true if the collection itself if empty', function () {
+        collection.reset();
+        expect(collection.isEmpty()).toEqual(true);
+      });
+
+      it('returns false if any of the child collections are non-empty', function () {
+        collection.at(0).get('values').add({ foo: 1});
+        expect(collection.isEmpty()).toEqual(false);
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
Adds a "no data" message to graphs when collection fetching fails.

To test, go into a `Collection#parse` method (eg https://github.com/alphagov/spotlight/blob/master/app/common/collections/grouped_timeseries.js#L20) and hardcode `data` to `[]`.

Example from Carer's Allowance:

![screen shot 2014-04-10 at 15 43 34](https://cloud.githubusercontent.com/assets/117398/2669090/d29eae08-c0be-11e3-9218-87fb91f450d5.png)
