### PR TITLE
Use dashboard generator to update dashboards

### DIFF
--- a/tools/tx-dashboard-generator/config.example.json
+++ b/tools/tx-dashboard-generator/config.example.json
@@ -1,4 +1,6 @@
 {
   "email": "name@digital.cabinet-office.gov.uk",
-  "password": "app-specific-password"
+  "password": "google-app-specific-password",
+  "stagecraft-host": "stagecraft.development.performance.service.gov.uk",
+  "signon-token": "bearer-token-with-dashboard-access-in-signon"
 }

--- a/tools/tx-dashboard-generator/package.json
+++ b/tools/tx-dashboard-generator/package.json
@@ -7,6 +7,7 @@
     "google-spreadsheets": "0.3.0",
     "googleclientlogin": "0.2.8",
     "underscore": "1.6.0",
+    "request": "2.48.0",
     "rimraf": "2.2.6"
   }
 }


### PR DESCRIPTION
The dashboard generator was originally written to take dashboards from a Google Spreadsheet and save them as JSON files.

We now need to pull in changes from the Google Spreadsheet and update the data stored in Stagecraft.

This commit retrieves the database ID for a given dashboard slug and uses that to ensure the dashboard is overwritten in the database rather than being duplicated.
