### PR TITLE
Add content dashboards to the homepage

### DIFF
--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -21,16 +21,16 @@
       <h3>Detailed dashboards</h3>
       <p class="count"><%= services.length + serviceGroups.length %></p>
     </div>
-    <div>
+    <div class="cols3 add3">
       <p>Services providing regularly updated, detailed data to GOV.UK</p>
-      <div class="cols3 service-listing">
+      <div class="cols2 service-listing">
         <ul>
           <% _.each(services, function (service, i) { %>
             <li><a href="/performance/<%= service.slug %>"><%= service.title %></a></li>
             <% if (i + 1 === Math.ceil((services.length + serviceGroups.length) / 2)) { %>
               </ul>
             </div>
-            <div class="cols3 service-listing">
+            <div class="cols2 service-listing">
               <ul>
             <% } %>
           <% }); %>
@@ -55,32 +55,51 @@
       <h3>Overview dashboards</h3>
       <p class="count"><%= highVolumeServices.length %></p>
     </div>
-    <p>Services providing quarterly data to GOV.UK</p>
-    <p><a href="/performance/services"><strong>View all services</strong></a></p>
+    <div class="cols3 add3">
+      <p>Services providing quarterly data to GOV.UK</p>
+      <p><a href="/performance/services"><strong>View all services</strong></a></p>
+    </div>
+  </section>
+  <section>
+    <h2>GOV.UK activity dashboards</h2>
+    <div class="cols3 service-listing">
+      <h3>Activity dashboards</h3>
+      <p class="count"><%= contentDashboards.length + 1 %></p>
+    </div>
+    <div class="cols3 add3">
+      <p>Web traffic on our site, including a look at how our content is being used.</p>
+      <p><a href="/performance/site-activity"><strong>GOV.UK site activity overview</strong></a></p>
+      <h3 class="underline">Department activity dashboards</h3>
+      <div class="cols2 service-listing">
+        <ul>
+          <% _.each(contentDashboards, function (contentDashboard, i) { %>
+            <li><a href="/performance/<%= contentDashboard.slug %>"><%= contentDashboard.title %></a></li>
+            <% if (i + 1 === Math.ceil(contentDashboards.length / 2)) { %>
+              </ul>
+            </div>
+            <div class="cols2 service-listing">
+              <ul>
+            <% } %>
+          <% }); %>
+        </ul>
+      </div>
+    </div>
   </section>
 
-  <div>
-    <section class="cols2 service-listing">
-      <h2>Transactions Explorer</h2>
-      <p>An overview of all transaction-based services the government provides.</p>
-      <ul>
-        <li><a href="/performance/transactions-explorer/all-services/by-transactions-per-year/descending">All services</a></li>
-        <li><a href="/performance/transactions-explorer/high-volume-services/by-transactions-per-year/descending">High-volume services</a></li>
-      </ul>
-      <a href='/performance/transactions-explorer/all-services/by-transactions-per-year/descending'>
-        <img alt="" src="<%= assetPath %>images/<%= assetDigest['homepage-transactions-explorer.png'] %>" width='465' height='223'>
-      </a>
-    </section>
-
-    <section class="cols2 service-listing">
-      <h2>Activity on GOV.UK</h2>
-      <p>Web performance data for all of GOV.UK, including site traffic and availability.</p>
-      <ul>
-        <li><a href="/performance/site-activity">Activity on GOV.UK</a></li>
-      </ul>
-      <!-- GOV.UK realtime module goes here -->
-    </section>
-  </div>
+  <section class="service-listing">
+    <h2>Transactions Explorer</h2>
+    <div class="row">
+      <div class="cols3">
+        <p>An overview of all transaction-based services the government provides.</p>
+        <p><a href="/performance/transactions-explorer/all-services/by-transactions-per-year/descending">View all services</a></p>
+      </div>
+      <div class="cols3 add3">
+        <a href='/performance/transactions-explorer/all-services/by-transactions-per-year/descending'>
+          <img alt="" src="<%= assetPath %>images/<%= assetDigest['homepage-transactions-explorer.png'] %>">
+        </a>
+      </div>
+    </div>
+  </section>
 
   <section>
     <h2>Further information</h2>

--- a/app/server/views/homepage.js
+++ b/app/server/views/homepage.js
@@ -17,10 +17,19 @@ module.exports = BaseView.extend(templater).extend({
 
   getContent: function () {
 
+    // the GOV.UK content dashboard should be removed from the list
+    // as it has an explicit link in the homepage template
+    var contentDashboards = this.collection.filterDashboards('content');
+
+    contentDashboards = _.filter(contentDashboards, function (dashboard) {
+      return dashboard.slug !== 'site-activity';
+    });
+
     return this.loadTemplate(path.resolve(__dirname, '../templates/homepage.html'), _.extend({}, {
       services: this.collection.filterDashboards('transaction', 'other'),
       serviceGroups: this.collection.filterDashboards('service-group'),
-      highVolumeServices: this.collection.filterDashboards('high-volume-transaction')
+      highVolumeServices: this.collection.filterDashboards('high-volume-transaction'),
+      contentDashboards: contentDashboards
     }, this.model.toJSON()));
 
   }

--- a/styles/common/columns.scss
+++ b/styles/common/columns.scss
@@ -20,14 +20,17 @@
     margin-left: 0;
   }
 
+  $third_width: 300px / $govuk-page-width * 100%;
+  $third_margin: 30px / $govuk-page-width * 100%;
+
   #content section.cols3,
   #content article.cols3,
   .cols3 {
-    width: 300px / $govuk-page-width * 100%;
+    width: $third_width;
     float: left;
     clear: none;
     margin-right: 0;
-    margin-left: 30px / $govuk-page-width * 100%;
+    margin-left: $third_margin;
   }
 
   .cols3:first-of-type,
@@ -37,6 +40,6 @@
   }
 
   .cols3.add3 {
-    width: (300px / $govuk-page-width * 100%) * 2;
+    width: $third_width * 2 + $third_margin;
   }
 }

--- a/styles/pages/homepage.scss
+++ b/styles/pages/homepage.scss
@@ -23,6 +23,9 @@
     h3 {
       @include bold-19;
       margin-top: 1em;
+      &.underline {
+        border-bottom: 1px solid $grey-3;
+      }
     }
 
     p, dl, ul {
@@ -32,6 +35,10 @@
     p {
       margin: 0.2em 0 1em 0;
     }
+  }
+
+  a strong {
+    @include bold-24;
   }
 
   article {
@@ -86,7 +93,6 @@
 
   img {
     display: block;
-    max-width: 100%;
-    margin-top: 1.579em;
+    width: 100%;
   }
 }


### PR DESCRIPTION
I switched the styling on the 1/3 + 2/3 columns to use the correct grid
styles, so that the widths were uniform down the whole homepage.

I had to do a bit a nasty in homepage.js in order to filter out the
GOV.UK content dashboard, which meant hardcoding a plus one into the
template. Not a massive fan but the other option I thought of would have
been to filter the list in the template which I liked even less.

I removed the hardcoded size from the transactions explorer tree-map
image as it seemed a little weird and I couldn't find a reason for its
existence.

The add3 style did not include the extra margins width it removed and
would never will 100% of the width. I have rectified this and pulled out
the widths to vars to be shared between col3 and add3.

The 'a strong' styling was added to make the two links on the homepage
match the style of the designs.

Conflicts:
    styles/common/columns.scss
