### PR TITLE
Set longer Cache-Control headers

### DIFF
--- a/app/process_request.js
+++ b/app/process_request.js
@@ -16,7 +16,7 @@ var renderContent = function (req, res, model) {
   });
 
   controller.once('ready', function () {
-    res.set('Cache-Control', 'public, max-age=120');
+    res.set('Cache-Control', 'public, max-age=600');
     if (model.get('published') !== true) {
       res.set('X-Robots-Tag', 'none');
     }

--- a/app/server/controllers/about.js
+++ b/app/server/controllers/about.js
@@ -13,6 +13,6 @@ module.exports = function (req, res) {
   });
   view.render();
 
-  res.set('Cache-Control', 'public, max-age=900');
+  res.set('Cache-Control', 'public, max-age=7200');
   res.send(view.html);
 };

--- a/app/server/controllers/homepage.js
+++ b/app/server/controllers/homepage.js
@@ -21,6 +21,6 @@ module.exports = function (req, res) {
   });
   view.render();
 
-  res.set('Cache-Control', 'public, max-age=120');
+  res.set('Cache-Control', 'public, max-age=7200');
   res.send(view.html);
 };

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -35,6 +35,6 @@ module.exports = function (req, res) {
   });
   view.render();
 
-  res.set('Cache-Control', 'public, max-age=120');
+  res.set('Cache-Control', 'public, max-age=7200');
   res.send(view.html);
 };

--- a/app/server/controllers/web-traffic.js
+++ b/app/server/controllers/web-traffic.js
@@ -35,6 +35,6 @@ module.exports = function (req, res) {
   });
   view.render();
 
-  res.set('Cache-Control', 'public, max-age=120');
+  res.set('Cache-Control', 'public, max-age=600');
   res.send(view.html);
 };

--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -126,7 +126,7 @@ describe('Services Controller', function () {
 
   it('has an explicit caching policy', function () {
     controller(req, res);
-    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=120');
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=7200');
   });
 
 });

--- a/spec/server-pure/spec.process_request.js
+++ b/spec/server-pure/spec.process_request.js
@@ -124,7 +124,7 @@ describe('processRequest middleware', function () {
       var controller = processRequest.renderContent(req, res, model);
       controller.html = 'test content';
       controller.trigger('ready');
-      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=120');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=600');
     });
 
     it('instructs search engines not to index unpublished dashboards', function () {


### PR DESCRIPTION
This commit sets the following Cache-Control headers:
- 600 seconds (10 minutes) for things that look like dashboards. This means that realtime data may initially be out of date on page load, but will be updated immediately after. No other modules have a granualarity of less than 1 hour. Most are updated daily.
- 7200 seconds (2 hours) on information pages like the homepage, services page and about page. These pages are so infrequently updated. If we did need to update them urgently, we could flush the cache.

I'm not sure why the homepage ever had a cache time of 2 minutes, except that in June I thought it was a good idea (#555).
