### PR TITLE
Standardise casing of "Service Explorer" strapline

### DIFF
--- a/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes/vat.json
@@ -3,7 +3,7 @@
   "page-type": "dashboard",
   "dashboard-type": "other",
   "published": false,
-  "strapline": "Service explorer",
+  "strapline": "Service Explorer",
   "title": "VAT",
   "tagline": "",
   "relatedPages": {


### PR DESCRIPTION
Because we only allow certain options for strapline in stagecraft, we
should standardise where these are used.
