### PR TITLE
Set the width of "more info" for small modules

### DIFF
--- a/styles/common/module.scss
+++ b/styles/common/module.scss
@@ -74,6 +74,12 @@
           width: 33%;
         }
       }
+
+      &.cols2, &.cols3 {
+        .visualisation-moreinfo {
+          width: 100%;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When a module is only half or a third of the width of the page (cols2 or cols3), its "more info" is set to a third of that width.

This commit adds Sass so that the info on a small module is the size of the module.
