### PR TITLE
Fix table display of unstacked device type graphs

### DIFF
--- a/app/support/stagecraft_stub/responses/apply-uk-visa.json
+++ b/app/support/stagecraft_stub/responses/apply-uk-visa.json
@@ -94,17 +94,17 @@
           {
             "label": "Mobile",
             "categoryId": "mobile",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Tablet",
             "categoryId": "tablet",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Desktop",
             "categoryId": "desktop",
-            "format": "integer"
+            "format": "percent"
           }
         ]
       }

--- a/app/support/stagecraft_stub/responses/experimental/no-realistic-dashboard.json
+++ b/app/support/stagecraft_stub/responses/experimental/no-realistic-dashboard.json
@@ -563,17 +563,17 @@
               {
                 "label": "Desktop",
                 "categoryId": "desktop",
-                "format": "integer"
+                "format": "percent"
               },
               {
                 "label": "Mobile",
                 "categoryId": "mobile",
-                "format": "integer"
+                "format": "percent"
               },
               {
                 "label": "Tablet",
                 "categoryId": "tablet",
-                "format": "integer"
+                "format": "percent"
               }
             ]
           }

--- a/app/support/stagecraft_stub/responses/practical-driving-test.json
+++ b/app/support/stagecraft_stub/responses/practical-driving-test.json
@@ -104,17 +104,17 @@
           {
             "label": "Mobile",
             "categoryId": "mobile",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Tablet",
             "categoryId": "tablet",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Desktop",
             "categoryId": "desktop",
-            "format": "integer"
+            "format": "percent"
           }
         ]
       }

--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -187,17 +187,17 @@
           {
             "label": "Desktop",
             "categoryId": "desktop",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Mobile",
             "categoryId": "mobile",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Tablet",
             "categoryId": "tablet",
-            "format": "integer"
+            "format": "percent"
           }
         ]
       }

--- a/app/support/stagecraft_stub/responses/student-finance.json
+++ b/app/support/stagecraft_stub/responses/student-finance.json
@@ -246,17 +246,17 @@
           {
             "label": "Mobile",
             "categoryId": "mobile",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Tablet",
             "categoryId": "tablet",
-            "format": "integer"
+            "format": "percent"
           },
           {
             "label": "Desktop",
             "categoryId": "desktop",
-            "format": "integer"
+            "format": "percent"
           }
         ]
       }


### PR DESCRIPTION
5af264c33918c5a0c45932e7e46cd0bfce54935e changed existing dashboards with "device type" graphs to use lines rather than stacked.

These line values are percentages, which needs to be reflected in the axes configuration.

This changes the table display of this data from either '0' or '1' to the actual percentage value.

(You can use `?w=1` as a query parameter on GitHub to see the diff without whitespace changes.)
