### PR TITLE
[#79445154] Strip cachebust params from module urls

### DIFF
--- a/app/extensions/controllers/dashboard.js
+++ b/app/extensions/controllers/dashboard.js
@@ -9,8 +9,8 @@ define([
         this.modules,
         this.model,
         function (model) {
-          if(this.url && this.url.indexOf('?') !== -1){
-            this.url = this.url.split('?')[0];
+          if(this.url && (this.url.indexOf('?') !== -1 || this.url.indexOf('#') !== -1)) {
+            this.url = this.url.split('?')[0].split('#')[0];
           }
           return {
             url: model.get('parent').get('page-type') === 'module' ? this.url : this.url + '/' + model.get('slug')

--- a/spec/client/controllers/spec.dashboard.js
+++ b/spec/client/controllers/spec.dashboard.js
@@ -59,6 +59,19 @@ define([
         });
       });
 
+      it('does not use fragments in slug generation', function () {
+        controller = new DashboardController({
+          model: model,
+          url: '/test#hashBang'
+        });
+
+        controller.render();
+        expect(moduleSpy).toHaveBeenCalledWith({
+          model: jasmine.any(Backbone.Model),
+          url: '/test/foo'
+        });
+      });
+
       it('does not add slugs to module url if page type is "module"', function () {
         model.set('page-type', 'module');
         controller.render();


### PR DESCRIPTION
- `app/extensions/controllers/dashboard.js` checks for the presence of a url and any additional parameters, then strips parameters before building the module slug.
- This is much the same as with the client modifications in #816 (https://github.com/alphagov/spotlight/pull/816/files )
- I've added a test that should show that slugs attached to models should be free of param strings
