### PR TITLE
Bugfix/table layouts

### DIFF
--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -38,7 +38,7 @@
         @include media(tablet) {
           float: left;
           padding-right: 3em;
-          width: 66%;
+          min-width: 66%;
         }
       }
 


### PR DESCRIPTION
The min-width that set the width of the table component got lost in favour of a regular width in https://github.com/alphagov/spotlight/commit/c144e56cabb7329535eeae4c7f85526be6d72cf5

This means that wide tables on pages like http://localhost:3057/performance/register-to-vote/user-satisfaction end up overlapping with the more info content.

Swapping back to a min-width allows the table to break the float down on to the next line.
