### PR TITLE
Reduced text size in graphs for mobile devices.

### DIFF
--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -188,6 +188,10 @@ figure.graph {
     text {
       @include core-19() ;
       text-anchor: middle;
+
+      @media (max-width: 640px) {
+        font-size: 9px;
+      }
     }
 
     rect {
@@ -236,6 +240,10 @@ figure.graph {
 
     .tick text {
       @include core-16();
+
+      @media (max-width: 640px) {
+        font-size: 9px;
+      }
     }
   }
 


### PR DESCRIPTION
For anything smaller than 640px we present the x-axis and bar text as 9px.

Like so: ![](https://i.cloudup.com/MfyssWkskx-2000x2000.png)
