### PR TITLE
Fix client-side logging in IE9

### DIFF
--- a/app/client/logger.js
+++ b/app/client/logger.js
@@ -1,30 +1,10 @@
 define([],
 function () {
   window.logger = {
-    debug: function() {
-      if (console) {
-        console.info.apply(console, arguments);
-      }
-    },
-    error: function() {
-      if (console) {
-        console.error.apply(console, arguments);
-      }
-    },
-    info: function() {
-      if (console) {
-        console.info.apply(console, arguments);
-      }
-    },
-    log: function() {
-      if (console) {
-        console.log.apply(console, arguments);
-      }
-    },
-    warn: function() {
-      if (console) {
-        console.warn.apply(console, arguments);
-      }
-    }
+    debug: function() {},
+    error: function() {},
+    info: function() {},
+    log: function() {},
+    warn: function() {}
   };
 });


### PR DESCRIPTION
In Internet Explorer 9, console.log (and similar) do not support `apply()`.

This commit introduces _a lot_ of duplication, and I'm not even convinced it works (particularly well, or at all). But I don't have enough knowledge about what the client-side logging is meant to be doing.

See #771 for when this was introduced and http://stackoverflow.com/a/5473193/127687 for more info.
