### PR TITLE
Push spotlight server response times to statsd

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -19,6 +19,7 @@ module.exports = {
     app.disable('x-powered-by');
 
     (function () {
+      app.use(require('./stats'));
       app.set('environment', environment);
       app.set('requirePath', requireBaseUrl || '/app/');
       app.set('assetPath', global.config.assetPath);

--- a/app/process_request.js
+++ b/app/process_request.js
@@ -20,6 +20,7 @@ var renderContent = function (req, res, model) {
     if (model.get('published') !== true) {
       res.set('X-Robots-Tag', 'none');
     }
+    req['spotlight-dashboard-slug'] = model.get('slug');
     res.send(controller.html);
   });
 

--- a/app/stats/index.js
+++ b/app/stats/index.js
@@ -1,0 +1,14 @@
+var morgan  = require('morgan');
+
+var StatsD = require('node-statsd').StatsD;
+var client = new StatsD({
+  prefix: global.config.statsdPrefix || ''
+});
+
+var stats = {
+  loadtime: require('./load-time')
+};
+
+module.exports = morgan(function (mgn, req, res) {
+  stats.loadtime(mgn, req, res, client);
+});

--- a/app/stats/load-time.js
+++ b/app/stats/load-time.js
@@ -1,0 +1,7 @@
+module.exports = function (morgan, req, res, statsd) {
+  if (req['spotlight-dashboard-slug']) {
+    var responseTime = morgan['response-time'](req, res);
+    statsd.timing('.response_time', responseTime);
+    statsd.timing('.dashboards.' + req['spotlight-dashboard-slug'] + '.response_time', responseTime);
+  }
+};

--- a/config/config.development.json
+++ b/config/config.development.json
@@ -4,5 +4,6 @@
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
-  "govukHost": "www.alphagov.co.uk"
+  "govukHost": "www.alphagov.co.uk",
+  "statsdPrefix": "pp.apps.spotlight"
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mustache": "0.8.2",
     "node-basicauth": "0.0.9",
     "node-sass": "0.9.3",
+    "node-statsd": "0.0.7",
     "optimist": "0.6.1",
     "q": "1.0.1",
     "requirejs": "2.1.14",


### PR DESCRIPTION
Wrap in morgan logging middleware because then the stats are automatically fired on request end, and with some useful metadata.

Middleware is declared at the top of the stack to ensure response times include _all_ processing that is performed.

Depends on https://github.gds/gds/pp-deployment/pull/357
