### PR TITLE
Update G-Cloud labels as per Raphaelle's request

### DIFF
--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -330,7 +330,7 @@
             "format": "currency"
           },
           {
-            "label": "Other wider public sector",
+            "label": "Wider public sector",
             "categoryId": "Other wider public sector",
             "format": "currency"
           },
@@ -340,7 +340,7 @@
             "format": "currency"
           },
           {
-            "label": "Not yet classified",
+            "label": "Other",
             "categoryId": "Unknown",
             "format": "currency"
           },


### PR DESCRIPTION
It's much easier to get the customer sector now, so "not yet classified" no
longer makes sense. It is however still useful for organisation types that we
don't have a clean category for yet, so "Unknown" is now more appropriate
than "Not yet classified".
