### PR TITLE
Prevent duplication of dashboard title in content dashboard breadcrumbs

### DIFF
--- a/app/server/views/dashboard.js
+++ b/app/server/views/dashboard.js
@@ -61,17 +61,6 @@ module.exports = View.extend({
       {'path': '/performance', 'title': 'Performance'}
     ];
     return crumbs;
-  },
-
-  getBreadcrumbs: function () {
-    var breadcrumbs = this.getBreadcrumbCrumbs();
-    if (this.model.get('page-type') === 'module') {
-      breadcrumbs.push({
-        title: this.model.get('title')
-      });
-    }
-    breadcrumbs = breadcrumbs.filter(_.identity);
-    breadcrumbs = this.ellipsifyBreadcrumbs(breadcrumbs);
-    return {'breadcrumbs': breadcrumbs};
   }
+
 });

--- a/app/server/views/dashboards/transaction.js
+++ b/app/server/views/dashboards/transaction.js
@@ -25,12 +25,17 @@ module.exports = DashboardView.extend({
     var crumbs = DashboardView.prototype.getBreadcrumbCrumbs.apply(this, arguments);
     if (this.model.get('department')) {
       crumbs.push({
-        'title': this.model.get('department').title
+        title: this.model.get('department').title
       });
     }
     if (this.model.get('agency')) {
       crumbs.push({
-        'title': this.model.get('agency').title
+        title: this.model.get('agency').title
+      });
+    }
+    if (this.model.get('page-type') === 'module') {
+      crumbs.push({
+        title: this.model.get('title')
       });
     }
     return crumbs;

--- a/spec/server-pure/views/spec.dashboard.js
+++ b/spec/server-pure/views/spec.dashboard.js
@@ -155,6 +155,18 @@ describe('ContentDashboardView', function () {
       ]);
     });
 
+    it('does not include additional dashboard title on page-per-thing pages [bugfix]', function () {
+
+      model.set('page-type', 'module');
+
+      expect(view.getBreadcrumbCrumbs()).toEqual([
+        { path: '/performance', title: 'Performance' },
+        { title: 'Activity on GOV.UK' },
+        { title: 'Content Dashboard' }
+      ]);
+
+    });
+
   });
 
 });
@@ -251,6 +263,23 @@ describe('TransactionDashboardView', function () {
         { title: 'Department for Work and Pensions' },
         { title: 'Agency Name'}
       ]);
+    });
+
+    it('includes top-level dashboard title on page-per-thing pages', function () {
+
+      model.set('page-type', 'module');
+      model.set({
+        department: {
+          title: 'Department for Work and Pensions'
+        }
+      });
+
+      expect(view.getBreadcrumbCrumbs()).toEqual([
+        { path: '/performance', title: 'Performance' },
+        { title: 'Department for Work and Pensions' },
+        { title: 'Carer\'s Allowance' }
+      ]);
+
     });
 
   });


### PR DESCRIPTION
Page-per-thing was adding the dashboard title twice in page per thing mode for content dashboards. Stop doing that.
