### PR TITLE
Better handling of KPIs with monthly data

### DIFF
--- a/app/server/views/modules/kpi.js
+++ b/app/server/views/modules/kpi.js
@@ -11,6 +11,8 @@ module.exports = View.extend({
     var formattedDate = '';
     if (period === 'week') {
       formattedDate = this.format([startDate, endDate], {type: 'dateRange', format: 'D MMM YYYY'});
+    } else if (period === 'month') {
+      formattedDate = this.format(startDate, {type: 'date', format: 'MMMM YYYY'});
     } else {
       formattedDate = this.format([startDate, endDate], {type: 'dateRange', format: 'MMM YYYY', subtract: 'months'});
     }

--- a/spec/server-pure/views/spec.kpi.js
+++ b/spec/server-pure/views/spec.kpi.js
@@ -68,6 +68,26 @@ describe('KPIView', function () {
       expect(dateKpi.$('.period').text()).toEqual('24 Mar 2014 to 30 Mar 2014');
     });
 
+    it('displays the month when the date period is month', function () {
+      var dateKpi = new KPIView({
+        model: new Model({
+          valueAttr: 'value',
+          format: 'currency',
+          'date-period': 'month'
+        }),
+        collection: new Collection([
+          {
+            value: 1100,
+            _timestamp: '2014-03-01T00:00:00+00:00',
+            end_at: '2014-03-31T00:00:00+00:00'
+          },
+          { value: 1000 }
+        ])
+      });
+      dateKpi.render();
+      expect(dateKpi.$('.period').text()).toEqual('March 2014');
+    });
+
     it('fails gracefully if there is no data', function () {
       var dateKpi = new KPIView({
         model: new Model({


### PR DESCRIPTION
I've freestyled the design a bit here because it seems obvious to me, but I'll double check with @henryhadlow or @mikieet that it makes sense.

In short, for monthly KPI data:
- Previously: "1 Feb 2014 to 28 Feb 2014"
- Now: "February 2014"

Also note that this doesn't actually fix the issue on the page. This is because waste carriers config is incorrectly set to a date period of "week" when it's monthly data.

But by a happy coincidence, their data is changing from monthly to weekly in a current story. So I'm not going to "fix" it only to have to change it back again later today.
