### PR TITLE
Add maxLength to JSON schema for dashboard title

### DIFF
--- a/schema/dashboard.json
+++ b/schema/dashboard.json
@@ -33,7 +33,8 @@
     },
     "title": {
       "type": "string",
-      "required": true
+      "required": true,
+      "maxLength": 80
     },
     "description": {
       "type": "string",


### PR DESCRIPTION
Django models require that strings have a maximum length that is a positive integer, so let's do that now.
