### PR TITLE
Log GOVUK-RequestId

### DIFF
--- a/app/extensions/collections/collection.js
+++ b/app/extensions/collections/collection.js
@@ -27,7 +27,7 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
         this.fetch({ reset: true });
       }, this);
       this.requestId = options.requestId || 'Not-Set';
-
+      this.govukRequestId = options.govukRequestId || 'Not-Set';
       Backbone.Collection.prototype.initialize.apply(this, arguments);
     },
 
@@ -106,11 +106,20 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
       }, this);
     },
 
-    fetch: function () {
+    fetch: function (options) {
       this.selectedItem = null;
       this.selectedIndex = null;
-      logger.info('Fetching <%s>', this.url(), { request_id: this.requestId });
-      return Backbone.Collection.prototype.fetch.apply(this, arguments);
+      options = _.extend({}, {
+        headers: {
+          'GOVUK-Request-Id': this.govukRequestId,
+          'Request-Id': this.requestId
+        }
+      }, options);
+      logger.info('Fetching <%s>', this.url(), {
+        request_id: this.requestId,
+        govuk_request_id: this.govukRequestId
+      });
+      return Backbone.Collection.prototype.fetch.call(this, options);
     },
 
     isXADate: function () {

--- a/app/extensions/controllers/controller.js
+++ b/app/extensions/controllers/controller.js
@@ -48,10 +48,18 @@ define([
         return null;
       };
 
+      var getGOVUKRequestId = function(m) {
+        if (m.get('parent')) {
+          return m.get('parent').get('govukRequestId');
+        }
+        return null;
+      };
+
       if (this.collectionClass && !this.collection) {
         this.collection = new this.collectionClass(this.collectionData(), _.extend({
           dataSource: this.model.get('data-source'),
-          requestId: getRequestId(this.model)
+          requestId: getRequestId(this.model),
+          govukRequestId: getGOVUKRequestId(this.model)
         }, this.collectionOptions()));
       }
 

--- a/app/page_config.js
+++ b/app/page_config.js
@@ -14,7 +14,8 @@ function () {
       environment: req.app.get('environment'),
       backdropUrl: req.app.get('backdropUrl'),
       clientRequiresCors: req.app.get('clientRequiresCors'),
-      requestId: req.get('Request-Id')
+      requestId: req.get('Request-Id'),
+      govukRequestId: req.get('GOVUK-Request-Id')
     };
   };
 

--- a/app/server/mixins/get_dashboard_and_render.js
+++ b/app/server/mixins/get_dashboard_and_render.js
@@ -6,7 +6,8 @@ var StagecraftApiClient = requirejs('stagecraft_api_client');
 var buildStagecraftApiClient = function(req){
   var this_client_instance = new StagecraftApiClient({}, {
     ControllerMap: controllerMap,
-    requestId: req.get('Request-Id')
+    requestId: req.get('Request-Id'),
+    govukRequestId: req.get('GOVUK-Request-Id')
   });
   this_client_instance.urlRoot = 'http://localhost:' + req.app.get('port') + '/stagecraft-stub';
   this_client_instance.stagecraftUrlRoot = req.app.get('stagecraftUrl') + '/public/dashboards';

--- a/app/stagecraft_api_client.js
+++ b/app/stagecraft_api_client.js
@@ -11,6 +11,7 @@ function (Model) {
     initialize: function (attrs, options) {
       this.controllers = options.ControllerMap;
       this.requestId = options.requestId || 'Not-Set';
+      this.govukRequestId = options.govukRequestId || 'Not-Set';
       Model.prototype.initialize.apply(this, arguments);
     },
 
@@ -40,11 +41,18 @@ function (Model) {
     fetch: function (options) {
       options = _.extend({}, {
         validate: true,
+        headers: {
+          'GOVUK-Request-Id': this.govukRequestId,
+          'Request-Id': this.requestId
+        },
         error: _.bind(function () {
           this.fetchFallback(options);
         }, this)
       }, options);
-      logger.info('Fetching <%s>', this.url(), { request_id: this.requestId });
+      logger.info('Fetching <%s>', this.url(), {
+        request_id: this.requestId,
+        govuk_request_id: this.govukRequestId
+      });
       Model.prototype.fetch.call(this, options);
     },
 

--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -21,7 +21,8 @@ describe('Services Controller', function () {
   var req = _.extend({
     get: function(key) {
       return {
-        'Request-Id':'Xb35Gt'
+        'Request-Id':'Xb35Gt',
+        'GOVUK-Request-Id': '1231234123'
       }[key];
     },
     query: {}

--- a/spec/server-pure/mixins/spec.get_dashboard_and_render.js
+++ b/spec/server-pure/mixins/spec.get_dashboard_and_render.js
@@ -20,7 +20,8 @@ describe('get_dashboard_and_render', function () {
     fake_request = {
       get: function(key) {
         return {
-          'Request-Id':'Xb35Gt'
+          'Request-Id':'Xb35Gt',
+          'GOVUK-Request-Id': '1231234123'
         }[key];
       },
       'app': {
@@ -38,7 +39,8 @@ describe('get_dashboard_and_render', function () {
       {}, 
       {
         ControllerMap: controllerMap,
-        requestId: 'Xb35Gt'
+        requestId: 'Xb35Gt',
+        govukRequestId: '1231234123'
       });
     expect(client_instance.urlRoot).toEqual('http://localhost:8989/stagecraft-stub');
     expect(client_instance.stagecraftUrlRoot).toEqual('urlURL/public/dashboards');

--- a/spec/server/spec.page_config.js
+++ b/spec/server/spec.page_config.js
@@ -16,7 +16,8 @@ function (PageConfig) {
       var headers = jasmine.createSpy();
       headers.plan = function(prop) {
         return {
-          'Request-Id': 'a-uuid'
+          'Request-Id': 'a-uuid',
+          'GOVUK-Request-Id': '1231234123'
         }[prop];
       };
       req = {


### PR DESCRIPTION
It’s helpful when comparing timings to see which request went from one
data centre to another and where any slow parts might be.

This also adds tracing by passing on the Request-Id and GOVUK-Request-Id
headers on to backdrop and stagecraft, via extending the options passed
to `fetch`.
