### PR TITLE
Default values in journey-series collection

### DIFF
--- a/app/common/collections/journey_series.js
+++ b/app/common/collections/journey_series.js
@@ -20,6 +20,7 @@ define([
     },
 
     parse: function (response) {
+      var valueAttr = this.options.valueAttr || 'uniqueEvents';
       var data = _.map(this.axes.y, function (step) {
         return _.extend({
           title: step.label,
@@ -28,6 +29,15 @@ define([
           return this.getStep(responseStep) === step.journeyId;
         }, this));
       }, this);
+
+      var hasData = _.any(data, function (m) {
+        return m[valueAttr] !== undefined;
+      });
+      if (hasData) {
+        _.each(data, function (m) {
+          m[valueAttr] = m[valueAttr] || 0;
+        });
+      }
 
       return data;
     },

--- a/spec/shared/common/collections/spec.journey_series.js
+++ b/spec/shared/common/collections/spec.journey_series.js
@@ -271,6 +271,49 @@ define([
         expect(collection.at(0).get('step')).toEqual('example:downloadFormPage');
         expect(collection.at(0).get('uniqueEvents')).toEqual(50000);
       });
+
+      it('should fill in missing data points with 0', function () {
+        var models = [
+          {eventCategory: 'example:downloadFormPage', uniqueEvents: 50000},
+          {eventCategory: 'example:submitApplicationPage', uniqueEvents: 25000},
+          {eventCategory: 'example:end'}
+        ];
+        var collection = new TestCollection();
+        var output = collection.parse({ data: models });
+
+        expect(output[0].uniqueEvents).toEqual(50000);
+        expect(output[1].uniqueEvents).toEqual(25000);
+        expect(output[2].uniqueEvents).toEqual(0);
+      });
+
+      it('should fill in missing data points with 0 when custom valueAttr is specified', function () {
+        var models = [
+          {eventCategory: 'example:downloadFormPage', value: 50000},
+          {eventCategory: 'example:submitApplicationPage', value: 25000},
+          {eventCategory: 'example:end'}
+        ];
+        var collection = new TestCollection([], { valueAttr: 'value' });
+        var output = collection.parse({ data: models });
+
+        expect(output[0].value).toEqual(50000);
+        expect(output[1].value).toEqual(25000);
+        expect(output[2].value).toEqual(0);
+      });
+
+      it('should not fill in missing data points with 0 if all are missing', function () {
+        var models = [
+          {eventCategory: 'example:downloadFormPage'},
+          {eventCategory: 'example:submitApplicationPage'},
+          {eventCategory: 'example:end'}
+        ];
+        var collection = new TestCollection();
+        var output = collection.parse({ data: models });
+
+        expect(output[0].uniqueEvents).toBeUndefined();
+        expect(output[1].uniqueEvents).toBeUndefined();
+        expect(output[2].uniqueEvents).toBeUndefined();
+      });
+
     });
   });
 });


### PR DESCRIPTION
When backdrop does not have any hits at all for one of the steps in a journey collection it returns no data point, which means the graph bar is rendered with a "no data" label.

If we have data for some of the steps, then assume that the value for the missing step should be zero, rather than "no data".
