### PR TITLE
Add waste carriers to the homepage

### DIFF
--- a/app/common/controllers/homepage.js
+++ b/app/common/controllers/homepage.js
@@ -52,6 +52,12 @@ function (Backbone, PageConfig, Controller, HomepageView) {
       ],
       [
         {
+          title: 'R',
+          services: [
+            {name: 'Register as a waste carrier, broker or dealer', slug: 'waste-carrier-or-broker-registration'}
+          ]
+        },
+        {
           title: 'S',
           services: [
             {name: 'SORN (Statutory Off Road Notification)', slug: 'sorn'}

--- a/styles/pages/homepage.scss
+++ b/styles/pages/homepage.scss
@@ -55,7 +55,6 @@
 
       &.service_groups {
         font-weight: bold;
-        margin-top: 3em;
       }
     }
 


### PR DESCRIPTION
Adding this link pushes the left column down a lot, I've dropped the
margin top on service groups to try and tuck them back up again.
