### PR TITLE
Show previous value if current value unavailable in KPIs.

### DIFF
--- a/app/common/templates/visualisations/kpi.html
+++ b/app/common/templates/visualisations/kpi.html
@@ -9,7 +9,10 @@
 {{#previousPeriod}}
     <div class="delta">
         <div class="single-stat-delta">
-            <span class="change impact-number {{sgn}}">{{change}}</span>
+            <span class="change impact-number {{sgn}}">
+              {{#hasValue}}{{change}}{{/hasValue}}
+              {{^hasValue}}{{previousPeriod.value}}{{/hasValue}}
+            </span>
             {{previousPeriod.start}} to {{previousPeriod.end}}
         </div>
     </div>

--- a/app/common/views/visualisations/kpi.js
+++ b/app/common/views/visualisations/kpi.js
@@ -28,7 +28,7 @@ function (View, Formatters, template) {
 
       var config = {
         hasValue: current.get(valueAttr) !== null && current.get(valueAttr) !== undefined,
-        value: this.format(current.get(valueAttr), format),
+        value: this.format(current.get(valueAttr), format)
       };
 
       if (current.get('_timestamp') && current.get('end_at')) {
@@ -40,14 +40,20 @@ function (View, Formatters, template) {
         });
       }
 
-      if (config.hasValue && previous) {
+      if (previous && previous.get(valueAttr)) {
         _.extend(config, {
-          change: this.format(current.get(valueAttr) / previous.get(valueAttr) - 1, { type: 'percent', dps: 2 }),
-          sgn: current.get(valueAttr) / previous.get(valueAttr) > 1 ? 'increase' : 'decrease',
           previousPeriod: {
+            value: this.format(previous.get(valueAttr), format),
             start: this.format(previous.get('_timestamp'), dateFormat),
             end: this.format(previous.get('end_at'), dateFormat)
           }
+        });
+      }
+
+      if (config.hasValue && previous) {
+        _.extend(config, {
+          change: this.format(current.get(valueAttr) / previous.get(valueAttr) - 1, { type: 'percent', dps: 2 }),
+          sgn: current.get(valueAttr) / previous.get(valueAttr) > 1 ? 'increase' : 'decrease'
         });
       }
 

--- a/spec/shared/common/views/visualisations/spec.kpi.js
+++ b/spec/shared/common/views/visualisations/spec.kpi.js
@@ -76,7 +76,7 @@ define([
       it('applies default formatting of `number` if none is provided', function () {
         kpi.model.unset('format');
         kpi.render();
-        expect(kpi.$('.delta .change').text()).toEqual('10%');
+        expect(kpi.$('.delta .change').text().trim()).toEqual('10%');
         expect(kpi.$('.delta .change').hasClass('increase')).toBe(true);
         expect(kpi.$('.delta .change').hasClass('decrease')).toBe(false);
       });
@@ -105,6 +105,20 @@ define([
         ]);
         kpi.render();
         expect(kpi.$('.delta').length).toEqual(0);
+      });
+
+      it('renders data in the delta section if the latest data point is empty but the penultimate data point is not', function () {
+        kpi.collection.reset([
+          {},
+          {
+            value: 1100,
+            _timestamp: '2014-03-01T00:00:00+00:00',
+            end_at: '2014-04-01T00:00:00+00:00'
+          }
+        ]);
+        kpi.render();
+        expect(kpi.$('.delta').text()).toContain('£1,100');
+        expect(kpi.$('.delta').text()).toContain('Mar 2014 to Apr 2014');
       });
 
     });


### PR DESCRIPTION
In the KPI module, if the current value of the data is unavailable,
currently we only display "no data" in the headline, and nothing
at all in the section where the delta value usually goes.

It would be nicer to display the previous value of the data in
the section where the delta value usually goes, so if the data
is out of date, at least the user has some information about
its previous value.

Amend KPI module to do this.

Pivotal: https://www.pivotaltracker.com/s/projects/911874/stories/69266758
