### PR TITLE
Allow overriding of flatten.

### DIFF
--- a/app/client/modules/table.js
+++ b/app/client/modules/table.js
@@ -13,7 +13,7 @@ define([
       return {
         id: 'list',
         title: 'List',
-        queryParams: _.extend({}, this.model.get('query-params'), {'flatten':true}),
+        queryParams: _.extend({}, {'flatten':true}, this.model.get('query-params')),
         axes: this.model.get('axes')
       };
     }

--- a/app/common/collections/journey_series.js
+++ b/app/common/collections/journey_series.js
@@ -16,8 +16,7 @@ define([
       var dateRange = this.lastWeekDateRange(this.getMoment(), options.weeksAgo || 0);
 
       options.dataSource = options.dataSource || {};
-      options.dataSource['query-params'] = _.extend(dateRange, options.dataSource['query-params']);
-      options.dataSource['query-params'] = _.extend(options.dataSource['query-params'], {flatten: true});
+      options.dataSource['query-params'] = _.extend({flatten: true}, dateRange, options.dataSource['query-params']);
 
       Collection.prototype.initialize.apply(this, arguments);
     },

--- a/app/common/modules/applications.js
+++ b/app/common/modules/applications.js
@@ -15,7 +15,7 @@ function (Collection) {
         { type: 'integer', magnitude: true, sigfigs: 3, pad: true };
 
       options.dataSource = this.model.get('data-source');
-      options.dataSource['query-params'] = _.extend(options.dataSource['query-params'], {flatten:true});
+      options.dataSource['query-params'] = _.extend({flatten:true}, options.dataSource['query-params']);
 
       options.axes = _.merge({
           x: {

--- a/app/common/modules/single-timeseries.js
+++ b/app/common/modules/single-timeseries.js
@@ -29,9 +29,9 @@ function (Collection) {
         ]
       }, this.model.get('axes')),
       options.dataSource = this.model.get('data-source');
-      options.dataSource['query-params'] = _.extend(options.dataSource['query-params'], {
+      options.dataSource['query-params'] = _.extend({
         flatten:true
-      });
+      }, options.dataSource['query-params']);
       options.defaultValue = this.model.get('default-value');
       return options;
     },


### PR DESCRIPTION
Flatten is currently problematic for some modules when
backdrop has to fill in lots of empty permutations. In
this case we should be able to turn flatten off.
