### PR TITLE
Fix site-activity config file against schema validation

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity.json
+++ b/app/support/stagecraft_stub/responses/site-activity.json
@@ -87,7 +87,9 @@
           "period": "week",
           "duration": 52,
           "group_by": "website",
-          "collect": "visitors:sum"
+          "collect": [
+            "visitors:sum"
+          ]
         }
       }
     },


### PR DESCRIPTION
Schema expects collect property to be an array.
