### PR TITLE
Adjust the min height of modules

### DIFF
--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -1,5 +1,5 @@
 #content {
   section.module {
-    min-height: 210px;
+    min-height: 190px;
   }
 }


### PR DESCRIPTION
Users on start page and User satisfaction are both smaller than the
min-height and the min-height then causes an annoying gap.

![gap](https://cloud.githubusercontent.com/assets/108382/2763561/3cbca8e0-ca05-11e3-8d9e-679678a493b3.png)
