### PR TITLE
Remove the requirejs-ness from purely node modules

### DIFF
--- a/app/environment_config.js
+++ b/app/environment_config.js
@@ -1,26 +1,21 @@
-define([
-  'path',
-  'fs'
-],
-function (path, fs) {
+var path = require('path');
+var fs = require('fs');
 
-  return {
-    configure: function (env, options) {
+module.exports = {
+  configure: function (env, options) {
 
-      var configFileName = function (key) {
-        return ['config.', key, '.json'].join('');
-      };
+    var configFileName = function (key) {
+      return ['config.', key, '.json'].join('');
+    };
 
-      // If we're in development and the personal gitignored config file exists, use it
-      if (env === 'development' && fs.existsSync(path.join('config', configFileName('development_personal')))) {
-        env = 'development_personal';
-      }
-
-      var config = JSON.parse(fs.readFileSync(path.join('config', configFileName(env))));
-
-      var filteredOptions = _.pick(options, _.keys(config));
-      return _.extend(config, filteredOptions);
+    // If we're in development and the personal gitignored config file exists, use it
+    if (env === 'development' && fs.existsSync(path.join('config', configFileName('development_personal')))) {
+      env = 'development_personal';
     }
-  };
 
-});
+    var config = JSON.parse(fs.readFileSync(path.join('config', configFileName(env))));
+
+    var filteredOptions = _.pick(options, _.keys(config));
+    return _.extend(config, filteredOptions);
+  }
+};

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,16 +1,11 @@
-define([
-  'winston'
-],
-function (winston) {
-  var logger = new (winston.Logger)({
-    transports: [
-      // In development we log debug messages to the console by default
-      new (winston.transports.Console)({
-        level: 'debug',
-        colorize: true
-      })
-    ]
-  });
+var winston = require('winston');
 
-  return logger;
+module.exports = new (winston.Logger)({
+  transports: [
+    // In development we log debug messages to the console by default
+    new (winston.transports.Console)({
+      level: 'debug',
+      colorize: true
+    })
+  ]
 });

--- a/app/server.js
+++ b/app/server.js
@@ -31,8 +31,8 @@ global.isServer = true;
 global.isClient = false;
 
 global._ = require('lodash');
-global.config = requirejs('environment_config').configure(environment, argv);
-global.logger = requirejs('logger');
+global.config = require('./environment_config').configure(environment, argv);
+global.logger = require('./logger');
 
 //App stuff
 


### PR DESCRIPTION
Using requirejs instead of require for modules which are only ever executed in a Node environment is a significant code smell.

See https://github.com/alphagov/spotlight/pull/737/files?w=1 for diff without indentation changes
