### PR TITLE
Fix for 501 in pages requiring a dashboard list

### DIFF
--- a/app/server/mixins/get_dashboard_and_render.js
+++ b/app/server/mixins/get_dashboard_and_render.js
@@ -27,7 +27,7 @@ var get_dashboard_and_render = function (req, res, renderContent) {
   });
   client_instance.on('sync', function () {
     client_instance.off();
-    res.status(client_instance.get('status'));
+    res.status(200);
     renderContent(req, res, client_instance);
   });
 


### PR DESCRIPTION
Hi Ben!

While you were gone we changed the services, homepage, and webtraffic pages to use the stagecraft api client to get the dashboards.json (and fall back to the local config if this failed). This makes the logic around giving a 501 if there is no dashboard type somewhat weird but I didn't think hard enough about it to get rid of it which was dumb. 

This change basically ignores this 501 and set's the status to 200 for any successful sync, thus fixing the 501 on the homepage. Perhaps this should be different in process_request.js (where the dashboard-type is a thing) or perhaps we should rethink the 501 altogether.

See this for the earlier changes:

https://github.com/alphagov/spotlight/pull/796
