### PR TITLE
Update config to point at production data by default

### DIFF
--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,8 +1,8 @@
 {
   "assetPath": "/spotlight/",
   "port": 3057,
-  "backdropUrl": "https://www.preview.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
+  "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
-  "govukHost": "www.preview.alphagov.co.uk"
+  "govukHost": "www.alphagov.co.uk"
 }


### PR DESCRIPTION
We've agreed that we should develop against production data by
default. Update our config files to do this.

Also update the path to govukHost.
