### PR TITLE
Change completion rate to work with flat data

### DIFF
--- a/app/common/collections/completion.js
+++ b/app/common/collections/completion.js
@@ -1,7 +1,8 @@
 define([
-  'extensions/collections/collection'
+  'extensions/collections/collection',
+  'extensions/models/data_source'
 ],
-function (Collection) {
+function (Collection, DataSource) {
 
   var CompletionCollection = Collection.extend({
 
@@ -10,6 +11,8 @@ function (Collection) {
       this.denominatorMatcher = options.denominatorMatcher;
       this.numeratorMatcher = options.numeratorMatcher;
       this.matchingAttribute = options.matchingAttribute;
+      this.dataSource = new DataSource(options.dataSource);
+      this.flat = options.flat || this._isFlat() || false;
 
       Collection.prototype.initialize.apply(this, arguments);
       if (!this.denominatorMatcher) {

--- a/app/common/collections/completion_rate.js
+++ b/app/common/collections/completion_rate.js
@@ -9,36 +9,65 @@ define([
     },
 
     parse: function (response) {
-      var values = [];
-      if (response.data && response.data.length > 0 && response.data[0].values) {
+      var values = [],
+      data = response.data;
+      if (data && data.length > 0 && (data[0].values || this.flat)) {
         values = this.calculateCompletion(response.data);
       }
       return values;
     },
 
     calculateCompletion: function (dataset) {
-      return _.map(dataset[0].values, function (model, i) {
-        var totals = _.reduce(dataset, function (memo, d) {
-          if (d.values[i][this.valueAttr] !== null) {
-            if (d[this.matchingAttribute].match(this.denominatorMatcher) !== null) {
-              memo.start += d.values[i][this.valueAttr];
-            }
-            if (d[this.matchingAttribute].match(this.numeratorMatcher) !== null) {
-              memo.end += d.values[i][this.valueAttr];
-            }
+      if (this.flat) {
+        return _.map(_.filter(dataset, function(data) {
+          return data[this.matchingAttribute] && data[this.matchingAttribute].match(this.denominatorMatcher);
+        }, this), function (model) {
+          var matchingStart, matchingEnd;
+          if (model[this.valueAttr] !== null) {
+            matchingStart = _.find(dataset, function (data) {
+              return data['_start_at'] === model['_start_at'] && data[this.matchingAttribute] && data[this.matchingAttribute].match(this.denominatorMatcher);
+            }, this);
+            matchingEnd = _.find(dataset, function (data) {
+              return data['_end_at'] === model['_end_at'] && data[this.matchingAttribute] && data[this.matchingAttribute].match(this.numeratorMatcher);
+            }, this);
           }
-          return memo;
-        }, {start: null, end: null}, this);
+          var totals = {};
+          totals['start'] = (matchingStart ? matchingStart[this.valueAttr]: null);
+          totals['end'] = (matchingEnd ? matchingEnd[this.valueAttr]: null);
 
-        var value = {
-          _start_at: this.getMoment(model._start_at),
-          _end_at: this.getMoment(model._end_at),
-          _start: totals.start,
-          _end: totals.end
-        };
-        return _.extend(this.defaultValueAttrs(value), value);
+          var value = {
+            _start_at: this.getMoment(model._start_at),
+            _end_at: this.getMoment(model._end_at),
+            _start: totals.start,
+            _end: totals.end
+          };
+          return _.extend(this.defaultValueAttrs(value), value);
 
-      }, this);
+        }, this);
+      } else {
+        return _.map(dataset[0].values, function (model, i){
+          var totals = _.reduce(dataset, function (memo, d) {
+            if (d.values[i][this.valueAttr] !== null) {
+              if (d[this.matchingAttribute].match(this.denominatorMatcher) !== null) {
+                memo.start += d.values[i][this.valueAttr];
+              }
+              if (d[this.matchingAttribute].match(this.numeratorMatcher) !== null) {
+                memo.end += d.values[i][this.valueAttr];
+              }
+            }
+            return memo;
+          }, {start: null, end: null}, this);
+
+          var value = {
+            _start_at: this.getMoment(model._start_at),
+            _end_at: this.getMoment(model._end_at),
+            _start: totals.start,
+            _end: totals.end
+          };
+          return _.extend(this.defaultValueAttrs(value), value);
+
+        }, this);
+      }
     },
 
     mean: function (attr) {

--- a/app/common/modules/completion_rate.js
+++ b/app/common/modules/completion_rate.js
@@ -28,7 +28,8 @@ function (CompletionRateCollection) {
               format: 'percent'
             }
           ]
-        }, this.model.get('axes'))
+        }, this.model.get('axes')),
+      dataSource: _.extend({}, this.model.get('data-source'), {'query-params': _.extend({'flatten': true}, this.model.get('data-source')['query-params'])})
       };
     },
 

--- a/spec/shared/common/collections/spec.completion_rate.js
+++ b/spec/shared/common/collections/spec.completion_rate.js
@@ -4,7 +4,8 @@ define([
 function (CompletionCollection) {
   describe('Completion rate collection', function () {
 
-    var mockResponse;
+    var mockResponse,
+    flatMockResponse;
 
     beforeEach(function () {
       mockResponse = {
@@ -60,6 +61,47 @@ function (CompletionCollection) {
         ]
       };
 
+      flatMockResponse = {
+        data: [
+              {
+                _end_at: '2013-12-02T00:00:00+00:00',
+                _start_at: '2013-11-25T00:00:00+00:00',
+                eventCategory: 'start',
+                'uniqueEvents:sum': 15.0
+              },
+              {
+                _end_at: '2013-12-09T00:00:00+00:00',
+                _start_at: '2013-12-02T00:00:00+00:00',
+                eventCategory: 'start',
+                'uniqueEvents:sum': 25.0
+              },
+              {
+                _end_at: '2013-12-02T00:00:00+00:00',
+                _start_at: '2013-11-25T00:00:00+00:00',
+                eventCategory: 'confirm',
+                'uniqueEvents:sum': 8.0
+              },
+              {
+                _end_at: '2013-12-09T00:00:00+00:00',
+                _start_at: '2013-12-02T00:00:00+00:00',
+                eventCategory: 'confirm',
+                'uniqueEvents:sum': 12.0
+              },
+              {
+                _end_at: '2013-12-02T00:00:00+00:00',
+                _start_at: '2013-11-25T00:00:00+00:00',
+                eventCategory: 'done',
+                'uniqueEvents:sum': 10.0
+              },
+              {
+                _end_at: '2013-12-09T00:00:00+00:00',
+                _start_at: '2013-12-02T00:00:00+00:00',
+                eventCategory: 'done',
+                'uniqueEvents:sum': null
+              }
+        ]
+      };
+
     });
 
     it('throws if no denominatorMatcher is defined', function () {
@@ -99,6 +141,39 @@ function (CompletionCollection) {
         expect(result[1]._end).toEqual(null);
         expect(result[0].completion).toEqual(2 / 3);
         expect(result[1].completion).toEqual(0);
+      });
+
+      it('should parse flat responses', function () {
+        var collection = new CompletionCollection({}, {
+          denominatorMatcher: 'start',
+          numeratorMatcher: 'done',
+          matchingAttribute: 'eventCategory',
+          valueAttr: 'uniqueEvents:sum',
+          flat: true
+        });
+
+        var result = collection.parse(flatMockResponse);
+
+        expect(result.length).toEqual(2);
+        expect(result[0]._start).toEqual(15);
+        expect(result[1]._start).toEqual(25);
+        expect(result[0]._end).toEqual(10);
+        expect(result[1]._end).toEqual(null);
+        expect(result[0].completion).toEqual(2 / 3);
+        expect(result[1].completion).toEqual(0);
+      });
+
+      it('should parse flat responses with null matchingAttribute', function () {
+        var collection = new CompletionCollection({}, {
+          denominatorMatcher: 'start',
+          numeratorMatcher: 'done',
+          matchingAttribute: 'eventCategory',
+          valueAttr: 'uniqueEvents:sum',
+          flat: true
+        });
+        delete flatMockResponse['data'][0]['eventCategory'];
+        var result = collection.parse(flatMockResponse);
+        expect(result.length).toEqual(1);
       });
 
       it('should handle an empty data response', function () {


### PR DESCRIPTION
- re implement based on flattened data structure
  - do this and explicily match on start date rather than relying on
    order we unflatten data in - concerned this would not match the order
    it comes from backdrop
  - branches for flat and unflat data remain - needs clearing up when we
    are happy with flat data working
