### PR TITLE
Add abbreviations for department and agency to dashboard output.

### DIFF
--- a/tools/tx-dashboard-generator/index.js
+++ b/tools/tx-dashboard-generator/index.js
@@ -43,8 +43,10 @@ googleAuth.on(GoogleClientLogin.events.login, function () {
           addField(row.nameofservice, output, 'title');
           output.department = {};
           addField(row.department, output.department, 'title');
+          addField(row.abbr, output.department, 'abbr');
           output.agency = {};
           addField(row.agencybody, output.agency, 'title');
+          addField(row.agencyabbr, output.agency, 'abbr');
           if (!_.isObject(row.url)) {
             output.relatedPages = {};
             output.relatedPages.transaction = {};


### PR DESCRIPTION
The designs for the services page include this information as part of the list, so it needs to be included in the dashboard jsons.

(It's worth leaving the actual generation of the files until we've sorted the url/duplication issues, but this is going to be needed eventually)
