### PR TITLE
Remove trailing commas

### DIFF
--- a/app/client/modules/visitors-realtime.js
+++ b/app/client/modules/visitors-realtime.js
@@ -6,7 +6,7 @@ define([
 function (ModuleController, RealtimeModule, VisitorsRealtimeView) {
   return ModuleController.extend(RealtimeModule).extend({
 
-    visualisationClass: VisitorsRealtimeView,
+    visualisationClass: VisitorsRealtimeView
 
   });
 

--- a/app/common/modules/comparison.js
+++ b/app/common/modules/comparison.js
@@ -14,7 +14,7 @@ function (GroupedTimeseriesController, ModuleController, ComparisonCollection) {
     collectionOptions: function () {
       var options = GroupedTimeseriesController.collectionOptions.apply(this, arguments);
       return _.extend(options, {
-        comparison: this.model.get('comparison'),
+        comparison: this.model.get('comparison')
       });
     }
 

--- a/app/common/views/visualisations/sparkline.js
+++ b/app/common/views/visualisations/sparkline.js
@@ -50,7 +50,7 @@ function (Graph) {
         });
       }) || 0;
       return min;
-    },
+    }
 
 
   });

--- a/app/extensions/controllers/controller.js
+++ b/app/extensions/controllers/controller.js
@@ -49,7 +49,7 @@ define([
 
       var renderViewOptions = _.merge({
         collection: this.collection,
-        model: this.model,
+        model: this.model
       }, options);
 
       if (this.collection && this.collection.isEmpty()) {


### PR DESCRIPTION
Trailing commas cause Internet Explorer 7 and lower to break.

I thought we were linting for these? The oldest example has existed since the end of March.
