### PR TITLE
Bump GOV.UK template from 0.7.1 to 0.8.0

### DIFF
--- a/app/common/templates/content.html
+++ b/app/common/templates/content.html
@@ -1,5 +1,3 @@
-<div id="performance-platform-colour-bar" role="presentation"></div>
-
 {{{ breadcrumbs }}}
 
 <div id="wrapper">

--- a/app/common/templates/govuk_template.html
+++ b/app/common/templates/govuk_template.html
@@ -11,19 +11,19 @@
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script>
 
-    <!--[if gt IE 8]><!--><link href="{{ assetPath }}stylesheets/govuk-template.css?0.7.1" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-    <!--[if IE 6]><link href="{{ assetPath }}stylesheets/govuk-template-ie6.css?0.7.1" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 7]><link href="{{ assetPath }}stylesheets/govuk-template-ie7.css?0.7.1" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 8]><link href="{{ assetPath }}stylesheets/govuk-template-ie8.css?0.7.1" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if gt IE 8]><!--><link href="{{{ assetPath }}}stylesheets/govuk-template.css?0.8.0" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{{ assetPath }}}stylesheets/govuk-template-ie6.css?0.8.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 7]><link href="{{{ assetPath }}}stylesheets/govuk-template-ie7.css?0.8.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 8]><link href="{{{ assetPath }}}stylesheets/govuk-template-ie8.css?0.8.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-    <link href="{{ assetPath }}stylesheets/govuk-template-print.css?0.7.1" media="print" rel="stylesheet" type="text/css" />
+    <link href="{{{ assetPath }}}stylesheets/govuk-template-print.css?0.8.0" media="print" rel="stylesheet" type="text/css" />
 
     <!--[if IE 8]>
     <script type="text/javascript">
       (function(){if(window.opera){return;}
        setTimeout(function(){var a=document,g,b={families:(g=
-       ["nta"]),urls:["{{ assetPath }}stylesheets/fonts-ie8.css?0.7.1"]},
-       c="{{ assetPath }}javascripts/vendor/goog/webfont-debug.js?0.7.1",d="script",
+       ["nta"]),urls:["{{{ assetPath }}}stylesheets/fonts-ie8.css?0.8.0"]},
+       c="{{{ assetPath }}}javascripts/vendor/goog/webfont-debug.js?0.8.0",d="script",
        e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
        ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
        .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
@@ -31,27 +31,27 @@
     </script>
     <![endif]-->
     <!--[if gte IE 9]><!-->
-      <link href="{{ assetPath }}stylesheets/fonts.css?0.7.1" media="all" rel="stylesheet" type="text/css" />
+      <link href="{{{ assetPath }}}stylesheets/fonts.css?0.8.0" media="all" rel="stylesheet" type="text/css" />
     <!--<![endif]-->
 
 
     <!--[if lt IE 9]>
-      <script src="{{ assetPath }}javascripts/ie.js?0.7.1" type="text/javascript"></script>
+      <script src="{{{ assetPath }}}javascripts/ie.js?0.8.0" type="text/javascript"></script>
     <![endif]-->
 
-    <link rel="shortcut icon" href="{{ assetPath }}images/favicon.ico?0.7.1" type="image/x-icon" />
+    <link rel="shortcut icon" href="{{{ assetPath }}}images/favicon.ico?0.8.0" type="image/x-icon" />
 
     <!-- For third-generation iPad with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ assetPath }}images/apple-touch-icon-144x144.png?0.7.1">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{{ assetPath }}}images/apple-touch-icon-144x144.png?0.8.0">
     <!-- For iPhone with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ assetPath }}images/apple-touch-icon-114x114.png?0.7.1">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{{ assetPath }}}images/apple-touch-icon-114x114.png?0.8.0">
     <!-- For first- and second-generation iPad: -->
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ assetPath }}images/apple-touch-icon-72x72.png?0.7.1">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{{ assetPath }}}images/apple-touch-icon-72x72.png?0.8.0">
     <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-    <link rel="apple-touch-icon-precomposed" href="{{ assetPath }}images/apple-touch-icon-57x57.png?0.7.1">
+    <link rel="apple-touch-icon-precomposed" href="{{{ assetPath }}}images/apple-touch-icon-57x57.png?0.8.0">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="{{ assetPath }}images/opengraph-image.png?0.7.1">
+    <meta property="og:image" content="{{{ assetPath }}}images/opengraph-image.png?0.8.0">
 
     {{{ head }}}
   </head>
@@ -65,13 +65,24 @@
       </div>
     </div>
 
+    <div id="global-cookie-message">
+      <div class="outer-block">
+        <div class="inner-block">
+          
+            {{{ cookieMessage }}}
+          
+        </div>
+      </div>
+    </div>
+    <!--end global-cookie-message-->
+
     
     <header role="banner" id="global-header" class="{{{ headerClass }}}">
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="{{ assetPath }}images/gov.uk_logotype_crown.png?0.7.1" width="35" height="31" alt=""> GOV.UK
+              <img src="{{{ assetPath }}}images/gov.uk_logotype_crown.png?0.8.0" width="35" height="31" alt=""> GOV.UK
             </a>
           </div>
           {{{ insideHeader }}}
@@ -84,11 +95,12 @@
 
     {{{ afterHeader }}}
 
-    <div id="global-cookie-message">
-      
-        {{{ cookieMessage }}}
-      
+    <div id="global-header-bar">
+      <div class="inner-block">
+        <div class="header-bar"></div>
+      </div>
     </div>
+    <!--end global-header-bar-->
 
     {{{ content }}}
 
@@ -102,13 +114,13 @@
             {{{ footerSupportLinks }}}
 
             <div class="open-government-licence">
-              <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2">Open Government Licence</a></h2>
-              <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2">Open Government Licence v2.0</a>, except where otherwise stated</p>
+              <h2><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/">Open Government Licence</a></h2>
+              <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/">Open Government Licence v2.0</a>, except where otherwise stated</p>
             </div>
           </div>
 
           <div class="copyright">
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
+            <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
           </div>
         </div>
       </div>
@@ -118,7 +130,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="{{ assetPath }}javascripts/govuk-template.js?0.7.1" type="text/javascript"></script>
+    <script src="{{{ assetPath }}}javascripts/govuk-template.js?0.8.0" type="text/javascript"></script>
 
     {{{ bodyEnd }}}
   </body>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "3.5.1",
     "glob": "3.2.9",
     "govuk_frontend_toolkit": "0.46.1",
-    "govuk_template_mustache": "0.7.1",
+    "govuk_template_mustache": "0.8.0",
     "graceful-fs": "^2.0.3",
     "jquery": "1.8.3",
     "lodash": "2.4.1",

--- a/spec/server/common/views/spec.govuk.js
+++ b/spec/server/common/views/spec.govuk.js
@@ -44,7 +44,7 @@ function (GovUkView, View, Model) {
       expect(context.pageTitle).toEqual('Performance - GOV.UK');
 
       var content = context.content.replace(/\s+/g, ' ').trim();
-      expect(content).toEqual('<div id="performance-platform-colour-bar" role="presentation"></div> <div id="global-breadcrumb"> <ol class="group" role="breadcrumbs"> <li> <a href="/performance"> <span title="Performance"> Performance </span> </a> </li> </ol> </div> <div id="wrapper"> <main id="content" class="group" role="main"> <div class="performance-platform-outer"> test_content report_a_problem </div> </main> </div>');
+      expect(content).toEqual('<div id="global-breadcrumb"> <ol class="group" role="breadcrumbs"> <li> <a href="/performance"> <span title="Performance"> Performance </span> </a> </li> </ol> </div> <div id="wrapper"> <main id="content" class="group" role="main"> <div class="performance-platform-outer"> test_content report_a_problem </div> </main> </div>');
     });
 
     it('doesn\'t display the breadcrumb wrapper if there are no breadcrumbs', function () {

--- a/styles/common/navigation.scss
+++ b/styles/common/navigation.scss
@@ -16,10 +16,6 @@ span.alpha-tag {
   }
 }
 
-#performance-platform-colour-bar {
-  margin: 0 auto;
-  height: 0;
-  max-width: $govuk-page-width;
-
-  border-top: 10px solid $primary-colour;
+#global-header-bar .header-bar {
+  background-color: $primary-colour;
 }

--- a/styles/common/raw.scss
+++ b/styles/common/raw.scss
@@ -1,7 +1,7 @@
 body.raw {
   #skiplink-container,
   #global-cookie-message,
-  #performance-platform-colour-bar,
+  #global-header-bar .header-bar,
   #global-header,
   #global-breadcrumb,
   #footer,


### PR DESCRIPTION
https://github.com/alphagov/govuk_template/compare/v0.7.1...v0.8.0
- Moves cookie message above header
- Fixes HTML-escaping of asset path using Mustache
- Switch to using the new global colour bar
