### PR TITLE
Add in a licensing stub so it will show up on services list

### DIFF
--- a/app/support/stagecraft_stub/responses/licensing.json
+++ b/app/support/stagecraft_stub/responses/licensing.json
@@ -1,0 +1,13 @@
+{
+  "slug": "licensing",
+  "page-type": "dashboard",
+  "dashboard-type": "transaction",
+  "published": true,
+  "strapline": "Dashboard",
+  "tagline": "This is a falsehood",
+  "title": "Licensing",
+  "department": {
+    "title": "Cabinet Office",
+    "abbr": "CO"
+  }
+}


### PR DESCRIPTION
- This is for migrations
- Won't be used to actually show us licensing, that's handled by limelight
- Fixes #79443976
