### PR TITLE
Only load scripts if we have something to run

### DIFF
--- a/app/common/templates/body-end.html
+++ b/app/common/templates/body-end.html
@@ -3,10 +3,12 @@
   GOVUK.config = <%= JSON.stringify(model.toJSON()) %>;
 </script>
 
+<% if (model.get('script')) { %>
 <% if (model.get('environment') === 'development') { %>
 <script data-main="<%= requirePath %>client.js" src="<%= requirePath %>vendor/require.js" type="text/javascript"></script>
 <% } else { %>
 <!--[if lt IE 9]><script src="<%= assetPath %>javascripts/<%= assetDigest['spotlight-no-d3.js'] %>" type="text/javascript"></script><![endif]-->
 <!--[if gt IE 8]><!--><script src="<%= assetPath %>javascripts/<%= assetDigest['spotlight.js'] %>" type="text/javascript"></script><!--<![endif]-->
 
+<% } %>
 <% } %>

--- a/app/process_request.js
+++ b/app/process_request.js
@@ -26,6 +26,7 @@ var renderContent = function (req, res, model) {
 
 var setup = function (req, res) {
   var model = setup.getStagecraftApiClient();
+  model.set('script', true);
 
   model.urlRoot = 'http://localhost:' + req.app.get('port') + '/stagecraft-stub';
 

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -13,8 +13,9 @@ module.exports = function (req, res) {
       model = new Backbone.Model(_.extend(PageConfig.commonConfig(req), {
     title: 'Services',
     'page-type': 'services',
-    'filter': req.query.filter || '',
-    'data': services
+    filter: req.query.filter || '',
+    data: services,
+    script: true
   }));
 
   var collection = new DashboardCollection(services);

--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -40,7 +40,8 @@ describe('Services Controller', function () {
       title: 'Services',
       'page-type': 'services',
       filter: '',
-      data: jasmine.any(Array)
+      data: jasmine.any(Array),
+      script: true
     });
   });
 
@@ -51,7 +52,8 @@ describe('Services Controller', function () {
       title: 'Services',
       'page-type': 'services',
       filter: 'foo',
-      data: jasmine.any(Array)
+      data: jasmine.any(Array),
+      script: true
     });
   });
 


### PR DESCRIPTION
In particular, prevent loading ~600kb of javascript to not do anything on the homepage and new (proposed) about page.
