### PR TITLE
Feature/flat data for single timeseries

### DIFF
--- a/app/common/modules/single-timeseries.js
+++ b/app/common/modules/single-timeseries.js
@@ -28,8 +28,11 @@ function (Collection) {
           }
         ]
       }, this.model.get('axes')),
-
-      options.defaultValue = this.model.get('default-value')
+      options.dataSource = this.model.get('data-source');
+      options.dataSource['query-params'] = _.extend(options.dataSource['query-params'], {
+        flatten:true
+      });
+      options.defaultValue = this.model.get('default-value');
       return options;
     },
 


### PR DESCRIPTION
- Switch to using 'options set' inside collection, as with newer module definitions
- Switches `query-params` to use flat data
