### PR TITLE
Allow gitignored Google credentials

### DIFF
--- a/tools/tx-dashboard-generator/.gitignore
+++ b/tools/tx-dashboard-generator/.gitignore
@@ -1,0 +1,2 @@
+config.json
+dashboards/

--- a/tools/tx-dashboard-generator/config.example.json
+++ b/tools/tx-dashboard-generator/config.example.json
@@ -1,0 +1,4 @@
+{
+  "email": "name@digital.cabinet-office.gov.uk",
+  "password": "app-specific-password"
+}

--- a/tools/tx-dashboard-generator/index.js
+++ b/tools/tx-dashboard-generator/index.js
@@ -3,13 +3,14 @@ var GoogleSpreadsheets = require('google-spreadsheets');
 var _ = require('underscore');
 var fs = require('fs');
 var rimraf = require('rimraf');
+var googleCredentials = require('./config.json');
 
-var googleAuth = new GoogleClientLogin({
+var googleAuth = new GoogleClientLogin(_.extend({
   email: 'email@digital.cabinet-office.gov.uk',
   password: 'password',
   service: 'spreadsheets',
   accountType: GoogleClientLogin.accountTypes.google
-});
+}, googleCredentials));
 
 googleAuth.on(GoogleClientLogin.events.login, function () {
   GoogleSpreadsheets.rows({


### PR DESCRIPTION
I like leaving my Google creds in place, which means I'd constantly get git telling me about having modified the index.js file.

Require credentials in from a gitignored file.

Add the dashboards directory to gitignore too to prevent accidental commitage.
