### PR TITLE
Pin Carer's completion rate module to 19 May

### DIFF
--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -115,7 +115,8 @@
       ],
       "denominator-matcher": "about-you$",
       "numerator-matcher": "thank-you$",
-      "matching-attribute": "eventLabel"
+      "matching-attribute": "eventLabel",
+      "start-at": "2014-05-19T00:00:00+00:00"
     },
     {
       "slug": "users-at-each-step",


### PR DESCRIPTION
Instead of displaying data going back 9 weeks, just display back to the 19th of May because that's when we started collecting data with the `thank-you` label.

This change should be reverted in a few weeks once there is enough data in place to make a decent-looking graph. [A chore has been created for that](https://www.pivotaltracker.com/story/show/72963084).

You can see the problem with the graph here:

![screen shot 2014-06-10 at 14 39 29](https://cloud.githubusercontent.com/assets/121219/3230619/b5ddd80a-f0a4-11e3-96b0-8437c028046b.png)
