### PR TITLE
Fix line breaks in legend labels on hover

### DIFF
--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -411,6 +411,7 @@ figure.graph {
       li {
         position: absolute;
         margin-top: 16px;
+        right: 0;
 
         &.selected {
           font-weight: bold;


### PR DESCRIPTION
The labels in the legend for graphs like https://www.gov.uk/performance/register-to-vote/registrations-by-age-group cause a slightly nasty overlap because a line break appears on hover.
Setting the right value at 0 allows the absolutely positioned labels to fill the full width of the parent container, and so prevents the line breaks appearing when the font-face is changed to bold.

This fixes the bug I reported yesterday. I thought you guys might appreciate it since I imagine you're getting a lot of hits lately.