### PR TITLE
Updated package to forked version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,7 +286,7 @@ module.exports = function (grunt) {
   // Load external module tasks
   [
     'grunt-contrib-jasmine',
-    'grunt-jasmine-node',
+    'grunt-jasmine-node-new',
     'grunt-contrib-jshint',
     'grunt-contrib-clean',
     'grunt-contrib-requirejs',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-watch": "0.6.1",
     "grunt-digest": "0.1.2",
-    "grunt-jasmine-node": "0.2.1",
+    "grunt-jasmine-node-new": "0.3.2",
     "grunt-sass": "0.12.1",
     "grunt-shell": "0.7.0",
     "jquery": "1.8.3",


### PR DESCRIPTION
The original grunt-jasmine-node package is unmaintained and had a critical bug where it would return false positives if test specs contained errors. Use a forked version of g-j-n which includes a fix for this bug.

Also includes fix for bug in grunt-jasmine-node which prevented it from respecting the `verbose` option.
