### PR TITLE
Use simple lines for line graphs

### DIFF
--- a/app/common/views/visualisations/availability/response-time-graph.js
+++ b/app/common/views/visualisations/availability/response-time-graph.js
@@ -26,7 +26,7 @@ function (Graph) {
           }
         },
         stack: {
-          view: this.sharedComponents.stack
+          view: this.sharedComponents.line
         },
         tooltip: {
           view: this.sharedComponents.tooltip,

--- a/app/common/views/visualisations/volumetrics/completion-graph.js
+++ b/app/common/views/visualisations/volumetrics/completion-graph.js
@@ -21,7 +21,7 @@ function (Graph) {
           }
         },
         stack: {
-          view: this.sharedComponents.stack
+          view: this.sharedComponents.line
         },
         hover: {
           view: this.sharedComponents.hover

--- a/app/common/views/visualisations/volumetrics/submissions-graph.js
+++ b/app/common/views/visualisations/volumetrics/submissions-graph.js
@@ -11,7 +11,7 @@ function (Graph) {
       values = {
         xaxis: { view: this.sharedComponents.xaxis },
         yaxis: { view: this.sharedComponents.yaxis },
-        stack: { view: this.sharedComponents.stack },
+        stack: { view: this.sharedComponents.line },
         hover: { view: this.sharedComponents.hover },
         callout: { view: this.sharedComponents.callout }
       };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {
-    "cheapseats": "git+https://github.com/alphagov/cheapseats#9fc2f2032ae0a4ab653d3c4fdc93fa09ae738137",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats#05e7e0d79af20549685700f07134f5e8978bdcad",
     "supervisor": "0.5.7"
   }
 }

--- a/styles/common/single-decker-graph.scss
+++ b/styles/common/single-decker-graph.scss
@@ -53,9 +53,6 @@
         display: inherit;
       }
 
-      .stack {
-        fill: none;
-      }
     }
   }
 


### PR DESCRIPTION
Line graphs were using stacks with a white background, instead of just being lines.

Using lines instead of stacks keeps the code simpler, since it doesn't add extra "invisible" elements.
