### PR TITLE
Change the default dev config to use production

### DIFF
--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,10 +1,10 @@
 {
   "assetPath": "/spotlight/",
   "port": 3057,
-  "backdropUrl": "https://www.preview.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
+  "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
   "govukHost": "www.alphagov.co.uk",
-  "stagecraftUrl": "https://stagecraft.preview.performance.service.gov.uk",
+  "stagecraftUrl": "https://stagecraft.production.performance.service.gov.uk",
   "statsdPrefix": "pp.apps.spotlight"
 }


### PR DESCRIPTION
Cheapseats (our testing app) uses production by default, but until this commit Spotlight was using preview. This causes test failures because the instance of Spotlight that Cheapseats spins up is using preview data, but it's making assertions against production Stagecraft.
