### PR TITLE
Display the last valid model, rather than the total, of the collection for line labels

### DIFF
--- a/app/extensions/collections/collection.js
+++ b/app/extensions/collections/collection.js
@@ -304,6 +304,10 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
       return this.length > 0;
     },
 
+    lastDefined: function () {
+      return this.defined.apply(this, arguments).pop();
+    },
+
     mean: function (attr) {
       var total = this.total(attr);
       var count = this.defined(attr).length;
@@ -321,10 +325,16 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
       return total;
     },
 
-    defined: function (attr) {
+    defined: function (attrs) {
+      if (_.isArray(attrs)) {
+        return this.defined.apply(this, attrs);
+      }
+      var args = arguments;
       return this.filter(function (model) {
-        var val = model.get(attr);
-        return val !== null && !isNaN(Number(val));
+        return _.any(args, function (arg) {
+          var val = model.get(arg);
+          return val !== null && !isNaN(Number(val));
+        });
       });
     },
 

--- a/app/extensions/views/graph/linelabel.js
+++ b/app/extensions/views/graph/linelabel.js
@@ -109,17 +109,17 @@ function (Component) {
       this.summaryHeight = 0;
 
       var selected = this.collection.getCurrentSelection();
-      var period = this.model.get('period');
-      var output;
+      var model;
 
       if (selected.selectedModel) {
-        output = this.formatPeriod(selected.selectedModel, period);
+        model = selected.selectedModel;
       } else {
-        var start = this.graph.modelToDate(this.collection.first());
-        var end = this.graph.modelToDate(this.collection.last());
-        var format = this.getFormat(period);
-        output = this.format([start, end], { type: 'dateRange', format: format });
+        var lines = this.graph.getLines();
+        model = this.collection.lastDefined.apply(
+          this.collection, _.map(lines, function (line) {return line.key;})
+        );
       }
+      var output = this.formatPeriod(model, model.get('period'));
 
       var summary = '<span class="timeperiod">' + output + '</span>';
 
@@ -236,24 +236,20 @@ function (Component) {
 
       if (selected.selectedModel) {
         model = selected.selectedModel;
-        if (this.graph.isOneHundredPercent()) {
-          value = model.get(attr.replace(':percent', ''));
+      } else {
+        model = this.collection.lastDefined(_.pluck(this.graph.getLines(), 'key'));
+      }
+
+      if (this.graph.isOneHundredPercent()) {
+        value = model.get(attr.replace(':percent', ''));
+        if (value !== null) {
           percentage = model.get(attr);
-        } else {
-          value = model.get(attr);
-          if (this.showPercentages()) {
-            percentage = model.get(attr + ':percent');
-          }
         }
       } else {
-        if (this.graph.isOneHundredPercent()) {
-          model = this.collection.defined(attr).pop();
-          value = model.get(attr.replace(':percent', ''));
-          percentage = model.get(attr);
-        } else {
-          value = this.collection.total(attr);
-          if (this.showPercentages()) {
-            percentage = value / this.collection.total('total:' + this.graph.valueAttr);
+        value = model.get(attr);
+        if (this.showPercentages()) {
+          if (value !== null) {
+            percentage = model.get(attr + ':percent');
           }
         }
       }

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -18,6 +18,7 @@ function (LineLabel, Collection, Model) {
             '_count:percent': 0.33,
             '_value:percent': 0.67,
             'total:_count': 30,
+            'total:_count:percent': 1,
             'abc:_count': 10,
             'def:_count': 20,
             'abc:_count:percent': 0.33,
@@ -29,6 +30,7 @@ function (LineLabel, Collection, Model) {
             '_count:percent': 0.4,
             '_value:percent': 0.6,
             'total:_count': 50,
+            'total:_count:percent': 1,
             'abc:_count': 20,
             'def:_count': 30,
             'abc:_count:percent': 0.4,
@@ -40,6 +42,7 @@ function (LineLabel, Collection, Model) {
             '_count:percent': 0.5,
             '_value:percent': 0.5,
             'total:_count': 60,
+            'total:_count:percent': 1,
             'abc:_count': 20,
             'def:_count': 40,
             'abc:_count:percent': 0.33,
@@ -173,15 +176,15 @@ function (LineLabel, Collection, Model) {
           expect(links.eq(1).attr('href')).toEqual('/link2');
         });
 
-        it('renders a label with additional value text showing total value', function () {
+        it('renders a label with additional value text showing last value', function () {
           lineLabel.render();
 
           var labels = lineLabel.$el.find('figcaption ol li');
           var label1 = labels.eq(0);
           var label2 = labels.eq(1);
 
-          expect(label1.find('span.value')).toHaveText('60');
-          expect(label2.find('span.value')).toHaveText('80');
+          expect(label1.find('span.value')).toHaveText('30');
+          expect(label2.find('span.value')).toHaveText('30');
         });
 
         it('does not render percentages if there is no total line', function () {
@@ -211,8 +214,8 @@ function (LineLabel, Collection, Model) {
           var label3 = labels.eq(2);
 
           expect(label1.find('span.percentage')).toHaveText('(100%)');
-          expect(label2.find('span.percentage')).toHaveText('(35.7%)');
-          expect(label3.find('span.percentage')).toHaveText('(64.3%)');
+          expect(label2.find('span.percentage')).toHaveText('(33%)');
+          expect(label3.find('span.percentage')).toHaveText('(67%)');
         });
 
         it('renders links and additional value text', function () {
@@ -343,8 +346,8 @@ function (LineLabel, Collection, Model) {
           expect(figcaption.find('li').eq(1).find('.percentage')).not.toExist();
 
           collection.selectItem(null);
-          expect(figcaption.find('li').eq(0).find('.value')).toHaveText('60');
-          expect(figcaption.find('li').eq(1).find('.value')).toHaveText('80');
+          expect(figcaption.find('li').eq(0).find('.value')).toHaveText('30');
+          expect(figcaption.find('li').eq(1).find('.value')).toHaveText('30');
           expect(figcaption.find('li').eq(0).find('.percentage')).not.toExist();
           expect(figcaption.find('li').eq(1).find('.percentage')).not.toExist();
         });
@@ -371,8 +374,8 @@ function (LineLabel, Collection, Model) {
           expect(figcaption.find('li').eq(2).find('.percentage')).toHaveText('(60%)');
 
           collection.selectItem(null);
-          expect(figcaption.find('li').eq(1).find('.percentage')).toHaveText('(35.7%)');
-          expect(figcaption.find('li').eq(2).find('.percentage')).toHaveText('(64.3%)');
+          expect(figcaption.find('li').eq(1).find('.percentage')).toHaveText('(33%)');
+          expect(figcaption.find('li').eq(2).find('.percentage')).toHaveText('(67%)');
         });
 
         it('displays (no data) when the current selection is null', function () {

--- a/spec/client/views/views/graph/spec.stacked-linelabel.js
+++ b/spec/client/views/views/graph/spec.stacked-linelabel.js
@@ -88,12 +88,18 @@ function (LineLabel, Collection, Model) {
         spyOn(lineLabel, 'renderSummary');
       });
 
-      it('always renders percentages', function () {
+      it('always renders percentages for non-null values', function () {
         lineLabel.render();
         var labels = lineLabel.$el.find('figcaption ol li');
-        expect(labels.eq(0).find('.percentage')).toHaveText('(99.9%)');
-        expect(labels.eq(1).find('.percentage')).toHaveText('(0.1%)');
+        expect(labels.eq(0).find('.percentage').text()).toContain('(60%)');
       });
+
+      it('always renders no-data for null values', function () {
+        lineLabel.render();
+        var labels = lineLabel.$el.find('figcaption ol li');
+        expect(labels.eq(1).text()).toContain('(no data)');
+      });
+
     });
 
   });


### PR DESCRIPTION
This was particularly bad for lines showing totals for other lines in the
graph.

https://www.pivotaltracker.com/n/projects/911874/stories/74682680
