### PR TITLE
Don't render user satisfaction bars on dashboard

### DIFF
--- a/app/common/views/visualisations/user-satisfaction-graph.js
+++ b/app/common/views/visualisations/user-satisfaction-graph.js
@@ -54,14 +54,16 @@ function (template, CompletionRateView, UserSatisfactionView, Collection) {
     views: function () {
       var views = CompletionRateView.prototype.views.apply(this, arguments);
 
-      views['#volumetrics-bar-selected'] = {
-        view: UserSatisfactionView,
-        options: {
-          valueAttr: 'count',
-          selectionValueAttr: this.valueAttr,
-          collection: this.userSatisfactionCollection
-        }
-      };
+      if (this.model.get('page-type') === 'module') {
+        views['#volumetrics-bar-selected'] = {
+          view: UserSatisfactionView,
+          options: {
+            valueAttr: 'count',
+            selectionValueAttr: this.valueAttr,
+            collection: this.userSatisfactionCollection
+          }
+        };
+      }
 
       return views;
     }

--- a/spec/client/common/views/visualisations/spec.user-satisfaction-graph.js
+++ b/spec/client/common/views/visualisations/spec.user-satisfaction-graph.js
@@ -5,9 +5,10 @@ define([
   'extensions/models/model'
 ],
 function (UserSatisfactionGraphView, CompletionRateView, Collection, Model) {
-  describe('User Satisfaction Graph', function () {
+  describe('User satisfaction graph', function () {
 
     var collection, view;
+
     beforeEach(function () {
       spyOn(CompletionRateView.prototype, 'views').andReturn({});
       collection = new Collection();
@@ -62,7 +63,9 @@ function (UserSatisfactionGraphView, CompletionRateView, Collection, Model) {
         limit: 0,
         min: 1,
         max: 5,
-        model: new Model(),
+        model: new Model({
+          'page-type': 'module'
+        }),
         period: 'day',
         duration: 30,
         trim: true,
@@ -89,7 +92,7 @@ function (UserSatisfactionGraphView, CompletionRateView, Collection, Model) {
     });
 
     describe('rendering a graph', function () {
-      it('renders the graph x-axis', function () {
+      it('renders the bars x-axis', function () {
         jasmine.renderView(view, function () {
           var xaxis = view.$el.find('.x-axis text');
 
@@ -113,8 +116,16 @@ function (UserSatisfactionGraphView, CompletionRateView, Collection, Model) {
         });
       });
 
+      it('doesn\'t render the bars on the dashboard, only on page-per-thing', function () {
+        view.model.set('page-type', undefined);
+
+        jasmine.renderView(view, function () {
+          expect(view.$el.find('.bar').length).toEqual(0);
+        });
+      });
+
       describe('updating the graph', function () {
-        it('updates the values when the collection is reset', function () {
+        it('updates the bar values when the collection is reset', function () {
           jasmine.renderView(view, function () {
             var changedModel = collection.at(0).get('values').at(2);
             view.collection.trigger('change:selected', undefined, undefined, changedModel);


### PR DESCRIPTION
The five bars under the user satisfaction over time graph show a detailed breakdown of the satisfaction responses for a specific day.

They should only be shown on the page-per-thing for the module, not on the main dashboard.

([Diff without whitespace changes](https://github.com/alphagov/spotlight/pull/553/files?w=1))
