### PR TITLE
Set minimum heights on tabs once the active tab has rendered

### DIFF
--- a/app/common/modules/tab.js
+++ b/app/common/modules/tab.js
@@ -46,7 +46,10 @@ function (ModuleController, TabView) {
             el: this.view.$('section').eq(this.model.get('activeIndex'))
           };
         }, this),
-        function () { }
+        _.bind(function () {
+          var height = this.view.$('section').eq(this.model.get('activeIndex')).height();
+          this.view.$('section').css('min-height', height);
+        }, this)
       );
     },
 


### PR DESCRIPTION
To prevent the jump in heights when waiting for new modules to render when switching between tabs.
