### PR TITLE
Fix model lookup for page-type

### DIFF
--- a/app/extensions/controllers/dashboard.js
+++ b/app/extensions/controllers/dashboard.js
@@ -10,7 +10,7 @@ define([
         this.model,
         function (model) {
           return {
-            url: model.get('page-type') === 'module' ? this.url : this.url + '/' + model.get('slug')
+            url: model.get('parent').get('page-type') === 'module' ? this.url : this.url + '/' + model.get('slug')
           };
         }.bind(this),
         { init: options.init },

--- a/spec/client/controllers/spec.dashboard.js
+++ b/spec/client/controllers/spec.dashboard.js
@@ -34,7 +34,7 @@ define([
         expect(renderSpy.calls.length).toEqual(2);
       });
 
-      it('passes correct module urls to modules', function () {
+      it('adds slugs to module urls', function () {
         controller.render();
         expect(moduleSpy).toHaveBeenCalledWith({
           model: jasmine.any(Backbone.Model),
@@ -43,6 +43,19 @@ define([
         expect(moduleSpy).toHaveBeenCalledWith({
           model: jasmine.any(Backbone.Model),
           url: '/test/bar'
+        });
+      });
+
+      it('does not add slugs to module url if page type is "module"', function () {
+        model.set('page-type', 'module');
+        controller.render();
+        expect(moduleSpy).toHaveBeenCalledWith({
+          model: jasmine.any(Backbone.Model),
+          url: '/test'
+        });
+        expect(moduleSpy).toHaveBeenCalledWith({
+          model: jasmine.any(Backbone.Model),
+          url: '/test'
         });
       });
 


### PR DESCRIPTION
Was looking for model.page-type, which broke image fallbacks on page-per-thing. The actual value was on the parent.
