### PR TITLE
Updated copy on Warwickshire dashboard

### DIFF
--- a/app/support/stagecraft_stub/responses/warwickshire-library-item-renewals.json
+++ b/app/support/stagecraft_stub/responses/warwickshire-library-item-renewals.json
@@ -4,7 +4,7 @@
   "dashboard-type": "transaction",
   "published": false,
   "strapline": "Dashboard",
-  "title": "Warwickshire library book renewals",
+  "title": "Warwickshire library item renewals",
   "department": {
     "title": "Warwickshire County Council"
   },
@@ -19,8 +19,8 @@
   "modules": [
     {
       "slug": "transactions-by-channel",
-      "title": "Book renewals breakdown",
-      "description": "Which channels are used to make book renewals",
+      "title": "Item renewals breakdown",
+      "description": "Which channels are used to make library item renewals",
       "module-type": "grouped_timeseries",
       "value-attribute": "count:sum",
       "show-line-labels": true,
@@ -64,7 +64,7 @@
       "slug": "digital-takeup",
       "module-type": "completion_rate",
       "title": "Digital take-up",
-      "description": "Proportion of applications made using the digital service",
+      "description": "Proportion of renewals made using the digital service",
       "denominator-matcher": "^(.)*$",
       "numerator-matcher": "^online$",
       "matching-attribute": "channel",


### PR DESCRIPTION
Renewals is not just books, could be CDs etc. Copy updated to reflect this.
