### PR TITLE
Add Transaction Explorer modules for CA/LPA

### DIFF
--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -29,6 +29,48 @@
   "business-model": "Department budget",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dwp-carers-allowance-new-claims", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dwp-carers-allowance-new-claims", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dwp-carers-allowance-new-claims", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Live service usage",

--- a/app/support/stagecraft_stub/responses/lasting-power-of-attorney.json
+++ b/app/support/stagecraft_stub/responses/lasting-power-of-attorney.json
@@ -19,6 +19,48 @@
   },
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:moj-lasting-power-of-attorney-applications", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:moj-lasting-power-of-attorney-applications", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:moj-lasting-power-of-attorney-applications", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "applications-breakdown",
       "module-type": "grouped_timeseries",
       "title": "Applications breakdown",


### PR DESCRIPTION
Don't merge this until @mharrington gives the go ahead!

https://github.com/alphagov/spotlight/pull/385 adds all except CA/LPA. 

This pull request adds CA/LPA and can be merged whenever
the data for these modules is ready. 
