### PR TITLE
Fix urls for error-ed modules

### DIFF
--- a/app/client/controllers/dashboard.js
+++ b/app/client/controllers/dashboard.js
@@ -1,5 +1,5 @@
 define([
-  'extensions/controllers/controller'
+  'extensions/controllers/dashboard'
 ], function (Controller) {
   return Controller.extend({
 
@@ -8,17 +8,7 @@ define([
     },
 
     render: function (options) {
-      options = options || {};
-      this.moduleInstances = this.renderModules(
-        this.modules,
-        this.model,
-        {
-          dashboard: true,
-          url: this.url
-        },
-        { init: options.init },
-        _.bind(function () { this.trigger('ready'); }, this)
-      );
+      this.renderDashboard(options, _.bind(function () { this.trigger('ready'); }, this));
     }
   });
 });

--- a/app/extensions/controllers/dashboard.js
+++ b/app/extensions/controllers/dashboard.js
@@ -1,0 +1,22 @@
+define([
+  'extensions/controllers/controller'
+], function (Controller) {
+  return Controller.extend({
+
+    renderDashboard: function (options, callback) {
+      options = options || {};
+      this.moduleInstances = this.renderModules(
+        this.modules,
+        this.model,
+        function (model) {
+          return {
+            url: model.get('page-type') === 'module' ? this.url : this.url + '/' + model.get('slug')
+          };
+        }.bind(this),
+        { init: options.init },
+        callback
+      );
+    }
+
+  });
+});

--- a/app/server/controllers/dashboard.js
+++ b/app/server/controllers/dashboard.js
@@ -1,6 +1,6 @@
 var requirejs = require('requirejs');
 
-var Controller = requirejs('extensions/controllers/controller');
+var Controller = requirejs('extensions/controllers/dashboard');
 
 var DashboardView = require('../views/dashboard');
 var ContentDashboardView = require('../views/dashboards/content');
@@ -31,18 +31,7 @@ module.exports = Controller.extend({
   },
 
   render: function (options) {
-    options = options || {};
-    var pageType = this.model.get('page-type');
-    this.moduleInstances = this.renderModules(
-      this.modules,
-      this.model,
-      function (model) {
-        return {
-          url: pageType === 'module' ? this.url : this.url + '/' + model.get('slug')
-        };
-      }.bind(this),
-      { init: options.init },
-      Controller.prototype.render.bind(this, options)
-    );
+    this.renderDashboard(options, Controller.prototype.render.bind(this, options));
   }
+
 });

--- a/spec/client/controllers/spec.dashboard.js
+++ b/spec/client/controllers/spec.dashboard.js
@@ -1,0 +1,54 @@
+define([
+  'client/controllers/dashboard',
+  'extensions/controllers/controller',
+  'backbone'
+], function (DashboardController, BaseController, Backbone) {
+
+  describe('Dashboard Controller', function () {
+
+    var controller, model, moduleSpy, renderSpy;
+
+    beforeEach(function () {
+      renderSpy = jasmine.createSpy();
+      moduleSpy = jasmine.createSpy().andReturn({
+        render: renderSpy,
+        once: function () {}
+      });
+      model = new Backbone.Model({
+        modules: [
+          { slug: 'foo', controller: moduleSpy },
+          { slug: 'bar', controller: moduleSpy }
+        ]
+      });
+      controller = new DashboardController({
+        model: model,
+        url: '/test'
+      });
+    });
+
+    describe('render', function () {
+
+      it('creates instances of modules and renders them', function () {
+        controller.render();
+        expect(moduleSpy.calls.length).toEqual(2);
+        expect(renderSpy.calls.length).toEqual(2);
+      });
+
+      it('passes correct module urls to modules', function () {
+        controller.render();
+        expect(moduleSpy).toHaveBeenCalledWith({
+          model: jasmine.any(Backbone.Model),
+          url: '/test/foo'
+        });
+        expect(moduleSpy).toHaveBeenCalledWith({
+          model: jasmine.any(Backbone.Model),
+          url: '/test/bar'
+        });
+      });
+
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
Client-side controllers were not passing correct page-per-thing urls to error view when backdrop failed, making debugging hard because you couldn't click through to get a json link.

Share the code that renders modules between client and server dashboard controllers to have a single implementation of this code.
