### PR TITLE
Remove extra homepage paragraph

### DIFF
--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -9,10 +9,6 @@
       <p class="lead">
         Our dashboards show you how services are doing, like how much they cost to run and how many people use them.
       </p>
-
-      <p class="lead">
-      The dashboards show the latest information about a service as soon as it becomes available. This lets you see how particular services are doing right now.
-      </p>
     </section>
 
     <aside>


### PR DESCRIPTION
Remove extra paragraph on the homepage because it makes the intro paragraph take up more than a whole iPhone screen. Show, don't tell...and all that.
