### PR TITLE
User sat graphs should be more configurable

### DIFF
--- a/app/client/views/visualisations/user-satisfaction-graph.js
+++ b/app/client/views/visualisations/user-satisfaction-graph.js
@@ -70,27 +70,21 @@ function (SingleTimeseriesView, UserSatisfactionView, VolumetricsNumberView, Col
         selectModel = _.isArray(selectModel) ? selectModel[0] : selectModel;
       }
 
-      var ratings = [],
-        attr, val, valueAttr;
-
-      _.each([
-        'Very dissatisfied',
-        'Dissatisfied',
-        'Neither satisfied or dissatisfied',
-        'Satisfied',
-        'Very satisfied'
-      ], function (label, i) {
-        attr = this.valueAttr + '_' + (i + 1) + ':sum';
-        if (selectModel) {
-          val = selectModel.get(attr);
-          valueAttr = selectModel.get(valueAttr);
-        } else {
-          val = this.collection.total(attr);
-        }
-        ratings.push({ count: val, title: label});
-      }, this);
-
-      return ratings;
+      return _.map(
+          this.collection.options.axes.y.slice(1),
+          function (axis) {
+            var val;
+            if (selectModel) {
+              val = selectModel.get(axis.key);
+            } else {
+              val = this.collection.total(axis.key);
+            }
+            return {
+              count: val,
+              title: axis.label,
+            };
+          }, this
+      );
     },
 
     views: function () {

--- a/app/common/collections/user-satisfaction.js
+++ b/app/common/collections/user-satisfaction.js
@@ -9,30 +9,37 @@ define([
       }
       return (score - this.options.min) / (this.options.max - this.options.min);
     },
-    queryParams: {
-      collect: [
-        'rating_1:sum',
-        'rating_2:sum',
-        'rating_3:sum',
-        'rating_4:sum',
-        'rating_5:sum',
-        'total:sum'
-      ]
+    queryParams: function () {
+      return (!this.options.migrated) ? {
+        collect: [
+          'rating_1:sum',
+          'rating_2:sum',
+          'rating_3:sum',
+          'rating_4:sum',
+          'rating_5:sum',
+          'total:sum'
+        ]
+      } : {};
     },
     parse: function () {
       var data = Collection.prototype.parse.apply(this, arguments);
-      _.each(data, function (datapoint) {
-        var score = 0;
-        _.each(_.range(this.options.min, this.options.max + 1), function (i) {
-          score += (datapoint['rating_' + i + ':sum'] * i);
-        });
-        var mean = score / datapoint['total:sum'];
-        datapoint[this.valueAttr + ':sum'] = score;
-        datapoint[this.valueAttr] = this.toPercent(mean);
-      }, this);
+
+      if (!this.options.migrated) {
+        _.each(data, function (datapoint) {
+          var score = 0;
+          _.each(_.range(this.options.min, this.options.max + 1), function (i) {
+            score += (datapoint['rating_' + i + ':sum'] * i);
+          });
+          var mean = score / datapoint['total:sum'];
+          datapoint[this.valueAttr + ':sum'] = score;
+          datapoint[this.valueAttr] = this.toPercent(mean);
+        }, this);
+      }
+
       if (this.options.trim) {
         this.trim(data, this.options.trim);
       }
+
       return data;
     },
 

--- a/app/common/modules/user_satisfaction_graph.js
+++ b/app/common/modules/user_satisfaction_graph.js
@@ -14,11 +14,12 @@ function (UserSatisfactionCollection) {
         title: 'User satisfaction',
         min: 1,
         max: 5,
-        totalAttr: 'totalRatings',
+        totalAttr: this.model.get('total-attribute') || 'totalRatings',
         valueAttr: this.model.get('value-attribute'),
         axisPeriod: this.model.get('axis-period'),
         trim: this.model.get('trim') === false ? false : true,
         format: this.model.get('format') || 'integer',
+        migrated: this.model.get('migrated') === true,
         axes: _.merge({
           x: {
             label: 'Date',
@@ -63,7 +64,7 @@ function (UserSatisfactionCollection) {
 
     visualisationOptions: function () {
       return {
-        totalAttr: 'totalRatings',
+        totalAttr: this.model.get('total-attribute') || 'totalRatings',
         valueAttr: this.model.get('value-attribute'),
         formatOptions: this.model.get('format') || 'integer',
         url: this.url

--- a/spec/client/common/views/visualisations/spec.user-satisfaction-graph.js
+++ b/spec/client/common/views/visualisations/spec.user-satisfaction-graph.js
@@ -7,12 +7,51 @@ define([
 function (UserSatisfactionGraphView, CompletionRateView, Collection, Model) {
   describe('User satisfaction graph', function () {
 
-    var collection, view;
+    var collection, view,
+        axes = {
+          x: {
+            label: 'Date',
+            key: '_start_at',
+            format: 'date'
+          },
+          y: [
+            {
+              label: 'User Satisfaction',
+              key: 'rating',
+              format: 'percent'
+            },
+            {
+              label: 'Very dissatisfied',
+              key: 'rating_1:sum',
+              format: 'integer'
+            },
+            {
+              label: 'Dissatisfied',
+              key: 'rating_2:sum',
+              format: 'integer'
+            },
+            {
+              label: 'Neither satisfied or dissatisfied',
+              key: 'rating_3:sum',
+              format: 'integer'
+            },
+            {
+              label: 'Satisfied',
+              key: 'rating_4:sum',
+              format: 'integer'
+            },
+            {
+              label: 'Very satisfied',
+              key: 'rating_5:sum',
+              format: 'integer'
+            }
+          ]
+        };
 
     beforeEach(function () {
       var $el = $('<div><div class="volumetrics-bar-selected"><p class="total-responses"><p><p class="volumetrics-bar-period"></p></div></div>');
       spyOn(CompletionRateView.prototype, 'views').andReturn({});
-      collection = new Collection([], { min: 1, max: 5 });
+      collection = new Collection([], { min: 1, max: 5, axes: axes });
       var data = [
         {
           'total:sum': 229.0,


### PR DESCRIPTION
In order to migrate the user_satisfaction_graph module over to using
transformed data we need more control over the keys that the module uses
to pull data out of records.

This also rewrites the gathering of a breakdown to use the axes rather
than a hard coded list of labels.

The migrated property is to skip the application of query parameters and
parsing that is required for dealing with the untransformed data.
