### PR TITLE
Update experimental site-activity dashboards

### DIFF
--- a/app/support/stagecraft_stub/responses/experimental/site-activity-attorney-generals-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-attorney-generals-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:attorney-generals-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "ago",
+      "numerator-matcher": "ago",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:attorney-generals-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:ago",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-cabinet-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-cabinet-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:cabinet-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "co",
+      "numerator-matcher": "co",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:cabinet-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:co",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-business-innovation-skills.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-business-innovation-skills.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-business-innovation-skills",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "bis",
+      "numerator-matcher": "bis",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-business-innovation-skills",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:bis",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-communities-and-local-government.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-communities-and-local-government.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-communities-and-local-government",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dclg",
+      "numerator-matcher": "dclg",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-communities-and-local-government",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dclg",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-culture-media-sport.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-culture-media-sport.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-culture-media-sport",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dcms",
+      "numerator-matcher": "dcms",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-culture-media-sport",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dcms",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-education.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-education.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-education",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dfe",
+      "numerator-matcher": "dfe",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-education",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dfe",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-environment-food-rural-affairs.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-environment-food-rural-affairs.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-environment-food-rural-affairs",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "defra",
+      "numerator-matcher": "defra",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-environment-food-rural-affairs",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:defra",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-international-development.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-international-development.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-international-development",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dfid",
+      "numerator-matcher": "dfid",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-international-development",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dfid",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-transport.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-transport.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-transport",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dft",
+      "numerator-matcher": "dft",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-transport",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dft",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-work-pensions.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-for-work-pensions.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-for-work-pensions",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dwp",
+      "numerator-matcher": "dwp",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-for-work-pensions",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dwp",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-of-energy-climate-change.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-of-energy-climate-change.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-of-energy-climate-change",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "decc",
+      "numerator-matcher": "decc",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-of-energy-climate-change",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:decc",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-department-of-health.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-department-of-health.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:department-of-health",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dh",
+      "numerator-matcher": "dh",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:department-of-health",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dh",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-deputy-prime-ministers-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-deputy-prime-ministers-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:deputy-prime-ministers-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dpmo",
+      "numerator-matcher": "dpmo",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:deputy-prime-ministers-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dpmo",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-driver-and-vehicle-licensing-agency.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-driver-and-vehicle-licensing-agency.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:driver-and-vehicle-licensing-agency",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dvla",
+      "numerator-matcher": "dvla",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:driver-and-vehicle-licensing-agency",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dvla",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-driving-standards-agency.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-driving-standards-agency.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:driving-standards-agency",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "dsa",
+      "numerator-matcher": "dsa",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:driving-standards-agency",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:dsa",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-foreign-commonwealth-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-foreign-commonwealth-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:foreign-commonwealth-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "fco",
+      "numerator-matcher": "fco",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:foreign-commonwealth-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:fco",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-hm-revenue-customs.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-hm-revenue-customs.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:hm-revenue-customs",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "hmrc",
+      "numerator-matcher": "hmrc",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:hm-revenue-customs",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:hmrc",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-hm-treasury.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-hm-treasury.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:hm-treasury",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "hmt",
+      "numerator-matcher": "hmt",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:hm-treasury",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:hmt",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-home-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-home-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:home-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "home_office",
+      "numerator-matcher": "home_office",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:home-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:home_office",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-ministry-of-defence.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-ministry-of-defence.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:ministry-of-defence",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "mod",
+      "numerator-matcher": "mod",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:ministry-of-defence",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:mod",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-ministry-of-justice.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-ministry-of-justice.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:ministry-of-justice",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "moj",
+      "numerator-matcher": "moj",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:ministry-of-justice",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:moj",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-northern-ireland-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-northern-ireland-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:northern-ireland-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "nio",
+      "numerator-matcher": "nio",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:northern-ireland-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:nio",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-prime-ministers-office-10-downing-street.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-prime-ministers-office-10-downing-street.json
@@ -1,8 +1,8 @@
 {
-  "slug": "No10-content-dashboard",
+  "slug": "No 10-content-dashboard",
   "page-type": "dashboard",
   "strapline": "Content Dashboard",
-  "title": "Prime Minister's Office, 10 Downing Street (No10)",
+  "title": "Prime Minister's Office, 10 Downing Street (No 10)",
   "tagline": "Web performance data for the Prime Minister's Office, 10 Downing Street, including site traffic and availability. <a href='http://www.gov.uk/performance/site-activity'>View GOV.UK site activity</a>",
   "relatedPages": {
     "transaction": {
@@ -11,11 +11,11 @@
     },
     "other": [
       {
-        "title": "No10 policies",
+        "title": "No 10 policies",
         "url": "https://www.gov.uk/government/policies?departments%5B%5D=prime-ministers-office-10-downing-street"
       },
       {
-        "title": "No10 publications",
+        "title": "No 10 publications",
         "url": "https://www.gov.uk/government/publications?departments%5B%5D=prime-ministers-office-10-downing-street"
       }
     ]
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:prime-ministers-office-10-downing-street",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "number_10",
+      "numerator-matcher": "number_10",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:prime-ministers-office-10-downing-street",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:number_10",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-scotland-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-scotland-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:scotland-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "scotland_office",
+      "numerator-matcher": "scotland_office",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:scotland-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:scotland_office",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-vehicle-and-operator-services-agency.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-vehicle-and-operator-services-agency.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:vehicle-and-operator-services-agency",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "vosa",
+      "numerator-matcher": "vosa",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:vehicle-and-operator-services-agency",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:vosa",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]

--- a/app/support/stagecraft_stub/responses/experimental/site-activity-wales-office.json
+++ b/app/support/stagecraft_stub/responses/experimental/site-activity-wales-office.json
@@ -189,8 +189,8 @@
         },
         {
           "module-type": "table",
-          "slug": "consulations",
-          "title": "Consulations",
+          "slug": "consultations",
+          "title": "Consultations",
           "description": "",
           "data-group": "gov-uk-content",
           "data-type": "top-consultations-count",
@@ -535,37 +535,25 @@
     },
     {
       "slug": "total-feedback-received",
-      "module-type": "completion_rate",
+      "module-type": "completion_numbers",
       "title": "Total feedback received",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "visitors-count",
-      "filter-by": "department:wales-office",
+      "data-type": "feedback-count",
       "info": [
       ],
-      "denominator-matcher": ".*$",
-      "numerator-matcher": "^Small",
-      "matching-attribute": "sme_large",
-      "value-attribute": "monthly_spend:sum",
+      "denominator-matcher": "wo",
+      "numerator-matcher": "wo",
+      "matching-attribute": "organisation_acronym",
+      "value-attribute": "comment_count:sum",
       "period": "month",
-      "tabs": [
-        {"id": "monthly_spend:sum", "name": "Unique visits"},
-        {"id": "count:sum", "name": "Unique pageviews"}
-      ],
-      "tabbed_attr": "collect",
-      "category": "sme_large",
       "axes": {
         "x": {
-          "label": "Date of sales",
-          "format": {
-            "type": "date",
-            "format": "MMMM YYYY"
-          },
-          "key": "_start_at"
+          "label": "Date"
         },
         "y": [
           {
-            "label": "Percentage of sales to SMEs"
+            "label": "Comment Count"
           }
         ]
       }
@@ -576,34 +564,28 @@
       "title": "Most commented pages",
       "description": "",
       "data-group": "gov-uk-content",
-      "data-type": "top-count",
-      "filter-by": "department:wales-office",
+      "data-type": "top-urls",
       "query-params": {
-        "filter_by": "type:tax-disc",
-        "group_by": "reason",
-        "collect": ["count:sum", "description:set"],
-        "period": "week",
+        "filter_by": "organisation_acronym:wo",
+        "group_by": "url",
+        "collect": ["comment_count:sum"],
+        "period": "month",
         "duration": 1
       },
       "axes": {
         "x": {
-          "label": "Department",
-          "key": "description:set"
+          "label": "URL",
+          "key": "url"
         },
         "y": [
           {
-            "label": "Visits",
-            "key": "count:sum",
+            "label": "Total comments",
+            "key": "comment_count:sum",
             "format": "integer"
-          },
-          {
-            "label": "Percentage of visits",
-            "key": "percentOfTotal(count:sum)",
-            "format": "percent"
           }
         ]
       },
-      "sort-by": "count:sum",
+      "sort-by": "comment_count:sum",
       "sort-order": "descending"
     }
   ]


### PR DESCRIPTION
This introduces the "Total feedback received" graph and the "Most commented
pages" table.

Since these live in the `/experimental/` namespace they don't need an intense
review.
