### PR TITLE
Fix non-overlapping ranges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ branches:
     - master
 env:
   - TEST_CMD: test:unit
-  - TEST_CMD: shell:cheapseats:--range:0..70
-  - TEST_CMD: shell:cheapseats:--range:71..
+  - TEST_CMD: shell:cheapseats:--range:0..80
+  - TEST_CMD: shell:cheapseats:--range:80..
 script: "grunt $TEST_CMD"
 matrix:
   fast_finish: true


### PR DESCRIPTION
There was a `<` and not a `<=` so the limits of the ranges need to match.

Also tinker with the range a little to put more tests in the first batch. Because it contains more of the "high volume" dashboards (because they mostly start with a "d"), which are quicker to test.
