### PR TITLE
Change patent renewal dashboard slug

### DIFF
--- a/app/support/stagecraft_stub/responses/renew-patent.json
+++ b/app/support/stagecraft_stub/responses/renew-patent.json
@@ -1,5 +1,5 @@
 {
-  "slug": "bis-payment-of-patent-renewal-fee-f12",
+  "slug": "renew-patent",
   "page-type": "dashboard",
   "dashboard-type": "transaction",
   "published": true,


### PR DESCRIPTION
This service is an exemplar, so we're giving it a URL that matches the service.

There will be a pull request to the router to redirect the old URL.
