### PR TITLE
Use the end date to plot data with period of a week

### DIFF
--- a/app/extensions/views/graph/graph.js
+++ b/app/extensions/views/graph/graph.js
@@ -127,7 +127,13 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, LineLabel, Hover, Cal
     },
 
     modelToDate: function (model) {
-      var prop = this.getPeriod() === 'hour' ? '_timestamp' : '_start_at';
+      var prop = '_start_at';
+      var period = this.getPeriod();
+      if (period === 'hour') {
+        prop = '_timestamp';
+      } else if (period === 'week') {
+        prop = '_end_at';
+      }
       return this.getMoment(model.get(prop));
     },
 

--- a/app/extensions/views/graph/xaxis.js
+++ b/app/extensions/views/graph/xaxis.js
@@ -111,7 +111,7 @@ function (d3, Axis) {
         },
         tickFormat: function () {
           return _.bind(function (d) {
-            return this.getMoment(d).format('D MMM');
+            return this.getMoment(d).subtract('days', 1).format('D MMM');
           }, this);
         }
       },

--- a/spec/client/extensions/views/graph/spec.graph.js
+++ b/spec/client/extensions/views/graph/spec.graph.js
@@ -737,12 +737,13 @@ function (Graph, Collection, Model, View, d3) {
           beforeEach(function () {
             spyOn(graph, 'getPeriod').andReturn(period);
           });
-          it('scales domain from start entry start date to end entry start date', function () {
-            var domain = graph.calcXScale().domain();
-            expect(graph.getMoment(domain[0]).format('YYYY-MM-DD')).toEqual('2013-01-14');
-            expect(graph.getMoment(domain[1]).format('YYYY-MM-DD')).toEqual('2013-01-28');
-          });
-
+          if (period !== 'week') {
+            it('scales domain from first entry start date to last entry start date', function () {
+              var domain = graph.calcXScale().domain();
+              expect(graph.getMoment(domain[0]).format('YYYY-MM-DD')).toEqual('2013-01-14');
+              expect(graph.getMoment(domain[1]).format('YYYY-MM-DD')).toEqual('2013-01-28');
+            });
+          }
           it('scales range to inner width', function () {
             expect(graph.calcXScale().range()).toEqual([0, 444]);
           });
@@ -813,6 +814,16 @@ function (Graph, Collection, Model, View, d3) {
 
       describe('week', function () {
         sharedSpecsForScalingBetweenStartAndEndDates('week');
+        describe('calcXScale', function () {
+          beforeEach(function () {
+            spyOn(graph, 'getPeriod').andReturn('week');
+          });
+          it('scales domain from first entry end date to last entry end date', function () {
+            var domain = graph.calcXScale().domain();
+            expect(graph.getMoment(domain[0]).format('YYYY-MM-DD')).toEqual('2013-01-21');
+            expect(graph.getMoment(domain[1]).format('YYYY-MM-DD')).toEqual('2013-02-04');
+          });
+        });
       });
 
       describe('month', function () {

--- a/spec/client/extensions/views/graph/spec.xaxis.js
+++ b/spec/client/extensions/views/graph/spec.xaxis.js
@@ -83,16 +83,16 @@ function (XAxis, Collection) {
     });
 
     describe('"week" configuration', function () {
-      it('shows tick and label each Monday', function () {
+      it('shows tick and label for the sunday at the end of each period', function () {
         var view = viewForConfig('week', '2013-03-05T00:00:00+00:00', '2013-04-05T00:00:00+01:00');
         view.render();
 
         var ticks = wrapper.selectAll('.tick')[0];
         expect(wrapper.selectAll('.tick')[0].length).toEqual(4);
-        expect(d3.select(ticks[0]).text()).toEqual('11 Mar');
-        expect(d3.select(ticks[1]).text()).toEqual('18 Mar');
-        expect(d3.select(ticks[2]).text()).toEqual('25 Mar');
-        expect(d3.select(ticks[3]).text()).toEqual('1 Apr');
+        expect(d3.select(ticks[0]).text()).toEqual('10 Mar');
+        expect(d3.select(ticks[1]).text()).toEqual('17 Mar');
+        expect(d3.select(ticks[2]).text()).toEqual('24 Mar');
+        expect(d3.select(ticks[3]).text()).toEqual('31 Mar');
       });
     });
 


### PR DESCRIPTION
Make weekly data plot at the end of the week (see http://localhost:3057/performance/waste-carrier-or-broker-registration/volumetrics).

Need to subtract a day from the tick labels because week periods are shown as ending on the Sunday, though `_end_at` property represents midnight on Monday.
