### PR TITLE
Switch everything to use flatten=true parameter

### DIFF
--- a/app/client/modules/table.js
+++ b/app/client/modules/table.js
@@ -13,7 +13,6 @@ define([
       return {
         id: 'list',
         title: 'List',
-        queryParams: _.extend({}, {'flatten':true}, this.model.get('query-params')),
         axes: this.model.get('axes')
       };
     }

--- a/app/common/collections/availability.js
+++ b/app/common/collections/availability.js
@@ -5,8 +5,7 @@ function (Collection) {
   var AvailabilityCollection = Collection.extend({
 
     queryParams: {
-      collect: ['downtime:sum', 'uptime:sum', 'unmonitored:sum', 'avgresponse:mean'],
-      flatten: true
+      collect: ['downtime:sum', 'uptime:sum', 'unmonitored:sum', 'avgresponse:mean']
     },
 
     parse: function () {

--- a/app/common/collections/journey_series.js
+++ b/app/common/collections/journey_series.js
@@ -16,7 +16,7 @@ define([
       var dateRange = this.lastWeekDateRange(this.getMoment(), options.weeksAgo || 0);
 
       options.dataSource = options.dataSource || {};
-      options.dataSource['query-params'] = _.extend({flatten: true}, dateRange, options.dataSource['query-params']);
+      options.dataSource['query-params'] = _.extend(dateRange, options.dataSource['query-params']);
 
       Collection.prototype.initialize.apply(this, arguments);
     },

--- a/app/common/collections/user-satisfaction.js
+++ b/app/common/collections/user-satisfaction.js
@@ -17,8 +17,7 @@ define([
         'rating_4:sum',
         'rating_5:sum',
         'total:sum'
-      ],
-      flatten: true
+      ]
     },
     parse: function () {
       var data = Collection.prototype.parse.apply(this, arguments);

--- a/app/common/modules/applications.js
+++ b/app/common/modules/applications.js
@@ -14,9 +14,6 @@ function (Collection) {
       options.format = this.model.get('format') ||
         { type: 'integer', magnitude: true, sigfigs: 3, pad: true };
 
-      options.dataSource = this.model.get('data-source');
-      options.dataSource['query-params'] = _.extend({flatten:true}, options.dataSource['query-params']);
-
       options.axes = _.merge({
           x: {
             label: 'Dates',

--- a/app/common/modules/bar_chart_with_number.js
+++ b/app/common/modules/bar_chart_with_number.js
@@ -15,8 +15,6 @@ function (Collection) {
       options.format = this.model.get('format') ||
         { type: 'integer', magnitude: true, sigfigs: 3, pad: true };
 
-      options['dataSource'] = _.extend({}, this.model.get('data-source'), {'query-params': _.extend({'flatten': true}, this.model.get('data-source')['query-params'])});
-
       options.axes = _.merge({
           x: {
             label: 'Dates',

--- a/app/common/modules/completion_rate.js
+++ b/app/common/modules/completion_rate.js
@@ -28,8 +28,7 @@ function (CompletionRateCollection) {
               format: 'percent'
             }
           ]
-        }, this.model.get('axes')),
-      dataSource: _.extend({}, this.model.get('data-source'), {'query-params': _.extend({'flatten': true}, this.model.get('data-source')['query-params'])})
+        }, this.model.get('axes'))
       };
     },
 

--- a/app/common/modules/single-timeseries.js
+++ b/app/common/modules/single-timeseries.js
@@ -28,10 +28,6 @@ function (Collection) {
           }
         ]
       }, this.model.get('axes')),
-      options.dataSource = this.model.get('data-source');
-      options.dataSource['query-params'] = _.extend({
-        flatten:true
-      }, options.dataSource['query-params']);
       options.defaultValue = this.model.get('default-value');
       return options;
     },

--- a/app/server/modules/kpi.js
+++ b/app/server/modules/kpi.js
@@ -10,12 +10,6 @@ module.exports = ModuleController.extend({
   visualisationClass: View,
   collectionClass: Collection,
 
-  hasTable: false,
-
-  collectionOptions: function () {
-    return {
-      dataSource: _.extend({}, this.model.get('data-source'), {'query-params': _.extend({'flatten': true}, this.model.get('data-source')['query-params'])}),
-    };
-  }
+  hasTable: false
 
 });


### PR DESCRIPTION
We were down to the last module as part of the switch over to flat
group_by data, so I migrated the addition of the flatten=true query
parameter from each individual module/collection into the data source.
This should make pulling it a little easier and ensures that all
requests will have this parameter provided (as everything uses
data_source).

This maintains the ability of a particular module to override this query
parameter as it as the json from stagecraft and any custom query
parameters get merged over the top.
