### PR TITLE
Give collect properties a mechanism to collect by

### DIFF
--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/vat-content.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/vat-content.json
@@ -277,7 +277,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -294,7 +294,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -319,7 +319,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -336,7 +336,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -361,7 +361,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -378,7 +378,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-attorney-generals-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-attorney-generals-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-cabinet-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-cabinet-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-business-innovation-skills.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-business-innovation-skills.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-communities-and-local-government.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-communities-and-local-government.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-culture-media-sport.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-culture-media-sport.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-education.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-education.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-environment-food-rural-affairs.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-environment-food-rural-affairs.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-international-development.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-international-development.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-transport.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-transport.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-work-pensions.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-work-pensions.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-of-energy-climate-change.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-of-energy-climate-change.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-department-of-health.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-of-health.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-deputy-prime-ministers-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-deputy-prime-ministers-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100

--- a/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-licensing-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-licensing-agency.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-standards-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-standards-agency.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-driving-standards-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driving-standards-agency.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-environment-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-environment-agency.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-foreign-commonwealth-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-foreign-commonwealth-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-hm-prison-service.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-prison-service.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-hm-revenue-customs.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-revenue-customs.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-hm-treasury.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-treasury.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-home-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-home-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-ministry-of-defence.json
+++ b/app/support/stagecraft_stub/responses/site-activity-ministry-of-defence.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-ministry-of-justice.json
+++ b/app/support/stagecraft_stub/responses/site-activity-ministry-of-justice.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-northern-ireland-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-northern-ireland-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-office-of-the-advocate-general-for-scotland.json
+++ b/app/support/stagecraft_stub/responses/site-activity-office-of-the-advocate-general-for-scotland.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-office-of-the-leader-of-the-house-of-lords.json
+++ b/app/support/stagecraft_stub/responses/site-activity-office-of-the-leader-of-the-house-of-lords.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-prime-ministers-office-10-downing-street.json
+++ b/app/support/stagecraft_stub/responses/site-activity-prime-ministers-office-10-downing-street.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-scotland-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-scotland-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-the-charity-commission-for-england-and-wales.json
+++ b/app/support/stagecraft_stub/responses/site-activity-the-charity-commission-for-england-and-wales.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-the-office-of-the-leader-of-the-house-of-commons.json
+++ b/app/support/stagecraft_stub/responses/site-activity-the-office-of-the-leader-of-the-house-of-commons.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-uk-export-finance.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-export-finance.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-uk-trade-investment.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-trade-investment.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-uk-visas-and-immigration.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-visas-and-immigration.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-vehicle-and-operator-services-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-vehicle-and-operator-services-agency.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1

--- a/app/support/stagecraft_stub/responses/site-activity-wales-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-wales-office.json
@@ -572,7 +572,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -592,7 +592,7 @@
               "group_by": "sourceMedium",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -617,7 +617,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -637,7 +637,7 @@
               "group_by": "keyword",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1
@@ -662,7 +662,7 @@
               },
               {
                 "label": "Bounce rate",
-                "key": "visitBounceRate",
+                "key": "visitBounceRate:mean",
                 "format": {
                   "type": "percent",
                   "normalisation": 100
@@ -682,7 +682,7 @@
               "group_by": "socialNetwork",
               "collect": [
                 "entrances:sum",
-                "visitBounceRate"
+                "visitBounceRate:mean"
               ],
               "period": "week",
               "duration": 1


### PR DESCRIPTION
Without providing a collection mechanism (i.e. "mean", "sum" etc) then the values are returned as an array instead of a single value, which causes problems when it comes to sorting values in tables as arrays are casted to strings when comparing with `<`, and sorted as strings instead of raw numerical values.
