### PR TITLE
Fix group_by params in site-activity dashboards that got broken in migration

### DIFF
--- a/app/support/stagecraft_stub/responses/site-activity-attorney-generals-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-attorney-generals-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:attorney-generals-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:attorney-generals-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:ago"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-cabinet-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-cabinet-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:cabinet-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:cabinet-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:co"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-business-innovation-skills.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-business-innovation-skills.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-business-innovation-skills"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-business-innovation-skills"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:bis"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-communities-and-local-government.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-communities-and-local-government.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-communities-and-local-government"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-communities-and-local-government"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dclg"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-culture-media-sport.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-culture-media-sport.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-culture-media-sport"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-culture-media-sport"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dcms"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-education.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-education.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-education"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-education"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dfe"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-environment-food-rural-affairs.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-environment-food-rural-affairs.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-environment-food-rural-affairs"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-environment-food-rural-affairs"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:defra"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-international-development.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-international-development.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-international-development"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-international-development"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dfid"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-transport.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-transport.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-transport"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-transport"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dft"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-for-work-pensions.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-for-work-pensions.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-work-pensions"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-for-work-pensions"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dwp"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-of-energy-climate-change.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-of-energy-climate-change.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-of-energy-climate-change"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-of-energy-climate-change"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:decc"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-department-of-health.json
+++ b/app/support/stagecraft_stub/responses/site-activity-department-of-health.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-of-health"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:department-of-health"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dh"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-deputy-prime-ministers-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-deputy-prime-ministers-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:deputy-prime-ministers-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:deputy-prime-ministers-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dpmo"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-licensing-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-licensing-agency.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driver-and-vehicle-licensing-agency"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driver-and-vehicle-licensing-agency"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dvla"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-standards-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driver-and-vehicle-standards-agency.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driver-and-vehicle-standards-agency"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driver-and-vehicle-standards-agency"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dvsa"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-driving-standards-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-driving-standards-agency.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driving-standards-agency"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:driving-standards-agency"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:dsa"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-environment-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-environment-agency.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:environment-agency"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:environment-agency"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:ea"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-foreign-commonwealth-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-foreign-commonwealth-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:foreign-commonwealth-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:foreign-commonwealth-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:fco"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-hm-prison-service.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-prison-service.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-prison-service"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-prison-service"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:hmps"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-hm-revenue-customs.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-revenue-customs.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-revenue-customs"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-revenue-customs"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:hmrc"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-hm-treasury.json
+++ b/app/support/stagecraft_stub/responses/site-activity-hm-treasury.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-treasury"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:hm-treasury"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:hmt"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-home-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-home-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:home-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:home-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:home_office"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-ministry-of-defence.json
+++ b/app/support/stagecraft_stub/responses/site-activity-ministry-of-defence.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:ministry-of-defence"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:ministry-of-defence"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:mod"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-ministry-of-justice.json
+++ b/app/support/stagecraft_stub/responses/site-activity-ministry-of-justice.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:ministry-of-justice"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:ministry-of-justice"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:moj"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-northern-ireland-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-northern-ireland-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:northern-ireland-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:northern-ireland-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:nio"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-office-of-the-advocate-general-for-scotland.json
+++ b/app/support/stagecraft_stub/responses/site-activity-office-of-the-advocate-general-for-scotland.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:office-of-the-advocate-general-for-scotland"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:office-of-the-advocate-general-for-scotland"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:oag"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-office-of-the-leader-of-the-house-of-lords.json
+++ b/app/support/stagecraft_stub/responses/site-activity-office-of-the-leader-of-the-house-of-lords.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:office-of-the-leader-of-the-house-of-lords"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:office-of-the-leader-of-the-house-of-lords"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:olhl"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-prime-ministers-office-10-downing-street.json
+++ b/app/support/stagecraft_stub/responses/site-activity-prime-ministers-office-10-downing-street.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:prime-ministers-office-10-downing-street"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:prime-ministers-office-10-downing-street"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:number_10"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-scotland-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-scotland-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:scotland-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:scotland-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:scotland_office"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-the-charity-commission-for-england-and-wales.json
+++ b/app/support/stagecraft_stub/responses/site-activity-the-charity-commission-for-england-and-wales.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:the-charity-commission-for-england-and-wales"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:the-charity-commission-for-england-and-wales"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:cc"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-the-office-of-the-leader-of-the-house-of-commons.json
+++ b/app/support/stagecraft_stub/responses/site-activity-the-office-of-the-leader-of-the-house-of-commons.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:the-office-of-the-leader-of-the-house-of-commons"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:the-office-of-the-leader-of-the-house-of-commons"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:olhc"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-uk-export-finance.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-export-finance.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-export-finance"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-export-finance"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:ukef"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-uk-trade-investment.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-trade-investment.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-trade-investment"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-trade-investment"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:ukti"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-uk-visas-and-immigration.json
+++ b/app/support/stagecraft_stub/responses/site-activity-uk-visas-and-immigration.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-visas-and-immigration"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:uk-visas-and-immigration"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:ukvi"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-vehicle-and-operator-services-agency.json
+++ b/app/support/stagecraft_stub/responses/site-activity-vehicle-and-operator-services-agency.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:vehicle-and-operator-services-agency"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:vehicle-and-operator-services-agency"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:vosa"
           ],

--- a/app/support/stagecraft_stub/responses/site-activity-wales-office.json
+++ b/app/support/stagecraft_stub/responses/site-activity-wales-office.json
@@ -57,13 +57,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "traffic-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:wales-office"
               ],
@@ -96,13 +95,12 @@
             ]
           },
           "axis-period": "week",
-          "matching-attribute": "eventCategory",
           "data-source": {
             "data-group": "gov-uk-content",
             "data-type": "pageviews-count",
             "query-params": {
               "period": "week",
-              "group_by": "eventCategory",
+              "group_by": "department",
               "filter_by": [
                 "department:wales-office"
               ],
@@ -714,13 +712,12 @@
         ]
       },
       "axis-period": "month",
-      "matching-attribute": "eventCategory",
       "data-source": {
         "data-group": "gov-uk-content",
         "data-type": "feedback-count",
         "query-params": {
           "period": "month",
-          "group_by": "eventCategory",
+          "group_by": "organisation_acronym",
           "filter_by": [
             "organisation_acronym:wo"
           ],


### PR DESCRIPTION
A bug in the migrator caused the group_by params to be overwritten with "eventCategory" instead of their correct values
