### PR TITLE
Fix table sorting for date range columns

### DIFF
--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -42,10 +42,14 @@ function (View, Formatters) {
       var head = '';
       head += _.map(this.getColumns(), function (column) {
         var label = column.label;
+        var key = column.key;
         if (column.timeshift) {
           label += ' (' + column.timeshift + ' ' + this.period + 's ago)';
         }
-        return '<th scope="col" data-key="' + column.key + '">' + label + '</th>';
+        if (_.isArray(column.key)) {
+          key = column.key[0];
+        }
+        return '<th scope="col" data-key="' + key + '">' + label + '</th>';
       }, this).join('\n');
       return '<thead><tr>' + head + '</tr></thead>';
     },

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -188,6 +188,20 @@ function (Table, View, Collection, $) {
         expect(table.collection.sortByAttr).toHaveBeenCalledWith('timestamp', false);
       });
 
+      it('adds column keys as data attrs to header cells', function () {
+        table.render();
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('timestamp');
+        expect(table.$('th:eq(1)').attr('data-key')).toEqual('value');
+        expect(table.$('th:eq(2)').attr('data-key')).toEqual('timeshift52:value');
+        expect(table.$('th:eq(3)').attr('data-key')).toEqual('value');
+      });
+
+      it('adds first key as data attrs to header cell if key is an array', function () {
+        table.collection.options.axes.x.key = ['start', 'end'];
+        table.render();
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('start');
+      });
+
     });
 
   });


### PR DESCRIPTION
Because column key is an array, adding the key as a data attr added a comma separated list, which then can't be used to lookup. Just use the start point of the range for sorting in this case.

Fixes https://www.pivotaltracker.com/story/show/77623752
