### PR TITLE
Stop using mean() when displaying volumetrics data

### DIFF
--- a/app/common/views/visualisations/volumetrics/number.js
+++ b/app/common/views/visualisations/volumetrics/number.js
@@ -13,7 +13,9 @@ function (SingleStatView) {
     },
 
     getValue: function () {
-      return this.formatValue(this.collection.lastDefined(this.valueAttr).get(this.valueAttr));
+      var lastDefined = this.collection.lastDefined(this.valueAttr);
+      var val = lastDefined ? lastDefined.get(this.valueAttr) : null;
+      return this.formatValue(val);
     },
 
     getLabel: function () {

--- a/spec/client/views/visualisations/volumetrics/spec.number.js
+++ b/spec/client/views/visualisations/volumetrics/spec.number.js
@@ -37,10 +37,20 @@ function (VolumetricsNumberView, View, Collection) {
 
     describe('getValue', function () {
       it('should call the view format method with the last defined model (valueAttr) on the collection', function () {
-        spyOn(VolumetricsNumberView.prototype, 'formatValue').andReturn('456');
-        var returnValue = subject.getValue();
+        spyOn(VolumetricsNumberView.prototype, 'formatValue');
+
+        subject.getValue();
+
         expect(VolumetricsNumberView.prototype.formatValue).toHaveBeenCalledWith(4);
-        expect(returnValue).toEqual('456');
+      });
+
+      it('should call the view format method with null if there is no last defined models in the collection', function () {
+        spyOn(VolumetricsNumberView.prototype, 'formatValue');
+        spyOn(Collection.prototype, 'lastDefined').andReturn(undefined);
+
+        subject.getValue();
+
+        expect(VolumetricsNumberView.prototype.formatValue).toHaveBeenCalledWith(null);
       });
     });
 


### PR DESCRIPTION
We now get the last model with data from the collection.
