### PR TITLE
Add filter country=england to student loans comparison module

### DIFF
--- a/app/support/stagecraft_stub/responses/student-finance.json
+++ b/app/support/stagecraft_stub/responses/student-finance.json
@@ -27,7 +27,7 @@
       "data-group": "student-finance",
       "data-type": "transactions-by-channel",
       "category": "stage",
-      "filter-by": ["province:england", "application_type:full-time application", "new_or_continuing:new", "channel:digital"],
+      "filter-by": ["country:england", "province:england", "application_type:full-time application", "new_or_continuing:new", "channel:digital"],
       "comparison": ["academic_year:2014/15", "academic_year:2013/14"],
       "period": "week",
       "axis-period": "month",


### PR DESCRIPTION
Numbers that included other countries were causing dodgy numbers to be returned.
