### PR TITLE
Make tables scrollable on touch devices.

### DIFF
--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -20,6 +20,9 @@ function (View, Formatters) {
     prepareTable: function () {
       this.$table = $('<table></table>');
       this.$table.appendTo(this.$el);
+      if (this.modernizr.touch) {
+        this.$table.addClass('touch-table');
+      }
     },
 
     renderEl: function (elementName, context, value, attr) {

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -110,6 +110,12 @@ function (Table, View, Collection, $) {
         expect(Table.prototype.prepareTable).not.toHaveBeenCalled();
       });
 
+      it('adds the .touch-table class on touch devices', function () {
+        table.modernizr = { touch: true };
+        table.render();
+        expect(table.$table.hasClass('touch-table')).toBe(true);
+      });
+
       it('will call renderEl with "no data" when a row has null values', function () {
         table.render();
         expect(Table.prototype.renderEl.mostRecentCall.args[2]).toEqual('no data');

--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -21,6 +21,9 @@
         table {
           width: 100%;
           margin-top: 0;
+          &.touch-table {
+            width: calc(100% - 1.5em);
+          }
         }
         @media (max-width: 640px) {
           width: 100%;

--- a/styles/common/table.scss
+++ b/styles/common/table.scss
@@ -3,6 +3,10 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   border: 1px solid darken($grey-2, 10%);
+  &.touch-table {
+    margin-left: 1.5em;
+    width: calc(100% - 1.5em);
+  }
 
   &.floated-header {
     thead {


### PR DESCRIPTION
Add a .touch-table class to tables on touch devices.

When this class is set, add a 1.5em left margin, and reduce
the width of the table accordingly.

I think calc() is the best way to do this, since we can't use
border-box with a margin, and we can't use padding on the table
since it has a border. The only other way I can see it do it
is a containing div and that starts to get messy.

NB: Haven't yet tested this on a real device!
