### PR TITLE
Fix config test

### DIFF
--- a/spec/server-pure/spec.environment_config.js
+++ b/spec/server-pure/spec.environment_config.js
@@ -18,6 +18,7 @@ describe('environmentConfig', function () {
     resultingConfigObject = environmentJson;
     resultingConfigObject.backdropUrl = args.backdropUrl;
     resultingConfigObject.screenshotTargetUrl = args.screenshotTargetUrl;
+    spyOn(fs, 'existsSync').andReturn(false);
   });
 
   describe('configure', function () {


### PR DESCRIPTION
The test failed if you modified your local config, which is stupid. Stubbing out fs.existsSync means it never looks at your local config.
