### PR TITLE
Display 'No data available' when there are no rows

### DIFF
--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -81,15 +81,25 @@ function (View, Formatters) {
         this.collection.sortByAttr(this.sortBy, this.sortOrder === 'descending');
       }
 
-      _.each(this.collection.getTableRows(keys), function (row) {
+      var rows = this.collection.getTableRows(keys);
+
+      if (rows.length > 0) {
+        _.each(rows, function (row) {
+          var $row = this.renderEl('tr', $tbody);
+          var renderCell = this.renderCell.bind(this, 'td', $row);
+
+          _.each(row, function (cell, index) {
+            renderCell(cell, columns[index]);
+          });
+
+        }, this);
+      } else {
         var $row = this.renderEl('tr', $tbody);
-        var renderCell = this.renderCell.bind(this, 'td', $row);
-
-        _.each(row, function (cell, index) {
-          renderCell(cell, columns[index]);
-        });
-
-      }, this);
+        this.renderEl('td', $row, 'No data available');
+        for (var i = 0; i < keys.length - 1; i++) {
+          this.renderEl('td', $row, '&ndash;');
+        }
+      }
     },
 
     renderCell: function (tag, parent, content, column) {

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -77,6 +77,16 @@ function (Table, View, Collection, $) {
         spyOn(table.collection, 'getTableRows').andReturn([['01/02/01', 'foo', null]]);
       });
 
+      it('renders no data if there are no rows', function () {
+        table.collection.getTableRows.andReturn([]);
+        table.render();
+
+        expect(table.$el.find('tbody tr').length).toBe(1);
+        expect(table.$el.find('tbody td').map(function (i, el) {
+          return el.innerHTML;
+        })).toBe(['No data available', '&ndash;', '&ndash;']);
+      });
+
       it('empties the table if $table exists and removes class', function () {
         spyOn(table, 'renderHead');
         spyOn(table, 'renderBody');


### PR DESCRIPTION
At the moment when a table has no rows it does not show a no data
message. This has been causing cheapseats to assume that the table is
broken when there is no data.
