### PR TITLE
Fix start dates following migration

### DIFF
--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -294,7 +294,7 @@
         "data-group": "carers-allowance",
         "data-type": "journey",
         "query-params": {
-          "start_at": "2014-05-19T01:00:00Z",
+          "start_at": "2014-05-19T00:00:00Z",
           "period": "week",
           "collect": [
             "uniqueEvents:sum"

--- a/app/support/stagecraft_stub/responses/g-cloud.json
+++ b/app/support/stagecraft_stub/responses/g-cloud.json
@@ -67,7 +67,7 @@
         "data-type": "sales",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "group_by": "sme_large",
           "collect": [
             "cumulative_spend:sum"
@@ -115,7 +115,7 @@
         "data-type": "sales",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "group_by": "sme_large",
           "collect": [
             "monthly_spend:sum"
@@ -158,7 +158,7 @@
         "data-type": "sales",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "collect": [
             "monthly_spend:sum"
           ],
@@ -229,7 +229,7 @@
         "data-type": "sales",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "group_by": "sector",
           "collect": [
             "cumulative_spend:sum"
@@ -289,7 +289,7 @@
         "data-type": "sales",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "group_by": "lot",
           "collect": [
             "monthly_spend:sum"

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/tax.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/tax.json
@@ -162,7 +162,7 @@
         "data-type": "receipts",
         "query-params": {
           "period": "quarter",
-          "start_at": "2008-04-01T01:00:00Z",
+          "start_at": "2008-04-01T00:00:00Z",
           "group_by": "service_slug",
           "collect": [
             "count:sum"
@@ -275,7 +275,7 @@
         "data-type": "receipts",
         "query-params": {
           "period": "quarter",
-          "start_at": "2008-04-01T01:00:00Z",
+          "start_at": "2008-04-01T00:00:00Z",
           "group_by": "service_slug",
           "collect": [
             "count:sum"

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/vat-registrations.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/vat-registrations.json
@@ -130,8 +130,8 @@
           "filter_by": [
             "registration_type:total-registrations"
           ],
-          "start_at": "2013-04-01T01:00:00Z",
-          "end_at": "2014-04-01T01:00:00Z"
+          "start_at": "2013-04-01T00:00:00Z",
+          "end_at": "2014-04-01T00:00:00Z"
         }
       }
     },
@@ -189,8 +189,8 @@
         "data-type": "registrations",
         "query-params": {
           "period": "month",
-          "start_at": "2013-04-01T01:00:00Z",
-          "end_at": "2014-04-01T01:00:00Z",
+          "start_at": "2013-04-01T00:00:00Z",
+          "end_at": "2014-04-01T00:00:00Z",
           "group_by": "registration_type",
           "collect": [
             "count:sum"

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
@@ -151,7 +151,7 @@
         "data-type": "receipts",
         "query-params": {
           "period": "month",
-          "start_at": "2012-04-01T01:00:00Z",
+          "start_at": "2012-04-01T00:00:00Z",
           "group_by": "receipts",
           "collect": [
             "count:sum"


### PR DESCRIPTION
The migration of dataset parameters caused an hour of timezone-ness to get added to the dates. This resulted in the first data point of the sets to return "no-data" (since I assume the monthly data is all in the database at a timestamp of midnight on the first of the month)
