### PR TITLE
Add an empty modules array

### DIFF
--- a/app/support/stagecraft_stub/responses/licensing.json
+++ b/app/support/stagecraft_stub/responses/licensing.json
@@ -9,5 +9,7 @@
   "department": {
     "title": "Cabinet Office",
     "abbr": "CO"
-  }
+  },
+  "modules": [
+  ]
 }


### PR DESCRIPTION
Migration script requires dashboards to have modules as a key within the
json
