### PR TITLE
Fix label on user satisfaction module

### DIFF
--- a/app/common/modules/user_satisfaction_graph.js
+++ b/app/common/modules/user_satisfaction_graph.js
@@ -32,7 +32,7 @@ function (UserSatisfactionCollection) {
               format: 'percent'
             },
             {
-              label: 'Not satisfied',
+              label: 'Very dissatisfied',
               key: 'rating_1:sum',
               format: 'integer'
             },


### PR DESCRIPTION
As per story:

"The user satisfaction table currently has a header of Not satisfied, when it should be Very dissatisfied as per the 5 point scale on the 'done' page."
