### PR TITLE
Don't escape HTML entities in link tags

### DIFF
--- a/app/common/templates/breadcrumbs.html
+++ b/app/common/templates/breadcrumbs.html
@@ -4,7 +4,7 @@
     {{# breadcrumbs }}
     <li>
     {{# path }}
-    <a href="{{ path }}">
+    <a href="{{{ path }}}">
     {{/ path }}
     <span title="{{ original_title }}">
     {{ title }}

--- a/app/common/templates/dashboard.html
+++ b/app/common/templates/dashboard.html
@@ -20,7 +20,7 @@
       {{# relatedPages.transaction }}
       <div class="related-transaction">
         <h3>Visit this service</h3>
-        <a href="{{ relatedPages.transaction.url }}">{{ relatedPages.transaction.title }}</a>
+        <a href="{{{ relatedPages.transaction.url }}}">{{ relatedPages.transaction.title }}</a>
       </div>
       {{/ relatedPages.transaction }}
 
@@ -30,7 +30,7 @@
         <ul class="items">
           {{# relatedPages.other }}
           <li>
-            <a href="{{ url }}">{{ title }}</a>
+            <a href="{{{ url }}}">{{ title }}</a>
             {{# metadata }}
             <span class="metadata">{{{ metadata }}}</span>
             {{/ metadata }}
@@ -67,7 +67,7 @@
         {{# relatedPages.transaction }}
         <div class="related-transaction">
           <h3>Visit this service</h3>
-          <a href="{{ relatedPages.transaction.url }}">{{ relatedPages.transaction.title }}</a>
+          <a href="{{{ relatedPages.transaction.url }}}">{{ relatedPages.transaction.title }}</a>
         </div>
         {{/ relatedPages.transaction }}
 
@@ -77,7 +77,7 @@
           <ul class="items">
             {{# relatedPages.other }}
             <li>
-              <a href="{{ url }}">{{ title }}</a>
+              <a href="{{{ url }}}">{{ title }}</a>
               {{# metadata }}
               <span class="metadata">{{{ metadata }}}</span>
               {{/ metadata }}

--- a/app/common/templates/report_a_problem.html
+++ b/app/common/templates/report_a_problem.html
@@ -3,7 +3,7 @@
   <h2>Help us improve GOV.UK</h2>
   <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">
     <div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="✓"></div>
-    <input id="url" name="url" type="hidden" value="{{ govukUrl }}">
+    <input id="url" name="url" type="hidden" value="{{{ govukUrl }}}">
     {{#source}}
     <input id="source" name="source" type="hidden" value="{{ source }}">
     {{/source}}

--- a/spec/server/common/views/spec.govuk.js
+++ b/spec/server/common/views/spec.govuk.js
@@ -44,7 +44,7 @@ function (GovUkView, View, Model) {
       expect(context.pageTitle).toEqual('Performance - GOV.UK');
 
       var content = context.content.replace(/\s+/g, ' ').trim();
-      expect(content).toEqual('<div id="performance-platform-colour-bar" role="presentation"></div> <div id="global-breadcrumb"> <ol class="group" role="breadcrumbs"> <li> <a href="&#x2F;performance"> <span title="Performance"> Performance </span> </a> </li> </ol> </div> <div id="wrapper"> <main id="content" class="group" role="main"> <div class="performance-platform-outer"> test_content report_a_problem </div> </main> </div>');
+      expect(content).toEqual('<div id="performance-platform-colour-bar" role="presentation"></div> <div id="global-breadcrumb"> <ol class="group" role="breadcrumbs"> <li> <a href="/performance"> <span title="Performance"> Performance </span> </a> </li> </ol> </div> <div id="wrapper"> <main id="content" class="group" role="main"> <div class="performance-platform-outer"> test_content report_a_problem </div> </main> </div>');
     });
 
     it('doesn\'t display the breadcrumb wrapper if there are no breadcrumbs', function () {


### PR DESCRIPTION
We occasionally see 404 responses go out from Spotlight because a client has made a request of `GET /performance/&`.

I believe this may be because of the way Mustache is HTML-escaping entities like this:

```
<a href="&#x2F;performance&#x2F;carers-allowance">
```

In some clients, this might make a request matching the 404s we see, because everything after the 2nd hash is treated as a fragment and isn't sent to the server.

Anyway, just a theory. It's got some holes in it.

In any case, I think not HTML escaping the contents of href attributes is the correct thing to do.

I'm going to make a similar pull request to alphagov/govuk_template to address places this happens in the template.

/cc @annapowellsmith @robyoung because I discussed this with both of you today.
