### PR TITLE
Fixed double escaping in tables.

### DIFF
--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -27,7 +27,8 @@ function (View, Formatters) {
       if (context) {
         element = $('<' + elementName + '></' + elementName + '>');
         if (value && value !== null || value !== undefined) {
-          element.text(value);
+          //fix double escaping of html entities.
+          element.text($('<div />').html(value).text());
         }
         if (attr) {
           element.attr(attr);

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -254,10 +254,11 @@ function (Table, View, Collection, $) {
       });
 
       it('renders a table', function () {
+        table.collection.options.axes.y[0].label = 'another &amp; another';
         table.render();
         expect(table.$table.html())
           .toBe('<thead>' +
-                  '<tr><th scope="col">date</th><th scope="col">another</th><th scope="col">last</th></tr>' +
+                  '<tr><th scope="col">date</th><th scope="col">another &amp; another</th><th scope="col">last</th></tr>' +
                 '</thead>' +
                 '<tbody>' +
                   '<tr><td class="">01/02/01</td><td class="">foo</td><td class="">no data</td></tr>' +


### PR DESCRIPTION
If escaped text was rendered into the table it was getting escaped again so:

&amp; was becoming &amp;amp; this fixes the issue although it's not the most elegant fix in the world.

Fixes #381 

Pivotal Story:
https://www.pivotaltracker.com/n/projects/911874/stories/70258422
