### PR TITLE
Stop cheapseats running on every Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,5 @@ cache:
 branches:
   only:
     - master
-env:
-  - TEST_CMD: test:unit
-  - TEST_CMD: shell:cheapseats:--range:0..100
-  - TEST_CMD: shell:cheapseats:--range:100..
-script: "grunt $TEST_CMD"
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "scripts": {
-    "test": "grunt test:all",
+    "test": "grunt test:unit",
     "start": "grunt",
     "lint": "[ -z \"$LINTFILES\" ] && LINTFILES=\"** app/support/**/**/*.json\"; ./node_modules/jshint/bin/jshint ${LINTFILES}"
   },


### PR DESCRIPTION
We are going to move cheapseats to run async on every successful release
tag. At the moment it is slowing down our pipeline from code -> preview
a lot. If something falls through the cracks post removing cheapseats
from the pipeline we can revisit its presence.

We no longer need to split up the build into 3 parts as we are dropping
cheapseats.
