### PR TITLE
Add config to pass arguments to grunt shell scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,12 @@ var getRequirejsConfig = function () {
   });
 };
 
+var addArgs = function (cmd) {
+  return function () {
+    return [cmd].concat([].slice.apply(arguments)).join(' ');
+  };
+};
+
 var requirejsConfig = getRequirejsConfig();
 
 
@@ -199,7 +205,7 @@ module.exports = function (grunt) {
           stderr: true,
           stdout: true
         },
-        command: 'node ./node_modules/cheapseats/index.js --standalone --path ./'
+        command: addArgs('node ./node_modules/cheapseats/index.js --standalone --path ./')
       },
       // Generates the page-per-thing module JSON stubs
       generate_module_stubs: {
@@ -226,16 +232,7 @@ module.exports = function (grunt) {
           stderr: true,
           stdout: true
         },
-        command: 'node tools/validate-stubs.js'
-      },
-      // Generates the page-per-thing module JSON stubs
-      validate_module_stubs_experimental: {
-        options: {
-          failOnError: true,
-          stderr: true,
-          stdout: true
-        },
-        command: 'node tools/validate-stubs.js --experimental'
+        command: addArgs('node tools/validate-stubs.js')
       },
       // Supervises the node process in development
       supervisor: {
@@ -319,7 +316,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('test:stubs:experimental', [
-    'shell:validate_module_stubs_experimental'
+    'shell:validate_module_stubs:--experimental'
   ]);
 
   grunt.registerTask('test:all', [
@@ -340,6 +337,10 @@ module.exports = function (grunt) {
 
   grunt.registerTask('cheapseats', [
     'shell:cheapseats'
+  ]);
+
+  grunt.registerTask('cheapseats:experimental', [
+    'shell:cheapseats:--experimental'
   ]);
 
   // Default task


### PR DESCRIPTION
A few places we want to pass flags into shell scripts. This is easier than configuring entire new tasks.
### Example

If `grunt shell:task` runs `$ node ./foo.js`
Then `grunt shell:task:--flag:val` will run `$ node ./foo.js --flag val`
