### PR TITLE
Include content dashboards when generating modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "uglify-js": "2.4.13",
     "winston": "0.7.3",
     "xmlhttprequest": "1.6.0",
-    "xtend": "2.2.0"
+    "xtend": "2.2.0",
+    "glob": "3.2.9"
   },
   "devDependencies": {
     "cheapseats": "git+https://github.com/alphagov/cheapseats",


### PR DESCRIPTION
We were missing out the experiemental/ directory when generating
modules, this meant none of the new content dashboards had page per
thing pages.

I've switched to using glob for simplicity when choosing what files to
generate modules for.
