### PR TITLE
Add an error handler for modules whose collections fail to fetch

### DIFF
--- a/app/common/templates/module-error.html
+++ b/app/common/templates/module-error.html
@@ -1,0 +1,26 @@
+<% if (pageType === 'module' && !model.get('parent').get('published')) { %>
+  <header id="unpublished-warning">
+    <h2>Prototype</h2>
+    <p>This dashboard is a prototype and may disappear at any time. The data is for demonstration purposes only.</p>
+  </header>
+<% } %>
+
+<% if (pageType === 'module') { %>
+  <h1 id="<%= this.ariaId() %>"><%= model.get('title') %></h1>
+<% } else { %>
+  <% if (url) { %>
+    <h2 id="<%= this.ariaId() %>"><a href="<%= url %>"><%= model.get('title') %></a></h2>
+  <% } else { %>
+    <h2 id="<%= this.ariaId() %>"><%= model.get('title') %></h2>
+  <% } %>
+<% } %>
+
+<% if (model.get('description')) { %>
+  <p><%= model.get('description') %></p>
+<% } %>
+
+<div class="visualisation">
+
+<h2 class="error">There was a problem getting data for this module.</h2>
+
+</div>

--- a/app/extensions/controllers/controller.js
+++ b/app/extensions/controllers/controller.js
@@ -1,7 +1,8 @@
 define([
   'backbone',
-  'extensions/models/model'
-], function (Backbone, Model) {
+  'extensions/models/model',
+  'extensions/views/error'
+], function (Backbone, Model, ErrorView) {
 
   var Controller = function (options) {
     options = options || {};
@@ -52,7 +53,11 @@ define([
       }, options);
 
       if (this.collection && this.collection.isEmpty()) {
-        this.listenToOnce(this.collection, 'reset error', function () {
+        this.listenToOnce(this.collection, 'reset', function () {
+          this.renderView(renderViewOptions);
+        }, this);
+        this.listenToOnce(this.collection, 'error', function () {
+          this.viewClass = ErrorView;
           this.renderView(renderViewOptions);
         }, this);
 

--- a/app/extensions/views/error.js
+++ b/app/extensions/views/error.js
@@ -1,0 +1,34 @@
+define([
+  'extensions/views/view',
+  'tpl!common/templates/module-error.html'
+], function (View, Template) {
+
+  return View.extend({
+
+    tagName: 'section',
+
+    template: Template,
+
+    templateContext: function () {
+      return _.extend(
+        View.prototype.templateContext.call(this),
+        {
+          url: this.url,
+          pageType: this.model.get('parent').get('page-type')
+        }
+      );
+    },
+
+    ariaId: function () {
+      function safeId(s) {
+        if (s.indexOf(' ') === -1) {
+          return s;
+        }
+        return s.replace(/ /g, '-');
+      }
+      return safeId(this.model.get('slug') + '-heading');
+    }
+
+  });
+
+});


### PR DESCRIPTION
Instead of potentially crashing out or rendering no-data everywhere, if a modules collection actually fails, then stop rendering and display an error message.

Example at http://localhost:3057/performance/site-activity-deputy-prime-ministers-office on master at the moment.

Should probably test against this message being present in cheapseats too, since backdrop _error_s (as opposed to empty data-sets) should cause a fail condition for published dashboards.
