### PR TITLE
Stop wide tables from overlapping with download links

### DIFF
--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -17,7 +17,7 @@
         margin-top: 2em;
         margin-bottom: 1em;
         padding-right: 3em;
-        width: 66%;
+        min-width: 66%;
         table {
           width: 100%;
           margin-top: 0;
@@ -34,6 +34,7 @@
         overflow: hidden;
         margin-top: 2em;
         display: inline-block;
+        float: right;
         @media (max-width: 640px) {
           width: 100%;
         }


### PR DESCRIPTION
min-width means floats will break to below the table i the table exceeds 66% width.
More info section stays floated right, according to request from @mikieet
