### PR TITLE
Use upstream winston rather than our fork

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -3,7 +3,7 @@
 var express = require('express');
 var fs = require('fs');
 var path = require('path');
-var winston = require('winston-alphagov');
+var winston = require('winston');
 var requirejs = require('requirejs');
 var basicAuth = require('node-basicauth');
 

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,4 +1,4 @@
-var winston = require('winston-alphagov');
+var winston = require('winston');
 
 module.exports = new (winston.Logger)({
   transports: [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "requirejs": "2.1.14",
     "sanitizer": "0.1.1",
     "uglify-js": "2.4.14",
-    "winston-alphagov": "0.7.4",
+    "winston": "0.8.1",
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
They’ve merged my pull request, so stop using our fork. Essentially this
change removes the ugliness from
abbfaa6eed650f783a64c769d72c01f7a3401fcc.
