### PR TITLE
Write port back to app.config if overwritten

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -46,6 +46,8 @@ var app = require('./appBuilder').getApp(environment, rootDir, argv.REQUIRE_BASE
 
 var port = process.env.PORT || app.get('port');
 
+app.set('port', port);
+
 var server = http.createServer(app).listen(port, function () {
   global.logger.info('Express server listening on port ' + port);
 });


### PR DESCRIPTION
The port is used in other places, such as when loading the model from stagecraft stubs in `app/process_request.js`. This means it can be reliably loaded with `app.get('port')` even if overwritten with environment variables.
