### PR TITLE
Prevent graph y-axis numbers being clipped

### DIFF
--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -49,7 +49,7 @@ figure.graph {
       position:absolute;
       top: 20px;
       bottom: 45px;
-      left: 55px;
+      left: 60px;
       right: 40px;
 
       @media (max-width: 640px) {


### PR DESCRIPTION
55px was not _quite_ enough space for 3 digits with a currency symbol and "m" suffix, so axis digits were being clipped on G-Coud dashboard.
