### PR TITLE
Fix handling of empty data sets in completion collection

### DIFF
--- a/app/common/collections/completion_rate.js
+++ b/app/common/collections/completion_rate.js
@@ -46,7 +46,7 @@ define([
       if (attr === 'completion') {
         var started = this.total('_start');
         var ended = this.total('_end');
-        return ended / started;
+        return !started ? null : ended / started;
       } else {
         return CompletionCollection.prototype.mean.apply(this, arguments);
       }

--- a/spec/shared/common/collections/spec.completion_rate.js
+++ b/spec/shared/common/collections/spec.completion_rate.js
@@ -97,7 +97,7 @@ function (CompletionCollection) {
         expect(result[1]._start).toEqual(25);
         expect(result[0]._end).toEqual(10);
         expect(result[1]._end).toEqual(null);
-        expect(result[0].completion).toEqual(2/3);
+        expect(result[0].completion).toEqual(2 / 3);
         expect(result[1].completion).toEqual(0);
       });
 
@@ -197,6 +197,30 @@ function (CompletionCollection) {
 
       it('returns the overall mean completion if called with "completion"', function () {
         expect(collection.mean('completion')).toEqual(0.25);
+      });
+
+      it('returns null for an empty collection', function () {
+        collection = new CompletionCollection([], {
+          denominatorMatcher: 'start',
+          numeratorMatcher: 'done',
+          matchingAttribute: 'eventCategory',
+          valueAttr: 'uniqueEvents:sum'
+        });
+        expect(collection.mean('completion')).toBeNull();
+      });
+
+      it('returns zero if no "ended" values', function () {
+        collection = new CompletionCollection([], {
+          denominatorMatcher: 'start',
+          numeratorMatcher: 'done',
+          matchingAttribute: 'eventCategory',
+          valueAttr: 'uniqueEvents:sum'
+        });
+        collection.reset(mockResponse, { parse: true });
+        collection.each(function (model) {
+          model.set('_end', null);
+        });
+        expect(collection.mean('completion')).toEqual(0);
       });
 
     });


### PR DESCRIPTION
Calculations involve potential division by 0 if data sets are empty, which results in rendering out "NaN" to users.

See http://localhost:3057/performance/waste-carrier-or-broker-registration/digital-takeup (with data from preview)
