### PR TITLE
Remove 'not yet classified' from SME/Large

### DIFF
--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -61,11 +61,6 @@
                "label": "Large enterprises",
                "categoryId": "Large enterprises",
                "format": "currency"
-              },
-              {
-               "label": "Not yet classified",
-               "categoryId": "Unknown",
-               "format": "currency"
               }
             ]
           },
@@ -104,11 +99,6 @@
               {
                "label": "Large enterprises",
                "categoryId": "Large enterprises",
-               "format": "integer"
-              },
-              {
-               "label": "Not yet classified",
-               "categoryId": "Unknown",
                "format": "integer"
               }
             ]
@@ -157,11 +147,6 @@
                  "label": "Large enterprises",
                  "categoryId": "Large enterprises",
                  "format": "currency"
-               },
-               {
-                 "label": "Not yet classified",
-                 "categoryId": "Unknown",
-                 "format": "currency"
                }
              ]
           },
@@ -200,11 +185,6 @@
                {
                  "label": "Large enterprises",
                  "categoryId": "Large enterprises",
-                 "format": "integer"
-               },
-               {
-                 "label": "Not yet classified",
-                 "categoryId": "Unknown",
                  "format": "integer"
                }
              ]


### PR DESCRIPTION
There should no longer any rows which have an unclassified SME or Large 
column, so this axis will always be zero.
