### PR TITLE
Prevent line-set from selecting a line if model has no values

### DIFF
--- a/app/extensions/views/graph/line-set.js
+++ b/app/extensions/views/graph/line-set.js
@@ -55,7 +55,7 @@ define([
       var interpolator;
       var diff = this.lines[0].x(index) - e.x;
       var next = diff < 0 ? index + 1 : index - 1;
-      if (this.hasValueAtIndex(next)) {
+      if (diff !== 0 && this.hasValueAtIndex(next)) {
         interpolator = function (line) {
           var interpx = diff / (line.x(index) - line.x(next));
           return d3.interpolateNumber(line.y(index), line.y(next))(interpx);
@@ -69,18 +69,19 @@ define([
     },
 
     getClosestLine: function (e, index) {
-      var ydiff = Infinity;
-      var closestY = {};
-      var interpolator = this.getInterpolator(e, index);
+      var closestY = { valueAttr: null };
+      if (this.hasValueAtIndex(index)) {
+        var ydiff = Infinity;
+        var interpolator = this.getInterpolator(e, index);
 
-      _.each(this.lines, function (line) {
-        var diff = interpolator(line) - e.y;
-        if (Math.abs(diff) < Math.abs(ydiff)) {
-          closestY = line;
-          ydiff = diff;
-        }
-      });
-
+        _.each(this.lines, function (line) {
+          var diff = interpolator(line) - e.y;
+          if (Math.abs(diff) < Math.abs(ydiff)) {
+            closestY = line;
+            ydiff = diff;
+          }
+        });
+      }
       return closestY;
     },
 

--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -325,15 +325,15 @@ function (Component) {
     },
 
     onChangeSelected: function (model, index, options) {
+      options = options || {};
       this.render();
       var labels = this.figcaption.selectAll('li');
       var lines = this.componentWrapper.selectAll('line');
       var selected = function (line) {
-        var valueAttr = line.key;
-        return model && (!options.valueAttr || options.valueAttr === valueAttr);
+        return model && options.valueAttr === line.key;
       };
       var unselected = function (line) {
-        return model && !selected(line);
+        return model && options.valueAttr && options.valueAttr !== line.key;
       };
       labels.classed('selected', selected);
       labels.classed('not-selected', unselected);

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -366,6 +366,21 @@ function (LineLabel, Collection, Model) {
           expect(hasClass(littleLines.select('line:nth-child(2)'), 'not-selected')).toBe(false);
         });
 
+        it('does not mark any line selected or deselected if a model is provided and no valueAttr is defined', function () {
+          lineLabel.render();
+          var littleLines = wrapper.select('.labels');
+          var labels = lineLabel.$el.find('figcaption ol li');
+          lineLabel.onChangeSelected(collection.at(0), 0);
+          expect(hasClass(labels.eq(0), 'selected')).toBe(false);
+          expect(hasClass(labels.eq(1), 'selected')).toBe(false);
+          expect(hasClass(labels.eq(0), 'not-selected')).toBe(false);
+          expect(hasClass(labels.eq(1), 'not-selected')).toBe(false);
+          expect(hasClass(littleLines.select('line:nth-child(1)'), 'selected')).toBe(false);
+          expect(hasClass(littleLines.select('line:nth-child(2)'), 'selected')).toBe(false);
+          expect(hasClass(littleLines.select('line:nth-child(1)'), 'not-selected')).toBe(false);
+          expect(hasClass(littleLines.select('line:nth-child(2)'), 'not-selected')).toBe(false);
+        });
+
         it('displays the values for the current selection', function () {
           lineLabel.render();
 


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/911874/stories/75030506

If all lines have null values for the closest model then all the lines should be deselected, rather than selecting an arbitrary line as before

Added some extra testing rigour around the methods that do this as well
