### PR TITLE
Add Transaction Explorer modules, except CA/LPA

### DIFF
--- a/app/support/stagecraft_stub/responses/pay-legalisation-post.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post.json
@@ -17,6 +17,48 @@
   "description-extra": "Legalisation means a signature, seal or stamp made by a UK public official on the document is confirmed as genuine by the UK government.",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-apply-for-legalisation-apostille-certificate", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-apply-for-legalisation-apostille-certificate", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-apply-for-legalisation-apostille-certificate", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Live service usage",

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
@@ -18,6 +18,48 @@
   "business-model": "Department budget",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-birth-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-birth-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-birth-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Live service usage",

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
@@ -18,6 +18,48 @@
   "business-model": "Department budget",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-death-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-death-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:fco-registering-a-death-abroad", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Live service usage",

--- a/app/support/stagecraft_stub/responses/sorn.json
+++ b/app/support/stagecraft_stub/responses/sorn.json
@@ -23,6 +23,48 @@
   "business-model": "Department budget",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-request-statutory-off-road-notice-sorn", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-request-statutory-off-road-notice-sorn", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-request-statutory-off-road-notice-sorn", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Users on start page",

--- a/app/support/stagecraft_stub/responses/tax-disc.json
+++ b/app/support/stagecraft_stub/responses/tax-disc.json
@@ -23,6 +23,48 @@
   "business-model": "Fiscal",
   "modules": [
     {
+      "slug": "transactions-per-year",
+      "module-type": "kpi",
+      "title": "Transactions per year",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-tax-a-vehicle", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "number_of_transactions",
+      "format": { "type": "number", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "total-cost",
+      "module-type": "kpi",
+      "title": "Total cost",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-tax-a-vehicle", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "total_cost",
+      "format": { "type": "currency", "magnitude": true, "sigfigs": 3 }
+    },
+    {
+      "slug": "cost-per-transaction",
+      "module-type": "kpi",
+      "title": "Cost per transaction",
+      "data-group": "transactions-explorer",
+      "data-type": "spreadsheet",
+      "classes": "cols3",
+      "query-params": {
+        "filter_by": ["service_id:dft-tax-a-vehicle", "type:seasonally-adjusted"],
+        "sort_by": "_timestamp:descending"
+      },
+      "valueAttr": "cost_per_transaction",
+      "format": { "type": "currency", "pence": true }
+    },
+    {
       "slug": "live-service-usage",
       "module-type": "realtime",
       "title": "Users on start page",


### PR DESCRIPTION
They had been removed for a production release and are now ready to
drop back in again.

The modules for Carer's Allowance and LPA will be merged separately
since the data is not yet ready.

Don't include data for pay-legalisation-drop-off or for
pay-foreign-marriage-certificates since these are not in TxEx. Also
not for deposit-foreign-marriage since it has been archived.
