### PR TITLE
Removes stub checking in default grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -311,7 +311,6 @@ module.exports = function (grunt) {
     'copy:govuk_template',
     'clean',
     'copy:assets',
-    'shell:validate_module_stubs',
     'shell:generate_services_list'
   ]);
 


### PR DESCRIPTION
- Our stubs should be coming from stagecraft now, so we could reinstate this with stagecraft stubs downloaded to the `stagecraft_stub` folder from the api in future, but this should be removed until then imo.
