### PR TITLE
Update default backdrop location to preview

### DIFF
--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,8 +1,5 @@
 {
   "assetPath": "/spotlight/",
   "port": 3057,
-  "backdropUrl": "http://spotlight.perfplat.dev/backdrop-stub/{{ data-group }}/{{ data-type }}",
-  "screenshotTargetUrl": "http://spotlight.perfplat.dev",
-  "screenshotServiceUrl": "http://spotlight.perfplat.dev:3000",
-  "govukHost": "spotlight.dev.gov.uk"
+  "backdropUrl": "https://www.preview.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}"
 }


### PR DESCRIPTION
We no longer use dev VMs for local development, so it doesn't make sense to have dev VM as the default backdrop.

:eggplant:
