### PR TITLE
Fix register to vote digital take-up table

### DIFF
--- a/app/support/stagecraft_stub/responses/register-to-vote.json
+++ b/app/support/stagecraft_stub/responses/register-to-vote.json
@@ -85,7 +85,23 @@
       "numerator-matcher": "^ordinary$",
       "denominator-matcher": "^ordinary|ems$",
       "matching-attribute": "value",
-      "value-attribute": "count:sum"
+      "value-attribute": "count:sum",
+      "axes": {
+        "x": {
+          "label": "Date",
+          "key": "_start_at",
+          "format": {
+            "type": "date",
+            "format": "D MMM YYYY"
+          }
+        },
+        "y": [
+          {
+            "label": "Digital take-up",
+            "format": "percent"
+          }
+        ]
+      }
     },
     {
       "slug": "registrations-by-age-group",


### PR DESCRIPTION
We were using the default axes, which referenced completion rate.
