### PR TITLE
Render "nice" error pages for failed SSaaS requests

### DIFF
--- a/app/render_png.js
+++ b/app/render_png.js
@@ -1,18 +1,40 @@
 var http = require('http');
 var url = require('url');
 
+var requirejs = require('requirejs');
+
+var ErrorController = require('./server/controllers/error');
+var Model = requirejs('extensions/models/model');
+var PageConfig = requirejs('page_config');
+
 var renderPng = function (req, res) {
   var options = url.parse(renderPng.getScreenshotPath(req));
   http.get(options, function (screenshot) {
-    res.status(screenshot.statusCode);
-    for (var i in screenshot.headers) {
-      res.setHeader(i, screenshot.headers[i]);
+    if (screenshot.statusCode > 399) {
+      return renderError(screenshot.statusCode, req, res);
+    } else {
+      res.status(screenshot.statusCode);
+      for (var i in screenshot.headers) {
+        res.setHeader(i, screenshot.headers[i]);
+      }
+      screenshot.pipe(res);
     }
-    screenshot.pipe(res);
-  }).on('error', function (e) {
-    res.status(500);
-    res.send('Got error: ' + e.message);
+  }).on('error', function () {
+    renderError(500, req, res);
   });
+};
+
+var renderError = function (status, req, res) {
+  var model = new Model({
+    status: status || 500
+  });
+  model.set(PageConfig.commonConfig(req));
+  var error = new ErrorController({
+    model: model
+  });
+  error.render();
+  res.statusCode = status;
+  res.send(error.html);
 };
 
 if (global.config) {


### PR DESCRIPTION
If the page SSaaS is trying to screenshot fails for whatever reason, render a standard error page.

e.g. http://localhost:3057/performance/nope.png
