### PR TITLE
Flat data for users at each stage module

### DIFF
--- a/app/common/collections/journey_series.js
+++ b/app/common/collections/journey_series.js
@@ -17,6 +17,7 @@ define([
 
       options.dataSource = options.dataSource || {};
       options.dataSource['query-params'] = _.extend(dateRange, options.dataSource['query-params']);
+      options.dataSource['query-params'] = _.extend(options.dataSource['query-params'], {flatten: true});
 
       Collection.prototype.initialize.apply(this, arguments);
     },

--- a/app/extensions/collections/collection.js
+++ b/app/extensions/collections/collection.js
@@ -129,7 +129,7 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
 
     flatten: function (data) {
 
-      if (this._isFlat()) {
+      if (this._isFlat() && this.dataSource.groupedBy()) {
         data = this.groupByValue({'data': data}, this.dataSource.groupedBy(), this.dataSource.getCollect())['data'];
       }
 
@@ -150,6 +150,7 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
           }, this);
         }
       }
+
       return data;
     },
 

--- a/spec/shared/extensions/collections/spec.collection.js
+++ b/spec/shared/extensions/collections/spec.collection.js
@@ -864,6 +864,34 @@ function (Collection, Model, DataSource, Backbone, moment, groupedFixture, multi
         expect(collection.findValue(data, 'foo', 'bar')).toEqual({foo:'bar'});
         expect(collection.findValue(data, 'bar', 'boff')).toEqual(false);
       });
+
+      it('returns the same values when no group has been passed', function () {
+        delete unflatDataSource['query-params']['group_by'];
+        delete flatDataSource['query-params']['group_by'];
+
+        var collection = new Collection(undefined, {
+          dataSource: unflatDataSource
+        });
+        var collectionFlat = new Collection(undefined, {
+          dataSource: flatDataSource
+        });
+        var data = {
+          data: [
+                  {
+                    foo: 'bar'
+                  },
+                  {
+                    foo: 'boff'
+                  }
+                ]
+        };
+
+        var parsedWithFlat = collectionFlat.parse(data);
+        var parsedWithUnFlat = collection.parse(data);
+
+        expect(parsedWithFlat).toEqual(parsedWithUnFlat);
+
+      });
     });
 
 


### PR DESCRIPTION
### :fire: Adds in `flatten:true` to the `query-params` of journey_series module :fire:
### :fist: Checks for `group_by` before flattening :fist:
- If we don't have a `group_by` value in the `data_source` we shouldn't attempt to regroup the data by this field.
- It looks like data comes out 'flat' if we don't have a `group_by` value.

![](http://41.media.tumblr.com/c0acb7186db24cff6537ed379db051fd/tumblr_n9vf34Y74r1qcwuqfo1_500.png)

![](http://41.media.tumblr.com/0c1c210b5b7adcb0e487038b8e5fda93/tumblr_n9vf34Y74r1qcwuqfo2_500.png)
