### PR TITLE
Fix bug in line labels on grouped timeseries

### DIFF
--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -344,35 +344,40 @@ function (Component) {
       }
     },
 
-    onChangeSelected: function (groupSelected, groupIndexSelected) {
+    onChangeSelected: function (groupSelected) {
+      var groupIdSelected = groupSelected ? groupSelected.get('id') : null;
       this.render();
       var labels = this.figcaption.selectAll('li');
       var lines = this.componentWrapper.selectAll('line');
-      labels.classed('selected', function (group, groupIndex) {
-        return groupIndexSelected === groupIndex;
+      labels.classed('selected', function (group) {
+        return groupIdSelected === group.id;
       });
-      labels.classed('not-selected', function (group, groupIndex) {
-        return groupIndexSelected !== null && groupIndexSelected !== groupIndex;
+      labels.classed('not-selected', function (group) {
+        return groupIdSelected !== null && groupIdSelected !== group.id;
       });
-      lines.classed('selected', function (group, groupIndex) {
-        return groupIndexSelected === groupIndex;
+      lines.classed('selected', function (group) {
+        return groupIdSelected === group.id;
       });
-      lines.classed('not-selected', function (group, groupIndex) {
-        return groupIndexSelected !== null && groupIndexSelected !== groupIndex;
+      lines.classed('not-selected', function (group) {
+        return groupIdSelected !== null && groupIdSelected !== group.id;
       });
     },
 
     onHover: function (e) {
       var y = e.y;
-      var bestIndex, bestDistance = Infinity;
-      _.each(this.positions, function (elem, index) {
+      var bestIndex, bestId, bestDistance = Infinity;
+      _.each(this.positions, function (elem) {
         var yLabel = Math.floor(elem.min) + 0.5;
         var distance = Math.abs(yLabel - y);
         if (distance < bestDistance) {
           bestDistance = distance;
-          bestIndex = index;
+          bestId = elem.id;
         }
       });
+      var modelSelected = _.find(this.collection.models, function(elem) {
+        return (elem.id === bestId);
+      });
+      bestIndex = modelSelected ? this.collection.indexOf(modelSelected) : null;
       if (e.toggle && bestIndex === this.collection.selectedIndex) {
         this.collection.selectItem(null);
       } else {

--- a/spec/client/extensions/views/graph/spec.linelabel.js
+++ b/spec/client/extensions/views/graph/spec.linelabel.js
@@ -53,8 +53,8 @@ function (LineLabel, Collection) {
           left: 400
         };
         lineLabel.positions = [
-          { ideal: 30, min: 30, size: 20 },
-          { ideal: 80, min: 80, size: 30 }
+          { ideal: 30, min: 30, size: 20, id: 'id1' },
+          { ideal: 80, min: 80, size: 30, id: 'id2' }
         ];
         spyOn(lineLabel, 'setLabelPositions');
       });
@@ -273,7 +273,7 @@ function (LineLabel, Collection) {
           lineLabel.render();
           var littleLines = wrapper.select('.labels');
           var labels = lineLabel.$el.find('figcaption ol li');
-          lineLabel.onChangeSelected(collection.at(1), 1);
+          lineLabel.onChangeSelected(collection.at(1));
           expect(hasClass(labels.eq(0), 'selected')).toBe(false);
           expect(hasClass(labels.eq(1), 'selected')).toBe(true);
           expect(hasClass(labels.eq(0), 'not-selected')).toBe(true);
@@ -282,7 +282,7 @@ function (LineLabel, Collection) {
           expect(hasClass(littleLines.select('line:nth-child(2)'), 'selected')).toBe(true);
           expect(hasClass(littleLines.select('line:nth-child(1)'), 'not-selected')).toBe(true);
           expect(hasClass(littleLines.select('line:nth-child(2)'), 'not-selected')).toBe(false);
-          lineLabel.onChangeSelected(collection.at(0), 0);
+          lineLabel.onChangeSelected(collection.at(0));
           expect(hasClass(labels.eq(0), 'selected')).toBe(true);
           expect(hasClass(labels.eq(1), 'selected')).toBe(false);
           expect(hasClass(labels.eq(0), 'not-selected')).toBe(false);
@@ -291,7 +291,7 @@ function (LineLabel, Collection) {
           expect(hasClass(littleLines.select('line:nth-child(2)'), 'selected')).toBe(false);
           expect(hasClass(littleLines.select('line:nth-child(1)'), 'not-selected')).toBe(false);
           expect(hasClass(littleLines.select('line:nth-child(2)'), 'not-selected')).toBe(true);
-          lineLabel.onChangeSelected(null, null);
+          lineLabel.onChangeSelected(null);
           expect(hasClass(labels.eq(0), 'selected')).toBe(false);
           expect(hasClass(labels.eq(1), 'selected')).toBe(false);
           expect(hasClass(labels.eq(0), 'not-selected')).toBe(false);
@@ -403,6 +403,18 @@ function (LineLabel, Collection) {
           lineLabel.onHover({ x: null, y: 54, toggle: true });
           expect(collection.selectItem).toHaveBeenCalledWith(null);
         });
+
+        it('selects the closest label when label positions are out of sync with collection order', function () {
+          lineLabel.positions = [
+            { ideal: 30, min: 30, size: 20, id: 'id2' },
+            { ideal: 80, min: 80, size: 30, id: 'id1' }
+          ];
+          lineLabel.onHover({ x: null, y: 54 });
+          expect(collection.selectItem).toHaveBeenCalledWith(1);
+          lineLabel.onHover({ x: null, y: 56 });
+          expect(collection.selectItem).toHaveBeenCalledWith(0);
+        });
+
       });
 
     });


### PR DESCRIPTION
There was a bug in line labels as follows: where the ordering of the line
labels was different from the ordering of the models in the collection,
behaviour on mouseover was unpredictable. The wrong labels and lines
were highlighting.

This was because we were finding the selected model based on index,
not on model ID. When the labels were re-ordered by our label
positioning algorithm, the wrong index was being passed into the
collection's selectItem method.

Fix this to find the model by ID instead, and update tests.

Story: https://www.pivotaltracker.com/s/projects/911874/stories/74028388
