### PR TITLE
Use correct collection lookup for graph periods

### DIFF
--- a/app/common/views/visualisations/single-timeseries.js
+++ b/app/common/views/visualisations/single-timeseries.js
@@ -9,7 +9,7 @@ function (View, VolumetricsNumberView, SubmissionGraphView) {
     graphView: SubmissionGraphView,
 
     views: function () {
-      var period = this.collection.options.period || 'week';
+      var period = this.collection.getPeriod() || 'week';
       var views = View.prototype.views.apply(this, arguments);
 
       views['.volumetrics-completion-selected'].options = {
@@ -18,7 +18,7 @@ function (View, VolumetricsNumberView, SubmissionGraphView) {
         formatOptions: this.formatOptions
       };
 
-      _.extend( views['.volumetrics-completion'].options, {
+      _.extend(views['.volumetrics-completion'].options, {
         formatOptions: this.formatOptions
       });
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {
-    "cheapseats": "git+https://github.com/alphagov/cheapseats#0a0bbab268cd876a339eac40e0eada12cc0d033f",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats#d216bcf5f0a71359b8ec6161913c04e31ed7d0b6",
     "supervisor": "0.5.7"
   }
 }


### PR DESCRIPTION
collection.options.period is always undefined, so this would return "week" irrespective of the actual configured period.

Update cheapseats pointer to include tests that fail because of this.
