### PR TITLE
Fix bug in flat data for completion_rate module

### DIFF
--- a/spec/shared/common/collections/spec.completion_rate.js
+++ b/spec/shared/common/collections/spec.completion_rate.js
@@ -173,7 +173,7 @@ function (CompletionCollection) {
         });
         delete flatMockResponse['data'][0]['eventCategory'];
         var result = collection.parse(flatMockResponse);
-        expect(result.length).toEqual(1);
+        expect(result.length).toEqual(2);
       });
 
       it('should handle an empty data response', function () {
@@ -253,6 +253,40 @@ function (CompletionCollection) {
         expect(result[0].completion).toEqual(null);
         expect(result[1].completion).toEqual(null);
 
+      });
+    });
+
+    describe('calculateCompletion', function () {
+      it('supports regular expressions that require multiple data points', function () {
+        var data = [
+          {
+            '_count': 1.0,
+            '_end_at': '2014-11-01T00:00:00+00:00',
+            '_start_at': '2014-10-01T00:00:00+00:00',
+            'channel': 'paper',
+            'count:sum': 3098.0
+          },
+          {
+            '_count': 1.0,
+            '_end_at': '2014-11-01T00:00:00+00:00',
+            '_start_at': '2014-10-01T00:00:00+00:00',
+            'channel': 'digital',
+            'count:sum': 461.0
+          }
+        ];
+
+        var collection = new CompletionCollection({}, {
+          denominatorMatcher: '^digital|paper$',
+          numeratorMatcher: '^digital$',
+          matchingAttribute: 'channel',
+          valueAttr: 'count:sum',
+          flat: true
+        });
+
+        var result = collection.calculateCompletion(data);
+
+        expect(result.length).toEqual(1);
+        expect(result[0].completion).toEqual(461 / 3559);
       });
     });
 


### PR DESCRIPTION
My commit message doesn't make a lot of sense, but it's late and I've been doing this for a while. I can take another look at it if you think it needs it.

---

This `completion_rate` does not support the case where multiple pieces of data are used in the compilation of a single data point representing a given time period.

Additionally, this module would sometimes result in duplicated output in the table that accompanies a graph, for example on 'SORN':

```
1 to 30 November 2013                    123%
1 to 30 November 2013                    123%
```
