### PR TITLE
Only display ticks on y-axis of graph when showing data

### DIFF
--- a/app/extensions/views/graph/axis.js
+++ b/app/extensions/views/graph/axis.js
@@ -24,7 +24,7 @@ function (Component) {
         .orient(this.orient);
 
       _.each(['ticks', 'tickValues', 'tickFormat', 'tickPadding', 'tickSize'], function (id) {
-        if (this[id]) {
+        if (this[id] !== undefined) {
           var args = _.isFunction(this[id]) ? this[id]() : this[id];
           axis[id].apply(this, _.isArray(args) ? args : [args]);
         }

--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -159,27 +159,34 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Cal
     },
 
     calcYScale: function () {
+      var max = this.maxValue();
+
       var yScale = this.d3.scale.linear();
-      var tickValues = this.calculateLinearTicks([this.minValue(), Math.max(this.maxValue(), this.minYDomainExtent)], this.numYTicks);
-      yScale.domain(tickValues.extent);
+      if (max) {
+        var tickValues = this.calculateLinearTicks([this.minValue(), Math.max(this.maxValue(), this.minYDomainExtent)], this.numYTicks);
+        yScale.domain(tickValues.extent);
+        yScale.tickValueList = tickValues.values;
+      }
       yScale.rangeRound([this.innerHeight, 0]);
-      yScale.tickValueList = tickValues.values;
       return yScale;
     },
 
     maxValue: function () {
       var d3 = this.d3;
       var valueAttr = this.valueAttr;
-      var max = d3.max(this.collection.toJSON(), function (group) {
+      return d3.max(this.collection.toJSON(), function (group) {
         return d3.max(group.values.toJSON(), function (value) {
           return value[valueAttr];
         });
-      }) || 1;
-      return max;
+      });
     },
 
     minValue: function () {
       return 0;
+    },
+
+    hasData: function () {
+      return this.maxValue() !== undefined;
     },
 
     getPeriod: function () {

--- a/app/extensions/views/graph/yaxis.js
+++ b/app/extensions/views/graph/yaxis.js
@@ -7,22 +7,20 @@ function (require, Axis) {
   var YAxis = Axis.extend({
     position: 'left',
     classed: 'y-axis',
-    ticks: 7,
     orient: 'left',
-    initialize: function () {
-      Axis.prototype.initialize.apply(this, arguments);
-      if (this.graph.numYTicks !== null) {
-        this.ticks = this.graph.numYTicks;
-      }
-    },
     getScale: function () {
       return this.scales.y;
     },
+    ticks: function () {
+      return this.graph.hasData() ? this.graph.numYTicks : 0;
+    },
     tickFormat: function () {
-      return this.numberListFormatter(this.scales.y.tickValueList, this.graph.currency);
+      if (this.scales.y.tickValueList) {
+        return this.numberListFormatter(this.scales.y.tickValueList, this.graph.currency);
+      }
     },
     tickValues: function () {
-      if (this.graph.showStartAndEndTicks) {
+      if (this.graph.showStartAndEndTicks && this.scales.y.tickValueList) {
         var ticks = this.scales.y.tickValueList;
         return [[0, ticks[ticks.length - 1]]];
       }

--- a/spec/client/extensions/views/graph/spec.graph.js
+++ b/spec/client/extensions/views/graph/spec.graph.js
@@ -8,6 +8,87 @@ define([
 ],
 function (Graph, GraphTable, Collection, Model, View, d3) {
 
+  var defaultData;
+
+  beforeEach(function () {
+
+    defaultData = [
+      {
+        id: 'total',
+        title: 'Total applications',
+        values: new Collection([
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-14').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _count: 90,
+            alternativeValue: 444
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _count: 100,
+            alternativeValue: 333
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-02-04').startOf('day'),
+            _count: 114,
+            alternativeValue: 222
+          }
+        ])
+      },
+      {
+        id: 'westminster',
+        title: 'Westminster',
+        values: new Collection([
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-14').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _count: 1,
+            alternativeValue: 100
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _count: 6,
+            alternativeValue: 99
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-02-04').startOf('day'),
+            _count: 11,
+            alternativeValue: 98
+          }
+        ])
+      },
+      {
+        id: 'croydon',
+        title: 'Croydon',
+        values: new Collection([
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-14').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _count: 2,
+            alternativeValue: 80
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-21').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _count: 7,
+            alternativeValue: 87
+          },
+          {
+            _start_at: Collection.prototype.getMoment('2013-01-28').startOf('day'),
+            _end_at: Collection.prototype.getMoment('2013-02-04').startOf('day'),
+            _count: 12,
+            alternativeValue: 23
+          }
+        ])
+      }
+    ];
+
+  });
+
   describe('Graph', function () {
 
     beforeEach(function () {
@@ -580,80 +661,7 @@ function (Graph, GraphTable, Collection, Model, View, d3) {
 
         collection = new Collection();
 
-        collection.reset([
-          {
-            id: 'total',
-            title: 'Total applications',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 90,
-                alternativeValue: 444
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 100,
-                alternativeValue: 333
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 114,
-                alternativeValue: 222
-              }
-            ])
-          },
-          {
-            id: 'westminster',
-            title: 'Westminster',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 1,
-                alternativeValue: 100
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 6,
-                alternativeValue: 99
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 11,
-                alternativeValue: 98
-              }
-            ])
-          },
-          {
-            id: 'croydon',
-            title: 'Croydon',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 2,
-                alternativeValue: 80
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 7,
-                alternativeValue: 87
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 12,
-                alternativeValue: 23
-              }
-            ])
-          }
-        ]);
+        collection.reset(defaultData);
         collection.getCurrentSelection = jasmine.createSpy().andReturn({});
         graph = new Graph({
           collection: collection
@@ -697,12 +705,46 @@ function (Graph, GraphTable, Collection, Model, View, d3) {
             .toEqual([0, 20, 40, 60, 80, 100, 120]);
       });
 
-      it('still sets a scale for the domain (rather than throwing an error) when all data in the dataset is null', function () {
+      it('does not set a tickValueList to the scale if all data is null', function () {
         collection.at(0).get('values').each(function (model) { model.set('_count', null); });
         collection.at(1).get('values').each(function (model) { model.set('_count', null); });
         collection.at(2).get('values').each(function (model) { model.set('_count', null); });
-        expect(graph.calcYScale().domain()).toEqual([0, 6]);
+        expect(graph.calcYScale().tickValueList).toBeUndefined();
       });
+    });
+
+    describe('hasData', function () {
+
+      var collection, graph;
+      beforeEach(function () {
+
+        collection = new Collection();
+
+        collection.reset(defaultData);
+        collection.getCurrentSelection = jasmine.createSpy().andReturn({});
+        graph = new Graph({
+          collection: collection
+        });
+        graph.innerWidth = 444;
+        graph.innerHeight = 333;
+      });
+
+      it('returns true when collection is non-empty', function () {
+        expect(graph.hasData()).toEqual(true);
+      });
+
+      it('returns false when collecion is empty', function () {
+        collection.reset([]);
+        expect(graph.hasData()).toEqual(false);
+      });
+
+      it('returns false when collection data is null', function () {
+        collection.at(0).get('values').each(function (model) { model.set('_count', null); });
+        collection.at(1).get('values').each(function (model) { model.set('_count', null); });
+        collection.at(2).get('values').each(function (model) { model.set('_count', null); });
+        expect(graph.hasData()).toEqual(false);
+      });
+
     });
 
     describe('configs', function () {
@@ -713,80 +755,7 @@ function (Graph, GraphTable, Collection, Model, View, d3) {
 
         collection = new Collection();
 
-        collection.reset([
-          {
-            id: 'total',
-            title: 'Total applications',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 90,
-                alternativeValue: 444
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 100,
-                alternativeValue: 333
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 114,
-                alternativeValue: 222
-              }
-            ])
-          },
-          {
-            id: 'westminster',
-            title: 'Westminster',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 1,
-                alternativeValue: 100
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 6,
-                alternativeValue: 99
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 11,
-                alternativeValue: 98
-              }
-            ])
-          },
-          {
-            id: 'croydon',
-            title: 'Croydon',
-            values: new Collection([
-              {
-                _start_at: collection.getMoment('2013-01-14').startOf('day'),
-                _end_at: collection.getMoment('2013-01-21').startOf('day'),
-                _count: 2,
-                alternativeValue: 80
-              },
-              {
-                _start_at: collection.getMoment('2013-01-21').startOf('day'),
-                _end_at: collection.getMoment('2013-01-28').startOf('day'),
-                _count: 7,
-                alternativeValue: 87
-              },
-              {
-                _start_at: collection.getMoment('2013-01-28').startOf('day'),
-                _end_at: collection.getMoment('2013-02-04').startOf('day'),
-                _count: 12,
-                alternativeValue: 23
-              }
-            ])
-          }
-        ]);
+        collection.reset(defaultData);
         collection.getCurrentSelection = jasmine.createSpy().andReturn({});
         graph = new Graph({
           el: el,

--- a/spec/client/extensions/views/graph/spec.yaxis.js
+++ b/spec/client/extensions/views/graph/spec.yaxis.js
@@ -94,6 +94,25 @@ function (YAxis, Graph, Collection) {
       });
     });
 
+    describe('ticks', function () {
+
+      it('returns the graph numYTicks by default', function () {
+        var view = viewForValues(0, 10, true, 10);
+        view.graph.numYTicks = 10;
+        expect(view.ticks()).toEqual(10);
+
+        view.graph.numYTicks = 5;
+        expect(view.ticks()).toEqual(5);
+      });
+
+      it('returns zero if the graph has no data', function () {
+        var view = viewForValues(0, 10, true, 10);
+        spyOn(view.graph, 'hasData').andReturn(false);
+        expect(view.ticks()).toEqual(0);
+      });
+
+    });
+
 
   });
 });


### PR DESCRIPTION
To prevent case where whole-number graphs were showing [0, 0.5, 1] as y axis values, which is incongruous with integer values.
