### PR TITLE
Pass url option to table module views

### DIFF
--- a/app/common/modules/table.js
+++ b/app/common/modules/table.js
@@ -6,7 +6,8 @@ define(function () {
     visualisationOptions: function () {
       return {
         sortBy: this.model.get('sort-by'),
-        sortOrder: this.model.get('sort-order') || 'descending'
+        sortOrder: this.model.get('sort-order') || 'descending',
+        url: this.url
       };
     }
 

--- a/app/server/modules/table.js
+++ b/app/server/modules/table.js
@@ -20,12 +20,6 @@ module.exports = parent.extend({
       queryParams: this.model.get('query-params'),
       axes: this.model.get('axes')
     };
-  },
-
-  viewOptions: function () {
-    var options = parent.prototype.viewOptions.apply(this, arguments);
-    options.url = null;
-    return options;
   }
 
 });


### PR DESCRIPTION
This allows table page per thing links to be rendered.
No idea why it was being suppressed before.
