### PR TITLE
Remove licensing hardcoded to services list

### DIFF
--- a/tools/generate-services-list.js
+++ b/tools/generate-services-list.js
@@ -7,13 +7,7 @@ var fs = require('graceful-fs'),
 var stagecraftStubDir = path.resolve(__dirname, '../app/support/stagecraft_stub/responses'),
     stagecraftStubGlob = path.resolve(stagecraftStubDir, '**/*.json');
 
-var dashboards = [
-  {
-    slug: 'licensing',
-    title: 'Licensing',
-    'dashboard-type': 'transaction'
-  }
-];
+var dashboards = [];
 
 var departments = [],
     agencies = [];


### PR DESCRIPTION
- Otherwise we'll end up with two in the services list when we've run the json migrations
### Whoops:

![](http://cl.ly/image/2V2E1M2v2w3S/Screen%20Shot%202014-09-24%20at%2016.17.33.png)
