### PR TITLE
Show departmental acronyms in services list.

### DIFF
--- a/app/common/templates/filtered_list.html
+++ b/app/common/templates/filtered_list.html
@@ -11,6 +11,9 @@
           <% _.each(list, function (item) { %>
             <li>
               <a href="/performance/<%= item.slug %>"><%= item.title %></a>
+              <% if (item.department) { %>
+              <abbr title="<%= item.department.title %>" class="department"><%= item.department.abbr %></abbr>
+              <% } %>
             </li>
           <% }) %>
         </ol>

--- a/app/support/stagecraft_stub/responses/bis-payment-of-patent-renewal-fee-f12.json
+++ b/app/support/stagecraft_stub/responses/bis-payment-of-patent-renewal-fee-f12.json
@@ -6,10 +6,12 @@
   "description": "Renewals of patent intellectual property rights.",
   "title": "Payment of patent renewal fee (F12)",
   "department": {
-    "title": "Department for Business, Innovation and Skills"
+    "title": "Department for Business, Innovation and Skills",
+    "abbr": "BIS"
   },
   "agency": {
-    "title": "Intellectual Property Office"
+    "title": "Intellectual Property Office",
+    "abbr": "IPO"
   },
   "relatedPages": {
     "improve-dashboard-message": true,

--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -6,7 +6,8 @@
   "title": "Carer's Allowance applications",
   "description": "Carer's Allowance (CA) is a regular payment for carers to help look after someone with substantial caring needs - involving at least 35 hours a week.",
   "department": {
-    "title": "Department for Work and Pensions"
+    "title": "Department for Work and Pensions",
+    "abbr": "DWP"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/deposit-foreign-marriage.json
+++ b/app/support/stagecraft_stub/responses/deposit-foreign-marriage.json
@@ -4,6 +4,10 @@
   "dashboard-type": "other",
   "strapline": "Dashboard",
   "title": "Deposit foreign marriage or civil partnership certificates",
+  "department": {
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
+  },
   "other": {
     "tagline": "Figures for payments processed on GOV.UK in the UK to the Foreign & Commonwealth Office (FCO) to deposit a foreign marriage or civil partnership certificate at the General Registry Office. <strong>This transaction ceased to exist on 30 December 2013. Figures shown here are historical data.</strong>"
   },

--- a/app/support/stagecraft_stub/responses/experimental/book-practical-driving-test.json
+++ b/app/support/stagecraft_stub/responses/experimental/book-practical-driving-test.json
@@ -6,10 +6,12 @@
   "title": "Book a practical driving test (public users)",
   "description": "Figures for the service for the public to <strong>book a practical driving test</strong>. Figures include applications made via digital, phone and postal channels.<br><br> More performance information for the practical driving test can be found <a href='/performance/practical-driving-test' rel='external'>here</a>",
   "department": {
-     "title": "Department for Transport"
+     "title": "Department for Transport",
+     "abbr": "DfT"
   },
   "agency": {
-     "title": "Driver and Vehicle Standards Agency"
+     "title": "Driver and Vehicle Standards Agency",
+     "abbr": "DVSA"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/experimental/change-practical-driving-test.json
+++ b/app/support/stagecraft_stub/responses/experimental/change-practical-driving-test.json
@@ -6,10 +6,13 @@
   "title": "Change a practical driving test (public users)",
   "description": "Figures for the service for the public to <strong>change, including cancel, a practical driving test</strong>. Figures include applications made via digital, phone and postal channels.<br><br> More performance information for the practical driving test can be found <a href='/performance/practical-driving-test' rel='external'>here</a>",
   "department": {
-     "title": "Department for Transport"
+     "title": "Department for Transport",
+     "abbr": "DfT"
   },
   "agency": {
-     "title": "Driver and Vehicle Standards Agency"
+     "title": "Driver and Vehicle Standards Agency",
+     "abbr": "DVSA"
+
   },
   "relatedPages": {
     "improve-dashboard-message": true,

--- a/app/support/stagecraft_stub/responses/experimental/practical-driving-test.json
+++ b/app/support/stagecraft_stub/responses/experimental/practical-driving-test.json
@@ -6,10 +6,12 @@
   "title": "Practical driving test (public users)",
   "description": "This dashboard provides additional information for the :<br><a href='/performance/book-practical-driving-test' rel='external'>Book a practical driving test</a> dashboard<br><a href='/performance/change-practical-driving-test' rel='external'>Change the date of your practical driving or riding test</a> dashboard<br><a href='/performance/change-practical-driving-test' rel='external'>Cancel your practical driving or riding test</a> dashboard",
   "department": {
-     "title": "Department for Transport"
+     "title": "Department for Transport",
+     "abbr": "DfT"
   },
   "agency": {
-     "title": "Driver and Vehicle Standards Agency"
+     "title": "Driver and Vehicle Standards Agency",
+     "abbr": "DVSA"
   },
   "relatedPages": {
     "improve-dashboard-message": true,

--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -4,6 +4,10 @@
   "dashboard-type": "other",
   "strapline": "Dashboard",
   "title": "G-Cloud",
+  "department": {
+    "title": "Cabinet Office",
+    "abbr": "CO"
+  },
   "other": {
     "tagline": "CloudStore is the online marketplace where suppliers offer their services to the public sector via the G-Cloud framework. Key metrics include the proportion of sales via small and medium sized enterprises (SMEs)."
   },

--- a/app/support/stagecraft_stub/responses/lasting-power-of-attorney.json
+++ b/app/support/stagecraft_stub/responses/lasting-power-of-attorney.json
@@ -6,10 +6,12 @@
   "title": "Lasting Power of Attorney registrations",
   "description": "Figures for the service to make a <strong>lasting power of attorney (LPA)</strong> - a legal document that lets you appoint someone, known as an 'attorney', to make decisions on your behalf. Figures include applications made via both digital and paper form channels.",
   "department": {
-     "title": "Ministry of Justice"
+     "title": "Ministry of Justice",
+     "abbr": "MoJ"
   },
   "agency": {
-     "title": "Office of the Public Guardian"
+     "title": "Office of the Public Guardian",
+     "abbr": "OPG"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates.json
+++ b/app/support/stagecraft_stub/responses/pay-foreign-marriage-certificates.json
@@ -6,7 +6,8 @@
   "title": "Certificate to get married abroad: payments",
   "description": "Figures for payments processed on GOV.UK in the UK to the Foreign & Commonwealth Office (FCO) for documents you need to get married abroad.",
   "department": {
-    "title": "Foreign and Commonwealth Office"
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/pay-legalisation-drop-off.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-drop-off.json
@@ -6,7 +6,8 @@
   "title": "Document legalisation (premium) payments",
   "description": "Figures for payments processed on GOV.UK to the Foreign & Commonwealth Office (FCO) to use the premium service to get a UK public document 'legalised'.",
   "department": {
-    "title": "Foreign and Commonwealth Office"
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/pay-legalisation-post.json
+++ b/app/support/stagecraft_stub/responses/pay-legalisation-post.json
@@ -6,7 +6,8 @@
   "title": "Document legalisation payments",
   "description": "Figures for payments processed on GOV.UK to the Foreign & Commonwealth Office (FCO) to get a UK public document 'legalised'.",
   "department": {
-    "title": "Foreign and Commonwealth Office"
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-birth-abroad.json
@@ -6,7 +6,8 @@
   "title": "Register a birth abroad: payments",
   "description": "Figures for payments processed on GOV.UK in the UK to the Foreign & Commonwealth Office (FCO) if you're eligible to register the birth of a British national abroad.",
   "department": {
-    "title": "Foreign and Commonwealth Office"
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
+++ b/app/support/stagecraft_stub/responses/pay-register-death-abroad.json
@@ -6,7 +6,8 @@
   "title": "Register a death abroad: payments",
   "description": "Figures for payments processed on GOV.UK in the UK to the Foreign & Commonwealth Office (FCO) if you register the death of a British national abroad.",
   "department": {
-    "title": "Foreign and Commonwealth Office"
+    "title": "Foreign and Commonwealth Office",
+    "abbr": "FCO"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -4,6 +4,10 @@
   "dashboard-type": "content",
   "strapline": "Performance",
   "title": "Activity on GOV.UK",
+  "department": {
+    "title": "Cabinet Office",
+    "abbr": "CO"
+  },
   "tagline": "Web traffic on <a href=\"https://www.gov.uk\">our site</a>, based on data from Google Analytics.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/sorn.json
+++ b/app/support/stagecraft_stub/responses/sorn.json
@@ -6,7 +6,8 @@
   "description": "<abbr title='Statutory Off Road Notification'>SORN</abbr> is a service within <a href='vehicle-licensing'>vehicle licensing</a>, which also covers <a href='tax-disc'>tax disc</a>.",
   "title": "SORN (Statutory Off Road Notification) applications",
   "department": {
-    "title": "Department for Transport"
+    "title": "Department for Transport",
+    "abbr": "DfT"
   },
   "agency": {
     "title": "DVLA"

--- a/app/support/stagecraft_stub/responses/tax-disc.json
+++ b/app/support/stagecraft_stub/responses/tax-disc.json
@@ -6,7 +6,8 @@
   "description": "This service is provided by the DVLA to relicense vehicles that are kept on public roads.",
   "title": "Tax disc renewals",
   "department": {
-    "title": "Department for Transport"
+    "title": "Department for Transport",
+    "abbr": "DfT"
   },
   "agency": {
     "title": "DVLA"

--- a/app/support/stagecraft_stub/responses/vehicle-licensing.json
+++ b/app/support/stagecraft_stub/responses/vehicle-licensing.json
@@ -4,6 +4,10 @@
   "dashboard-type": "service-group",
   "strapline": "Dashboard",
   "title": "Vehicle licensing",
+  "department": {
+    "title": "Department for Transport",
+    "abbr": "DfT"
+  },
   "tagline": "Vehicle licensing covers <a href='tax-disc'>tax disc</a> relicensing and <a href='sorn'><abbr title='Statutory Off Road Notification'>SORN</abbr> (Statutory Off Road Notification)</a>, two services provided by <abbr title='Driver and Vehicle Licensing Agency'>DVLA</abbr>. Does not include first registrations.",
   "modules": [
     {

--- a/app/support/stagecraft_stub/responses/view-driving-record.json
+++ b/app/support/stagecraft_stub/responses/view-driving-record.json
@@ -6,7 +6,12 @@
   "title": "View driving record",
   "description": "",
   "department": {
-    "title": "Driver and Vehicle Licensing Agency"
+     "title": "Department for Transport",
+     "abbr": "DfT"
+  },
+  "agency": {
+    "title": "Driver and Vehicle Licensing Agency",
+    "abbr": "DVLA"
   },
   "relatedPages": {
     "transaction": {

--- a/app/support/stagecraft_stub/responses/waste-carrier-or-broker-registration.json
+++ b/app/support/stagecraft_stub/responses/waste-carrier-or-broker-registration.json
@@ -6,10 +6,12 @@
   "title": "Waste carrier registration",
   "description": "Businesses need to register as waste carriers if they transport waste regularly.",
   "department": {
-    "title": "Department for Environment, Food and Rural Affairs"
+    "title": "Department for Environment, Food and Rural Affairs",
+    "abbr": "Defra"
   },
   "agency": {
-    "title": "Environment Agency"
+    "title": "Environment Agency",
+    "abbr": "EA"
   },
   "relatedPages": {
     "transaction": {

--- a/styles/common/filteredlist.scss
+++ b/styles/common/filteredlist.scss
@@ -65,6 +65,11 @@
           li {
             border-bottom: 1px solid $grey-3;
             padding:.3em 0;
+
+            .department {
+              float: right;
+              color: $grey-1;
+            }
           }
         }
       }


### PR DESCRIPTION
Use <abbr> tags and style.

Add acronyms for existing services, which were missing them.

No tests since there's no logic, just display - shout if you
think this is wrong.

Pivotal story: https://www.pivotaltracker.com/s/projects/911874/stories/70840458
