### PR TITLE
Remove computed date diffs from tests

### DIFF
--- a/spec/client/views/spec.visitors-realtime.js
+++ b/spec/client/views/spec.visitors-realtime.js
@@ -210,6 +210,11 @@ function (VisitorsRealtimeView, Collection, Model, template) {
             }
           }
         };
+        spyOn(view, 'moment').andReturn({
+          fromNow: function () {
+            return '12 years ago';
+          }
+        });
         var returnValue = view.getLabelSelected(fakeSelection);
         expect(returnValue.headline).toEqual('users 1 Mar 2002,<br />12 years ago');
         expect(returnValue.graph).toEqual('');


### PR DESCRIPTION
Having a hard-coded date and a computed diff means that that test will fail and need fixing once a year.

By stubbing the method we stop being dependent on the date diffs actually matching the current date.
