### PR TITLE
Remove pinned date on carer's dashboard

### DIFF
--- a/app/support/stagecraft_stub/responses/carers-allowance.json
+++ b/app/support/stagecraft_stub/responses/carers-allowance.json
@@ -294,7 +294,6 @@
         "data-group": "carers-allowance",
         "data-type": "journey",
         "query-params": {
-          "start_at": "2014-05-19T00:00:00Z",
           "period": "week",
           "collect": [
             "uniqueEvents:sum"


### PR DESCRIPTION
We added this in to stop the graph looking funny when there wasn't enough data.

There is now enough data.

https://www.pivotaltracker.com/story/show/72963084
