### PR TITLE
Don't flatten the data for the applications module.

### DIFF
--- a/app/common/modules/applications.js
+++ b/app/common/modules/applications.js
@@ -7,9 +7,10 @@ function (Collection) {
     collectionClass: Collection,
 
     collectionOptions: function () {
-      var valueAttr = this.model.get('value-attribute') || '_count';
+      var valueAttr = this.model.get('value-attribute') || 'count:sum';
       var options = {
-        valueAttr: valueAttr
+        valueAttr: valueAttr,
+        flattenEverything: false
       };
       options.format = this.model.get('format') ||
         { type: 'integer', magnitude: true, sigfigs: 3, pad: true };


### PR DESCRIPTION
The application module doesn't work with flattened data right now. This ensures the module keeps working until we get to fix that.
