### PR TITLE
Make single-stat graph respect formatting options

### DIFF
--- a/app/client/views/visualisations/single-stat-graph.js
+++ b/app/client/views/visualisations/single-stat-graph.js
@@ -16,7 +16,7 @@ function (Graph) {
         hover: { view: this.sharedComponents.hover },
         callout: { view: this.sharedComponents.callout }
       };
-      if (this.formatOptions && this.formatOptions.type === 'duration') {
+      if (this.formatOptions) {
         values.yaxis.options = {};
         var self = this;
         values.yaxis.options.tickFormat = function () {

--- a/spec/client/views/visualisations/spec.single-stat-graph.js
+++ b/spec/client/views/visualisations/spec.single-stat-graph.js
@@ -52,6 +52,14 @@ function (SingleStatGraph, Collection, Model) {
         expect(tickFormat(120000)).toEqual('2m');
       });
 
+      it('should format ticks as percentages if specified', function () {
+        graph.formatOptions = {
+          type: 'percent'
+        };
+        var tickFormat = graph.components().yaxis.options.tickFormat.call(this);
+        expect(tickFormat(120000)).toContain('%');
+      });
+
     });
 
 


### PR DESCRIPTION
Single-stat graph should respect any formatting option set at
module level, not just duration.

This is required for the user satisfaction graph on the SLC
dashboard, which is formatted as a percentage. 
