### PR TITLE
Move strapline to start of <title> tag.

### DIFF
--- a/app/common/views/dashboard.js
+++ b/app/common/views/dashboard.js
@@ -54,11 +54,11 @@ function (GovUkView, contentTemplate) {
 
     getPageTitleItems: function () {
       var items = [];
-      items.push(this.getPageHeader());
       var strapline = this.model.get('strapline');
       if (strapline) {
         items.push(strapline);
       }
+      items.push(this.getPageHeader());
       return items;
     },
 

--- a/app/common/views/module_standalone.js
+++ b/app/common/views/module_standalone.js
@@ -23,9 +23,9 @@ function (GovUkView, Module) {
 
     getPageTitleItems: function () {
       return [
+        this.model.get('dashboard-strapline'),
         this.model.get('title'),
-        this.model.get('dashboard-title'),
-        this.model.get('dashboard-strapline')
+        this.model.get('dashboard-title')
       ];
     },
 

--- a/spec/server/common/views/spec.dashboard.js
+++ b/spec/server/common/views/spec.dashboard.js
@@ -128,7 +128,7 @@ function (DashboardView, Model) {
           strapline: 'Service dashboard'
         });
         view.dashboardType = 'service';
-        expect(view.getPageTitle()).toEqual('Title - Service dashboard - GOV.UK');
+        expect(view.getPageTitle()).toEqual('Service dashboard - Title - GOV.UK');
       });
 
       it('calculates page title from title alone', function () {

--- a/spec/server/common/views/spec.module_standalone.js
+++ b/spec/server/common/views/spec.module_standalone.js
@@ -92,11 +92,11 @@ function (StandaloneView, Collection, Model, View) {
     describe('getPageTitle', function () {
       it('calculates page title from title and dashboard information', function () {
         model.set({
-          title: 'Title',
-          'dashboard-title': 'Dashboard',
+          'title': 'Title',
+          'dashboard-title': 'Dashboard title',
           'dashboard-strapline': 'Strapline'
         });
-        expect(standaloneView.getPageTitle()).toEqual('Title - Dashboard - Strapline - GOV.UK');
+        expect(standaloneView.getPageTitle()).toEqual('Strapline - Title - Dashboard title - GOV.UK');
       });
 
       it('calculates page title from title alone', function () {


### PR DESCRIPTION
This is so that our "Dashboard" strapline is more visible in Google
search results - at the moment it's often hidden at the end of
a long service name. This results in users clicking through
to the dashboards when really they're looking for the service
itself.

Story: https://www.pivotaltracker.com/s/projects/911874/stories/71237550
