### PR TITLE
Stagecraft client

### DIFF
--- a/app/stagecraft_api_client.js
+++ b/app/stagecraft_api_client.js
@@ -82,7 +82,7 @@ function (Model) {
       }, this);
 
       // the response from /dashboards in stagecraft doesn't return a page-type
-      if (!controller && this.path.length) {
+      if (!controller && this.path && this.path.length) {
         data.controller = controllerMap.error;
         data.status = 501;
       } else {


### PR DESCRIPTION
We currently serve up a 501 for the service dashboards page.

This is because the response from stagecraft doesn't return a page-type so we end up service not implemented.

To get round this we can use the path. If we're not using a path we can assume we're hitting /dashboards and serve up a 200.

Tests for this has been added also.
