### PR TITLE
Fix ```grunt jasmine_node:server``` command

### DIFF
--- a/spec/server-pure/helpers.js
+++ b/spec/server-pure/helpers.js
@@ -14,3 +14,10 @@ global.config = {};
 global._ = require('lodash');
 global.$ = require('jquery');
 global.isClient = false;
+global.logger = {
+  info: function () {},
+  debug: function () {},
+  error: function () {},
+  log: function () {},
+  warn: function () {}
+};


### PR DESCRIPTION
If you run this command at moment it will fail as there's no global logger defined.

It works if you run the main jasmine_node as the helpers for ```legacy``` add it to the global.

This adds it to the global for server so you can now just run the server tests only and be happy.