### PR TITLE
Fixed maxbuffer exceeded issue when running 'grunt' for a while.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -253,7 +253,10 @@ module.exports = function (grunt) {
       supervisor: {
         options: {
           stdout: true,
-          stderr: true
+          stderr: true,
+          execOptions: {
+            maxBuffer: Infinity
+          }
         },
         command: './node_modules/supervisor/lib/cli-wrapper.js -w app -i app/vendor -e "js|html" -n error app/server'
       }


### PR DESCRIPTION
This should make our dev tools usable!!!!

![](http://media.giphy.com/media/y8fXirTJjj6E0/giphy.gif)
