### PR TITLE
Move hmrc-prototypes to top level to resolve slug issues

### DIFF
--- a/app/support/stagecraft_stub/responses/hmrc-prototypes-hmrc-operations.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes-hmrc-operations.json
@@ -1,5 +1,5 @@
 {
-  "slug": "hmrc-operations",
+  "slug": "hmrc-prototypes-hmrc-operations",
   "page-type": "dashboard",
   "dashboard-type": "other",
   "published": false,

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes-tax.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes-tax.json
@@ -1,5 +1,5 @@
 {
-  "slug": "tax",
+  "slug": "hmrc-prototypes-tax",
   "page-type": "dashboard",
   "dashboard-type": "other",
   "published": false,

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes-vat-content.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes-vat-content.json
@@ -1,5 +1,5 @@
 {
-  "slug": "vat-content",
+  "slug": "hmrc-prototypes-vat-content",
   "page-type": "dashboard",
   "dashboard-type": "content",
   "published": false,

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes-vat-registrations.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes-vat-registrations.json
@@ -1,5 +1,5 @@
 {
-  "slug": "vat-registrations",
+  "slug": "hmrc-prototypes-vat-registrations",
   "page-type": "dashboard",
   "dashboard-type": "transaction",
   "published": false,

--- a/app/support/stagecraft_stub/responses/hmrc-prototypes-vat.json
+++ b/app/support/stagecraft_stub/responses/hmrc-prototypes-vat.json
@@ -1,5 +1,5 @@
 {
-  "slug": "vat",
+  "slug": "hmrc-prototypes-vat",
   "page-type": "dashboard",
   "dashboard-type": "other",
   "published": false,


### PR DESCRIPTION
- Migration would currently incorrectly render migrated hmrc-prototypes/something
- The slug now indicates that the dashboard is a prototype without being in a sub directory
