### PR TITLE
Float "About the data" section left, not right, on PPT

### DIFF
--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -34,7 +34,7 @@
         overflow: hidden;
         margin-top: 2em;
         display: inline-block;
-        float: right;
+        float: left;
         @media (max-width: 640px) {
           width: 100%;
         }


### PR DESCRIPTION
This looks better on narrower screens, and fixes a bug
in the display on larger screens.

See: https://www.pivotaltracker.com/s/projects/911874/stories/73812576
for details of the bug.
