### PR TITLE
Correct slug to use - instead of _

### DIFF
--- a/app/support/stagecraft_stub/responses/experimental/solihull-local-authority.json
+++ b/app/support/stagecraft_stub/responses/experimental/solihull-local-authority.json
@@ -75,7 +75,7 @@
       }
     },
     {
-      "slug": "missed_bin-by-ward",
+      "slug": "missed-bin-by-ward",
       "module-type": "table",
       "title": "Missed bins by ward",
       "description": "Wards where missed bins were reported in the past week",


### PR DESCRIPTION
Now we validate modules the migration script has picked this up.
