### PR TITLE
Switch to the dot reporter for cheapseats

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,7 +229,7 @@ module.exports = function (grunt) {
           stderr: true,
           stdout: true
         },
-        command: addArgs('node ./node_modules/cheapseats/index.js --standalone --path ./')
+        command: addArgs('node ./node_modules/cheapseats/index.js --reporter dot --standalone --path ./')
       },
       // Generates the page-per-thing module JSON stubs
       generate_module_stubs: {


### PR DESCRIPTION
We were reaching the max ammount of stdout allowed in Travis due to
cheapseats being very verbose. The dot reporter will output different
coloured dots for each test run, this yields a massive reduction in
output.
