### PR TITLE
Fix groupId of >75 age group

### DIFF
--- a/app/support/stagecraft_stub/responses/register-to-vote.json
+++ b/app/support/stagecraft_stub/responses/register-to-vote.json
@@ -195,7 +195,7 @@
           },
           {
             "label": "Over 75",
-            "groupId": "> 75",
+            "groupId": "&gt; 75",
             "format": "integer"
           }
         ]


### PR DESCRIPTION
Attribute is returned from backdrop as an encoded entity, so it needs to be encoded in the config as well.

@annapowellsmith this seems to work ok for me
