### PR TITLE
Switch dev config to point to preview

### DIFF
--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,8 +1,8 @@
 {
   "assetPath": "/spotlight/",
   "port": 3057,
-  "backdropUrl": "http://spotlight.perfplat.dev/backdrop-stub/{{ data-group }}/{{ data-type }}",
-  "screenshotTargetUrl": "http://spotlight.perfplat.dev",
-  "screenshotServiceUrl": "http://spotlight.perfplat.dev:3000",
-  "govukHost": "spotlight.dev.gov.uk"
+  "backdropUrl": "https://www.preview.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
+  "screenshotTargetUrl": "http://localhost:3057",
+  "screenshotServiceUrl": "http://localhost:3060",
+  "govukHost": "www.preview.alphagov.co.uk"
 }


### PR DESCRIPTION
Most development is happening outside of the dev vm so we should point
to preview rather than expecting services to be running locally.
