### PR TITLE
Date range for kpi covers a year not 13 months.

### DIFF
--- a/app/common/templates/visualisations/kpi.html
+++ b/app/common/templates/visualisations/kpi.html
@@ -3,7 +3,7 @@
         {{#hasValue}}<strong>{{value}}</strong>{{/hasValue}}
         {{^hasValue}}<strong class="no-data">no data</strong>{{/hasValue}}
     </p>
-    {{#period}}<p class="period">{{period.start}} to {{period.end}}</p>{{/period}}
+    {{#period}}<p class="period">{{period}}</p>{{/period}}
 </div>
 
 {{#previousPeriod}}
@@ -13,7 +13,7 @@
               {{#hasValue}}{{change}}{{/hasValue}}
               {{^hasValue}}{{previousPeriod.value}}{{/hasValue}}
             </span>
-            {{previousPeriod.start}} to {{previousPeriod.end}}
+            {{previousPeriod.period}}
         </div>
     </div>
 {{/previousPeriod}}

--- a/app/common/views/visualisations/kpi.js
+++ b/app/common/views/visualisations/kpi.js
@@ -15,11 +15,12 @@ function (View, Formatters, template) {
         previous = this.collection.at(1),
         valueAttr = this.model.get('value-attribute'),
         format = this.model.get('format') || 'number',
-        dateFormat = { type: 'date', format: 'MMM YYYY' },
+        dateFormat = { type: 'dateRange', format: 'MMM YYYY', subtract: 'months'},
         datePeriod = this.model.get('date-period');
 
       if (datePeriod && datePeriod === 'week') {
         dateFormat.format = 'D MMM YYYY';
+        delete dateFormat.subtract;
       }
 
       if (!current) {
@@ -33,19 +34,22 @@ function (View, Formatters, template) {
 
       if (current.get('_timestamp') && current.get('end_at')) {
         _.extend(config, {
-          period: {
-            start: this.format(current.get('_timestamp'), dateFormat),
-            end: this.format(current.get('end_at'), dateFormat)
+          period: this.format([
+              current.get('_timestamp'),
+              current.get('end_at')
+            ], dateFormat)
           }
-        });
+        );
       }
 
       if (previous && previous.get(valueAttr)) {
         _.extend(config, {
           previousPeriod: {
-            value: this.format(previous.get(valueAttr), format),
-            start: this.format(previous.get('_timestamp'), dateFormat),
-            end: this.format(previous.get('end_at'), dateFormat)
+            period: this.format([
+              previous.get('_timestamp'),
+              previous.get('end_at')
+            ], dateFormat),
+            value: this.format(previous.get(valueAttr), format)
           }
         });
       }

--- a/spec/shared/common/views/visualisations/spec.kpi.js
+++ b/spec/shared/common/views/visualisations/spec.kpi.js
@@ -32,6 +32,25 @@ define([
         var dateKpi = new KPIView({
           model: new Model({
             valueAttr: 'value',
+            format: 'currency'
+          }),
+          collection: new Collection([
+            {
+              value: 1100,
+              _timestamp: '2014-03-24T00:00:00+00:00',
+              end_at: '2014-03-30T00:00:00+00:00'
+            },
+            { value: 1000 }
+          ])
+        });
+        dateKpi.render();
+        expect(dateKpi.$('.period').text()).toEqual('Mar 2014 to Feb 2014');
+      });
+
+      it('formats date period for week', function () {
+        var dateKpi = new KPIView({
+          model: new Model({
+            valueAttr: 'value',
             format: 'currency',
             'date-period': 'week'
           }),
@@ -45,7 +64,7 @@ define([
           ])
         });
         dateKpi.render();
-        expect(dateKpi.$('.period').text()).toEqual('24 Mar 2014 to 30 Mar 2014');
+        expect(dateKpi.$('.period').text()).toEqual('24 Mar 2014 to 29 Mar 2014');
       });
 
       it('fails gracefully if there is no data', function () {
@@ -118,7 +137,7 @@ define([
         ]);
         kpi.render();
         expect(kpi.$('.delta').text()).toContain('£1,100');
-        expect(kpi.$('.delta').text()).toContain('Mar 2014 to Apr 2014');
+        expect(kpi.$('.delta').text()).toContain('Mar 2014 to Mar 2014');
       });
 
     });


### PR DESCRIPTION
For example, if the data is:

"_timestamp": "2013-01-01T00:00:00+00:00"
"end_at": "2014-01-01T00:00:00+00:00"

it should render:

Jan 2013 to Dec 2013

not

Jan 2013 to Jan 2014

Updated tests to cover this.

Covers: https://www.pivotaltracker.com/n/projects/911874/stories/70925674
