### PR TITLE
gitignore /dashboards folder at root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ public/*
 dist
 node_modules
 _SpecRunner.html
-dashboards
+/dashboards
 
 *.log
 *.log.json


### PR DESCRIPTION
Without a leading / git will ignore all files/folders named dashboard in the
repo