### PR TITLE
Show no-change symbol in KPI module if delta is unchanged.

### DIFF
--- a/app/common/views/visualisations/kpi.js
+++ b/app/common/views/visualisations/kpi.js
@@ -54,10 +54,18 @@ function (View, Formatters, template) {
         });
       }
 
-      if (config.hasValue && previous) {
+      if (config.hasValue && previous && previous.get(valueAttr)) {
+          var sgn;
+          if (current.get(valueAttr) / previous.get(valueAttr) > 1) {
+            sgn = 'increase';
+          } else if (current.get(valueAttr) / previous.get(valueAttr) < 1) {
+            sgn = 'decrease';
+          } else {
+            sgn = 'no-change';
+          }
         _.extend(config, {
           change: this.format(current.get(valueAttr) / previous.get(valueAttr) - 1, { type: 'percent', dps: 2 }),
-          sgn: current.get(valueAttr) / previous.get(valueAttr) > 1 ? 'increase' : 'decrease'
+          sgn: sgn
         });
       }
 

--- a/spec/shared/common/views/visualisations/spec.kpi.js
+++ b/spec/shared/common/views/visualisations/spec.kpi.js
@@ -126,6 +126,24 @@ define([
         expect(kpi.$('.delta').length).toEqual(0);
       });
 
+      it('has a no-change class if the data is unchanged', function () {
+        kpi.collection.reset([
+          { value: 1100 },
+          { value: 1100 }
+        ]);
+        kpi.render();
+        expect(kpi.$('.delta .change').hasClass('no-change')).toBe(true);
+      });
+
+      it('does not attempt to calculate the delta if the previous value is zero', function () {
+        kpi.collection.reset([
+          { value: 1100 },
+          { value: 0 }
+        ]);
+        kpi.render();
+        expect(kpi.$('.delta').length).toEqual(0);
+      });
+
       it('renders data in the delta section if the latest data point is empty but the penultimate data point is not', function () {
         kpi.collection.reset([
           {},


### PR DESCRIPTION
Also don't attempt to calculate a delta if the previous value is
null/undefined/zero.

This should really be refactored to share code with the delta.js
view used in the multistats module. I'll add a story for this.
