### PR TITLE
Use header tag rather than section for unpublished banner

### DIFF
--- a/app/common/templates/dashboard.html
+++ b/app/common/templates/dashboard.html
@@ -48,10 +48,10 @@
 
 
 {{^ published }}
-  <section id="unpublished-warning">
+  <header id="unpublished-warning">
     <h2>Prototype</h2>
     <p>This dashboard is a prototype and may disappear at any time. The data is for demonstration purposes only.</p>
-  </section>
+  </header>
 {{/ published }}
 
 

--- a/app/common/templates/module.html
+++ b/app/common/templates/module.html
@@ -1,8 +1,8 @@
 <% if (pageType === 'module' && !model.get('parent').get('published')) { %>
-  <section id="unpublished-warning">
+  <header id="unpublished-warning">
     <h2>Prototype</h2>
     <p>This dashboard is a prototype and may disappear at any time. The data is for demonstration purposes only.</p>
-  </section>
+  </header>
 <% } %>
 
 <% if (pageType === 'module') { %>


### PR DESCRIPTION
Fixes this bug:
https://www.pivotaltracker.com/s/projects/537859/stories/75018342

This occured because our `:first-of-type` selector was matching the
banner, not the first KPI module. CSS3 doesn't have a way to select
the first element with a particular class, so it's easier just to
change the element type for the banner.

In addition, header is arguably a more appropriate tag for the
unpublished banner.
