### PR TITLE
Use SPDY to connect to backing services

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -41,7 +41,16 @@ if (environment.match(/^development/)) {
 }
 
 var http = require('http'),
-    path = require('path');
+    https = require('https'),
+    path = require('path'),
+    spdy = require('spdy');
+
+// Use SPDY to talk to backing services. Seems like a great fit, minimise TLS connection
+// overhead and multiplex requests to the same limited number of domains.
+https.globalAgent = spdy.createAgent({
+  host: 'www.google.com',
+  port: 443
+});
 
 var rootDir = path.join(__dirname, '..');
 var app = require('./appBuilder').getApp(environment, rootDir, argv.REQUIRE_BASE_URL);

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "q": "1.0.1",
     "requirejs": "2.1.14",
     "sanitizer": "0.1.1",
+    "spdy": "1.29.1",
     "uglify-js": "2.4.14",
     "winston": "0.8.1",
     "xmlhttprequest": "1.6.0"


### PR DESCRIPTION
Spotlight currently makes a lot of backing service requests over SSL. We
should see an improvement in our response times by using SPDY to connect
to each domain/port combination over SPDY, and only pay the overhead of
setting up a single TCP connection to have a conversation over TLS.

Currently, a request to render HTML might make 10 requests. Default node
settings will allow up to 5 connections to be made to a host / port
combination, so we will have the overhead of setting up 5 TLS
connections, then hopefully see connection keep alive giving a slight
benefit.

This change needs benchmarking and profiling to ensure that we’re
using SPDY correctly.

Can be traced in wireshark / tcpdump with ip.addr == 37.26.89.53 on
preview.
