### PR TITLE
Update slug to match the filename

### DIFF
--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
@@ -1,5 +1,5 @@
 {
-  "slug": "hmrc-tier-two-VAT",
+  "slug": "vat",
   "page-type": "dashboard",
   "dashboard-type": "other",
   "published": false,


### PR DESCRIPTION
I ran this -

`for file in app/support/stagecraft_stub/responses/**/*.json; do SLUG=$(cat $file | jq .slug | sed s/\"//g); NAME=$(basename $file); if [[ "${NAME%.*}" != $SLUG ]]; then echo ${NAME%.*}; echo $file; echo $SLUG; fi; done`

And all other filenames matched the slug. This also isnt a valid slug,
so fails the import
