### PR TITLE
Switch the kpi module to use flattened data

### DIFF
--- a/app/server/modules/kpi.js
+++ b/app/server/modules/kpi.js
@@ -10,6 +10,12 @@ module.exports = ModuleController.extend({
   visualisationClass: View,
   collectionClass: Collection,
 
-  hasTable: false
+  hasTable: false,
+
+  collectionOptions: function () {
+    return {
+      dataSource: _.extend({}, this.model.get('data-source'), {'query-params': _.extend({'flatten': true}, this.model.get('data-source')['query-params'])}),
+    };
+  }
 
 });


### PR DESCRIPTION
By extending datasource in the kpi module collectionOptions. This is the
first time one of the server modules uses collectionOptions.
