### PR TITLE
Shim: set `flattenEverything` to `false` for grouped_timeseries

### DIFF
--- a/app/common/collections/grouped_timeseries.js
+++ b/app/common/collections/grouped_timeseries.js
@@ -4,6 +4,12 @@ define([
 function (Collection) {
 
   return Collection.extend({
+    initialize: function (models, options) {
+      if(options !== undefined){
+        options.flattenEverything = false;
+      }
+      return Collection.prototype.initialize.apply(this, arguments);
+    },
 
     parse: function () {
       var data = Collection.prototype.parse.apply(this, arguments);


### PR DESCRIPTION
- Fixes our bug with huge unflattened timeseries data coming back
- Is a suitably horrible looking shim

![](http://www.cutecatgifs.com/wp-content/uploads/2013/10/bee-costume-cat1.gif)
