### PR TITLE
Remove further information from homepage

### DIFF
--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -104,22 +104,4 @@
     </div>
   </section>
 
-  <section id="misc">
-    <h2>Further information</h2>
-
-    <article class="cols2">
-      <a href="/performance/prototypes">
-        <h3>Performance prototypes</h3>
-      </a>
-      <p>Experiments and prototypes made by the Performance Platform data scientists.</p>
-    </article>
-
-    <article class="cols2">
-      <a href="https://gds.blog.gov.uk/category/measurement-analytics/">
-        <h3>Measurement and analytics — GDS blog</h3>
-      </a>
-      <p>Latest posts from the performance and analytics teams on the GDS blog.</p>
-    </article>
-  </section>
-
 </div>


### PR DESCRIPTION
We now have links to the blog and prototypes in the header of the all of
the pages, so they are no longer needed on the homepage.
