### PR TITLE
SORN start page on GOV.UK has changed

### DIFF
--- a/app/support/stagecraft_stub/responses/sorn.json
+++ b/app/support/stagecraft_stub/responses/sorn.json
@@ -16,7 +16,7 @@
   "relatedPages": {
     "transaction": {
       "title": "Make a SORN (Statutory Off Road Notification)",
-      "url": "https://www.gov.uk/register-sorn-statutory-off-road-notification"
+      "url": "https://www.gov.uk/make-a-sorn"
     },
     "improve-dashboard-message": true
   },


### PR DESCRIPTION
Avoid an unnecessary redirect.
