### PR TITLE
We're changing view driving record to view driving licence

### DIFF
--- a/app/support/stagecraft_stub/responses/view-driving-licence.json
+++ b/app/support/stagecraft_stub/responses/view-driving-licence.json
@@ -4,7 +4,7 @@
   "dashboard-type": "transaction",
   "published": true,
   "strapline": "Dashboard",
-  "title": "View driving licence",
+  "title": "Driving licence views",
   "description": "Find out which vehicles you can drive, penalty points and when your licence expires.",
   "department": {
     "title": "Department for Transport",
@@ -16,7 +16,7 @@
   },
   "relatedPages": {
     "transaction": {
-      "title": "View your driving licence information",
+      "title": "View driving licence",
       "url": "https://www.gov.uk/view-driving-licence"
     }
   },


### PR DESCRIPTION
We will redirect the old page after this gets merged.
After conversations with @alexmuller and @jabley we've decided to leave the
data group as is for now. We have data group inconsistencies elsewhere
and changing this will introduce alot of complexity into this.
