### PR TITLE
Content dashboards shouldnt appear in service list

### DIFF
--- a/app/client/controllers/services.js
+++ b/app/client/controllers/services.js
@@ -1,6 +1,6 @@
 define([
   'extensions/controllers/controller',
-  'common/collections/services',
+  'common/collections/dashboards',
   'client/views/services'
 ], function (Controller, FilteredListCollection, ServicesView) {
   return Controller.extend({

--- a/app/common/collections/dashboards.js
+++ b/app/common/collections/dashboards.js
@@ -18,10 +18,12 @@ function (Collection) {
       return groups;
     },
     filterDashboards: function () {
-      var types = _.toArray(arguments);
+      var types = _.isArray(arguments[0]) ? arguments[0] : _.toArray(arguments);
       return _.map(this.filter(function (service) {
         return types.indexOf(service.get('dashboard-type')) > -1;
       }), function (m) { return m.toJSON(); });
     }
+  }, {
+    SERVICES: ['transaction', 'high-volume-transaction', 'other', 'service-group']
   });
 });

--- a/app/server/controllers/homepage.js
+++ b/app/server/controllers/homepage.js
@@ -1,19 +1,19 @@
 var Backbone = require('backbone');
 var requirejs = require('requirejs');
 
-var services = require('../../support/stagecraft_stub/responses/services');
+var dashboards = require('../../support/stagecraft_stub/responses/dashboards');
 
 var View = require('../views/homepage');
 
-var Collection = requirejs('common/collections/services');
+var Collection = requirejs('common/collections/dashboards');
 var PageConfig = requirejs('page_config');
 
 module.exports = function (req, res) {
   var model = new Backbone.Model(_.extend(PageConfig.commonConfig(req), {
-    'data': services.items
+    'data': dashboards.items
   }));
 
-  var collection = new Collection(services.items);
+  var collection = new Collection(dashboards.items);
 
   var view = new View({
     model: model,

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -1,22 +1,23 @@
 var requirejs = require('requirejs');
 var Backbone = require('backbone');
 
-var services = require('../../support/stagecraft_stub/responses/services');
+var dashboards = require('../../support/stagecraft_stub/responses/dashboards');
 
 var View = require('../views/services');
 
-var Collection = requirejs('common/collections/services');
+var DashboardCollection = requirejs('common/collections/dashboards');
 var PageConfig = requirejs('page_config');
 
 module.exports = function (req, res) {
-  var model = new Backbone.Model(_.extend(PageConfig.commonConfig(req), {
+  var services = new DashboardCollection(dashboards.items).filterDashboards(DashboardCollection.SERVICES),
+      model = new Backbone.Model(_.extend(PageConfig.commonConfig(req), {
     title: 'Services',
     'page-type': 'services',
     'filter': req.query.filter || '',
-    'data': services.items
+    'data': services
   }));
 
-  var collection = new Collection(services.items);
+  var collection = new DashboardCollection(services);
 
   var view = new View({
     model: model,

--- a/app/server/views/services.js
+++ b/app/server/views/services.js
@@ -4,7 +4,7 @@ var path = require('path');
 var templater = require('../mixins/templater');
 
 var BaseView = requirejs('common/views/govuk');
-var ListView = requirejs('common/views/filtered_list');
+var FilterdListView = requirejs('common/views/filtered_list');
 
 module.exports = BaseView.extend(templater).extend({
 
@@ -21,7 +21,7 @@ module.exports = BaseView.extend(templater).extend({
 
   getContent: function () {
 
-    var list = new ListView({
+    var list = new FilterdListView({
       model: this.model,
       collection: this.collection
     });

--- a/app/support/stagecraft_stub/responses/.gitignore
+++ b/app/support/stagecraft_stub/responses/.gitignore
@@ -1,4 +1,4 @@
 *
 !.gitignore
 !*.json
-services.json
+dashboards.json

--- a/spec/shared/common/collections/spec.dashboards.js
+++ b/spec/shared/common/collections/spec.dashboards.js
@@ -1,5 +1,5 @@
 define([
-  'common/collections/services'
+  'common/collections/dashboards'
 ],
 function (Collection) {
   describe('Filtered List Collection', function () {
@@ -124,6 +124,14 @@ function (Collection) {
           { title: 'Duck', 'dashboard-type': 'transaction' },
           { title: 'Pig', 'dashboard-type': 'service-group' },
           { title: 'Sheep', 'dashboard-type': 'transaction' }
+        ]);
+      });
+
+      it('handles an array as the first argument', function () {
+        var output;
+        output = collection.filterDashboards(['service-group']);
+        expect(output).toEqual([
+          { title: 'Pig', 'dashboard-type': 'service-group' }
         ]);
       });
 

--- a/tools/generate-services-list.js
+++ b/tools/generate-services-list.js
@@ -7,7 +7,7 @@ var fs = require('fs'),
 var stagecraftStubDir = path.resolve(__dirname, '../app/support/stagecraft_stub/responses'),
     stagecraftStubGlob = path.resolve(stagecraftStubDir, '*.json');
 
-var services = [
+var dashboards = [
   {
     slug: 'licensing',
     title: 'Licensing',
@@ -30,7 +30,7 @@ function readModule(file) {
 
     dashboardData = JSON.parse(dashboardData);
     if (dashboardData['page-type'] === 'dashboard') {
-      services.push(_.pick(dashboardData, 'slug', 'title', 'department', 'agency', 'dashboard-type', 'on-homepage'));
+      dashboards.push(_.pick(dashboardData, 'slug', 'title', 'department', 'agency', 'dashboard-type', 'on-homepage'));
     }
     defer.resolve();
 
@@ -46,8 +46,8 @@ glob(stagecraftStubGlob, function (err, files) {
   Q.all(_.map(files, function (file) {
     return readModule(file);
   })).then(function () {
-    console.log('Writing ' + services.length + ' services into services.json');
-    fs.writeFileSync(stagecraftStubDir + '/services.json', JSON.stringify({ items: services }, null, 2) + '\n');
+    console.log('Writing ' + dashboards.length + ' dashboards into dashboards.json');
+    fs.writeFileSync(stagecraftStubDir + '/dashboards.json', JSON.stringify({ items: dashboards }, null, 2) + '\n');
   });
 
 });

--- a/tools/validate-stubs.js
+++ b/tools/validate-stubs.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 require('colors');
 
 var blacklist = [
-  'services.json',
+  'dashboards.json',
   'unimplemented-page-type.json',
   'no-realistic-dashboard.json'
 ];


### PR DESCRIPTION
At the moment the list of services includes all dashboards, which means
the numbers on the homepage don't add up and we are showing non-service
dashboards in the list of service dashboards.

I've renamed services.json to dashboards.json as this more truely
conveys what it is. This change knocks on into the collection.

I've made filterDashboards able to accept an array so that we can store
a list of dashboard-types which are 'services' and reference that
constant in any code that wants to filter all services.
