### PR TITLE
Make big screen link absolute

### DIFF
--- a/app/server/templates/dashboard.html
+++ b/app/server/templates/dashboard.html
@@ -46,7 +46,7 @@
   {{/ relatedPages }}
 
   {{# hasBigScreenView }}
-    <div class="big-screen-link-container"><a class="big-screen-link" href="/big-screen/{{ slug }}">View in big screen</a></div>
+    <div class="big-screen-link-container"><a class="big-screen-link" href="https://www.performance.service.gov.uk/big-screen/{{ slug }}">View in big screen</a></div>
   {{/ hasBigScreenView }}
   </aside>
 


### PR DESCRIPTION
Big screen is hosted on a different domain, so a relative link returns a 404.
