### PR TITLE
Fix image fallbacks for journey module

### DIFF
--- a/app/server/views/visualisation.js
+++ b/app/server/views/visualisation.js
@@ -1,12 +1,15 @@
 var requirejs = require('requirejs');
+var path = require('path');
 
 var View = requirejs('extensions/views/view');
 
-module.exports = View.extend({
+var templater = require('../mixins/templater');
+var templatePath = path.resolve(__dirname, '../templates/visualisation.html');
 
-  render: function () {
-    View.prototype.render.apply(this, arguments);
-    this.$el.attr('data-src', this.fallbackUrl);
-  }
+module.exports = View.extend(templater).extend({
+
+  templatePath: templatePath,
+
+  templateType: 'mustache'
 
 });


### PR DESCRIPTION
Noscript & img tags were not being output when JS was disabled for certain modules (in particular journey modules).
