### PR TITLE
Correctly get configured period for timeshifted graphs

### DIFF
--- a/app/extensions/collections/collection.js
+++ b/app/extensions/collections/collection.js
@@ -30,7 +30,7 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
       Backbone.Collection.prototype.initialize.apply(this, arguments);
     },
 
-    getPeriod: function() {
+    getPeriod: function () {
       var queryParams = this.dataSource.get('query-params');
       return queryParams ? queryParams.period : undefined;
     },

--- a/app/extensions/models/data_source.js
+++ b/app/extensions/models/data_source.js
@@ -33,7 +33,7 @@ function (Backbone, Mustache, _, moment) {
       return url;
     },
 
-    setQueryParam: function(key, value) {
+    setQueryParam: function (key, value) {
       var params = _.clone(this.get('query-params')) || {};
       params[key] = value;
       this.set('query-params', params);

--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -261,7 +261,7 @@ function (Component) {
       labelMeta += this.renderValuePercentage(value, percentage);
 
       if (line.timeshift) {
-        labelMeta = '<span class="label-title">(' + line.timeshift + ' ' + this.collection.options.period + 's ago)</span>' + labelMeta;
+        labelMeta = '<span class="label-title label-timeshift">(' + line.timeshift + ' ' + this.collection.getPeriod() + 's ago)</span>' + labelMeta;
       }
 
       if (line.href) {

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -10,7 +10,7 @@ function (View, Formatters) {
       var collection = this.collection = options.collection;
 
       this.valueAttr = options.valueAttr;
-      this.period = collection.options.period;
+      this.period = collection.getPeriod();
 
       View.prototype.initialize.apply(this, arguments);
 

--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -87,9 +87,7 @@
           "period": "week",
           "duration": 52,
           "group_by": "website",
-          "collect": [
-            "visitors:sum"
-          ]
+          "collect": "visitors:sum"
         }
       }
     },

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -90,6 +90,7 @@ function (LineLabel, Collection, Model) {
           { ideal: 80, min: 80, size: 30, key: '_value' }
         ];
         spyOn(lineLabel, 'setLabelPositions');
+        spyOn(collection, 'getPeriod').andReturn('week');
       });
 
       afterEach(function () {
@@ -141,6 +142,20 @@ function (LineLabel, Collection, Model) {
 
           expect(typeof textLabels.eq(0).prop('class')).toEqual('string');
           expect(textLabels.eq(0).prop('class')).toEqual('label0 timeshift');
+        });
+
+        it('adds timeshift subtitle to line labels for timeshifted lines', function () {
+          lineLabel.graph.getLines = function () {
+            return [
+              { label: 'Title 1', key: '_count', timeshift: 52 },
+              { label: 'Title 2', key: '_count' }
+            ];
+          };
+          lineLabel.render();
+
+          var textLabels = lineLabel.$el.find('figcaption li');
+
+          expect(textLabels.eq(0).find('.label-timeshift').text()).toEqual('(52 weeks ago)');
         });
 
         it('renders a label with correct WAI-ARIA attributes', function () {

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -18,6 +18,7 @@ function (Table, View, Collection, $) {
       var table;
       beforeEach(function () {
         spyOn(Table.prototype, 'render');
+        spyOn(Collection.prototype, 'getPeriod').andReturn('month');
         table = new Table({
           collection: new Collection()
         });
@@ -44,6 +45,11 @@ function (Table, View, Collection, $) {
         expect(table.render).not.toHaveBeenCalled();
       });
 
+      it('sets collection period to own period property', function () {
+        expect(table.collection.getPeriod).toHaveBeenCalled();
+        expect(table.period).toEqual('month');
+      });
+
     });
 
     describe('render', function () {
@@ -55,7 +61,6 @@ function (Table, View, Collection, $) {
           collection: {
             on: jasmine.createSpy(),
             options: {
-              period: 'week',
               axes: {
                 x: {
                   label: 'date',
@@ -69,7 +74,8 @@ function (Table, View, Collection, $) {
               }
             },
             getTableRows: function () {},
-            sortByAttr: function () {}
+            sortByAttr: function () {},
+            getPeriod: function () { return 'week'; }
           },
           valueAttr: 'value'
         });


### PR DESCRIPTION
Timeshift line labels and tables were expecting period to be passed as an option

Get from `Collection#getPeriod` instead
