### PR TITLE
Ensure breadcrumbs are added to high-volume transaction dashboards.

### DIFF
--- a/app/common/views/dashboard.js
+++ b/app/common/views/dashboard.js
@@ -70,7 +70,7 @@ function (GovUkView, contentTemplate) {
         crumbs.push({
           'title': this.model.get('department').title
         });
-      } else if (this.dashboardType === 'transaction') {
+      } else if (this.dashboardType === 'transaction' || this.dashboardType === 'high-volume-transaction') {
         crumbs.push({
           'title': this.model.get('department').title
         });

--- a/spec/server/common/views/spec.dashboard.js
+++ b/spec/server/common/views/spec.dashboard.js
@@ -152,6 +152,20 @@ function (DashboardView, Model) {
         ]);
       });
 
+
+      it('calculates correct crumbs for high-volume transactions', function () {
+        model.set({
+          department: {
+            title: 'Department for Work and Pensions'
+          }
+        });
+        view.dashboardType = 'high-volume-transaction';
+        expect(view.getBreadcrumbCrumbs()).toEqual([
+          {'path': '/performance', 'title': 'Performance'},
+          {'title': 'Department for Work and Pensions'}
+        ]);
+      });
+
       it('calculates correct crumbs for policies', function () {
         model.set({
           policy: {


### PR DESCRIPTION
These were missing, because the dashboard type wasn't handled in the
existing breadcrumb code. 

Once we have designs for department/agency dashboard pages, we should
revisit our dashboard configuration logic: it's quite messy as it stands. 
