### PR TITLE
Feature/sort refactor

### DIFF
--- a/app/client/views/services.js
+++ b/app/client/views/services.js
@@ -26,7 +26,8 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
         '.visualisation-table': {
           view: TableView,
           options: {
-            scrollable: false
+            scrollable: false,
+            collapseOnNarrowViewport: true
           }
         },
         '.summary-figure': {

--- a/app/client/views/table.js
+++ b/app/client/views/table.js
@@ -12,27 +12,20 @@ function (TableView, Modernizr, accessibility, $) {
 
       TableView.prototype.initialize.apply(this, arguments);
 
-      this.$table = this.$('table');
-
       this.options = _.extend({
         scrollable: true
       }, options || {});
-
-      this.tableCollection = new this.collection.constructor(this.collection.models, this.collection.options);
 
       this.sortFields = _.cloneDeep(this.collection.options.axes.y);
       this.sortFields.unshift(this.collection.options.axes.x);
       this.sortFields = _.object(_.pluck(this.sortFields, 'key'), this.sortFields);
 
-      this.listenTo(this.tableCollection, 'sort', this.renderSort);
-      this.sort();
+      this.listenTo(this.collection, 'sort', this.render);
 
-      this.listenTo(this.tableCollection, 'reset', _.bind(function() {
-        accessibility.updateLiveRegion(this.tableCollection.length + ' transactions in list');
-        this.renderSort();
+      this.listenTo(this.collection, 'reset', _.bind(function() {
+        accessibility.updateLiveRegion(this.collection.length + ' transactions in list');
+        this.render();
       }, this));
-
-      this.listenTo(this.collection, 'sync reset', this.syncToTableCollection);
 
       this.listenTo(this.model, 'change:sort-by change:sort-order', function () { this.sort(); });
       this.listenTo(this.model, 'sort-changed-external', _.bind(function(data) {
@@ -44,45 +37,6 @@ function (TableView, Modernizr, accessibility, $) {
 
     events: {
       'click .js-sort': 'sortCol'
-    },
-
-    syncToTableCollection: function () {
-      this.tableCollection.reset(this.collection.toJSON());
-    },
-
-    renderSort: function () {
-      if (this.$table.find('tbody')) {
-        this.$table.find('tbody').remove();
-      }
-      $(this.renderBody(this.tableCollection)).appendTo(this.$table);
-
-      var sortBy = this.model.get('sort-by'),
-        sortOrder = this.model.get('sort-order'),
-        $sortedCells;
-
-      if (sortBy) {
-        var ths = this.$('thead th'),
-          $allCells = this.$('th,td'),
-          th = this.$('thead th[data-key="' + sortBy + '"]');
-
-        ths.removeClass('asc');
-        ths.removeClass('desc');
-        ths.removeAttr('aria-sort');
-
-        if (sortOrder === 'descending') {
-          th.addClass('desc');
-          th.attr('aria-sort', 'descending');
-        } else {
-          th.addClass('asc');
-          th.attr('aria-sort', 'ascending');
-        }
-
-        $allCells.removeClass('sort-column');
-        $sortedCells = this.$('[data-key="' + this.model.get('sort-by') + '"]');
-        $sortedCells.addClass('sort-column');
-      }
-
-      this.render();
     },
 
     sortCol: function (e) {
@@ -109,105 +63,36 @@ function (TableView, Modernizr, accessibility, $) {
       this.updateUrlWithSort();
     },
 
-    sort: function (sortBy, sortOrder) {
-
-      sortBy = sortBy || this.model.get('sort-by');
-      sortOrder = sortOrder || this.model.get('sort-order') || 'descending';
-
-      if (!sortBy) {
-        return;
-      }
-
-      this.tableCollection.comparator = _.bind(function (a, b) {
-        var firstVal = a.get(sortBy),
-          firstTime = a.get('_timestamp') || a.get('_start_at'),
-          secondVal = b.get(sortBy),
-          secondTime = b.get('_timestamp') || b.get('_start_at'),
-          nullValues = (firstVal === null && secondVal === null),
-          ret = 0;
-
-        if (firstVal && typeof firstVal === 'string') {
-          firstVal = this.stripLink(firstVal).toLowerCase();
-        }
-        if (secondVal && typeof secondVal === 'string') {
-          secondVal = this.stripLink(secondVal).toLowerCase();
-        }
-
-        if (nullValues) {
-          if (firstTime < secondTime) {
-            ret = -1;
-          } else if (firstTime > secondTime) {
-            ret = 1;
-          }
-          if (sortOrder === 'descending') {
-            ret = -ret;
-          }
-        } else {
-          if (firstVal === null) {
-            ret = 1;
-          } else if (secondVal === null) {
-            ret = -1;
-          } else {
-            if (firstVal < secondVal) {
-              ret = -1;
-            } else if (firstVal > secondVal) {
-              ret = 1;
-            }
-            if (sortOrder === 'descending') {
-              ret = -ret;
-            }
-          }
-
-        }
-
-        return ret;
-      }, this);
-
-      this.tableCollection.sort();
-    },
-
-    stripLink: function (str) {
-      var $link = $(str).filter('a');
-      if ($link.length) {
-        return $link.html();
-      }
-      return str;
-    },
-
     render: function () {
+
+      TableView.prototype.render.apply(this, arguments);
+
       if (Modernizr.touch) {
-        this.$table.addClass('touch-table');
+        this.$('table').addClass('touch-table');
       }
+      this.adjustCellWidths();
 
-      this.$table.removeClass('floated-header');
-      var headers = this.$table.find('thead th'),
-          headerLinks = this.$table.find('.js-sort'),
-          body = this.$table.find('tbody td, tbody th');
+    },
 
-      headers.attr('width', '');
-      if (headerLinks.length === 0) {
-        headers.each(function () {
+    adjustCellWidths: function() {
+      var $bodyCells = this.$('table').find('tbody td, tbody th'),
+        $headerCells = this.$('table').find('thead th');
+      $headerCells.attr('width', '');
+      $bodyCells.attr('width', '');
 
-          $(this).attr('role', 'columnheader');
-          $(this).wrapInner('<a class="js-sort" href="#" role="button"></a>')
-            .find('a')
-            .append('<span class="visuallyhidden">Click to sort</span>');
-        });
-      }
-      body.attr('width', '');
+      this.$('table').removeClass('floated-header');
 
-      if (this.options.scrollable && (body.length > headers.length)) {
-        _.each(headers, function (th, index) {
-          body[index].width = body[index].offsetWidth;
+      if (this.options.scrollable && ($bodyCells.length > $headerCells.length)) {
+        _.each($headerCells, function (th, index) {
+          $bodyCells[index].width = $bodyCells[index].offsetWidth;
         }, this);
 
         this.$('table').addClass('floated-header');
 
-        _.each(headers, function (th, index) {
-          th.width = body[index].offsetWidth;
+        _.each($headerCells, function (th, index) {
+          th.width = $bodyCells[index].offsetWidth;
         }, this);
       }
-
     },
 
     screenreaderAnnounceSortChange: function(sortField, sortDirection) {
@@ -218,18 +103,11 @@ function (TableView, Modernizr, accessibility, $) {
     },
 
     updateUrlWithSort: function() {
+      var merged;
       if (Modernizr.history) {
-        var params = $.deparam(window.location.search.substr(1));
-
-        if (this.model.get('sort-by')) {
-          params.sortby = this.model.get('sort-by');
-        }
-        if (this.model.get('sort-order')) {
-          params.sortorder = this.model.get('sort-order');
-        }
-
-        params = $.param(params);
-        this.replaceUrlParams(params);
+        merged = this.mergeSortParams(window.location.search.substr(1), this.model.get('sort-by'),
+          this.model.get('sort-order'));
+        this.replaceUrlParams(merged);
       }
     },
 

--- a/app/extensions/controllers/controller.js
+++ b/app/extensions/controllers/controller.js
@@ -111,7 +111,7 @@ define([
 
         var model = new Model(definition);
         model.set('parent', parentModel);
-
+        model.set('params', parentModel.get('params'));
         var options = _.isFunction(moduleOptions) ? moduleOptions(model) : moduleOptions;
 
         var module = new definition.controller(_.merge({ model: model }, options));

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -44,8 +44,10 @@ var renderContent = function (req, res, client_instance) {
       script: true,
       noun: 'service',
       axesOptions: servicesController.serviceAxes,
-      'sort-by':  sanitizer.escape(req.query.sortby || 'number_of_transactions'),
-      'sort-order':  sanitizer.escape(req.query.sortorder || 'descending')
+      params: _.extend({
+        sortby:  'number_of_transactions',
+        sortorder:  'descending'
+      }, client_instance.get('params'))
     }));
 
     var client_instance_status = client_instance.get('status');

--- a/app/server/mixins/get_dashboard_and_render.js
+++ b/app/server/mixins/get_dashboard_and_render.js
@@ -2,9 +2,12 @@ var requirejs = require('requirejs');
 
 var controllerMap = require('../../server/controller_map')();
 var StagecraftApiClient = requirejs('stagecraft_api_client');
+var url = require('url');
 
 var buildStagecraftApiClient = function(req){
-  var this_client_instance = new StagecraftApiClient({}, {
+  var this_client_instance = new StagecraftApiClient({
+    params: url.parse(req.originalUrl, true).query
+  }, {
     ControllerMap: controllerMap,
     requestId: req.get('Request-Id'),
     govukRequestId: req.get('GOVUK-Request-Id')

--- a/app/server/modules/table.js
+++ b/app/server/modules/table.js
@@ -15,8 +15,6 @@ module.exports = ModuleController.extend({
 
   visualisationOptions: function () {
     return {
-      sortBy: this.model.get('sort-by'),
-      sortOrder: this.model.get('sort-order') || 'descending',
       url: this.url
     };
   },

--- a/app/stagecraft_api_client.js
+++ b/app/stagecraft_api_client.js
@@ -12,6 +12,7 @@ function (Model) {
       this.controllers = options.ControllerMap;
       this.requestId = options.requestId || 'Not-Set';
       this.govukRequestId = options.govukRequestId || 'Not-Set';
+      this.set('params', attrs.params);
       Model.prototype.initialize.apply(this, arguments);
     },
 

--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -27,7 +27,10 @@ describe('Services Controller', function () {
         'GOVUK-Request-Id': '1231234123'
       }[key];
     },
-    query: {}
+    originalUrl: '',
+    query: {
+      filter: ''
+    }
   }, fake_app);
   var res = {
     send: jasmine.createSpy(),
@@ -56,6 +59,10 @@ describe('Services Controller', function () {
         'status': 200,
         'items': _.cloneDeep(dashboards.items)
       });
+      client_instance.set('params', {
+        sortby: 'completion_rate',
+        sortorder: 'ascending'
+      });
       return client_instance;
     });
   });
@@ -75,20 +82,6 @@ describe('Services Controller', function () {
       config: 'setting',
       'page-type': 'services'
     }));
-  });
-
-  it('passes query params sort column to model if defined', function () {
-    controller(_.extend({ query: { sortby: 'completion_rate' } }, fake_app), res);
-    client_instance.trigger('sync');
-    expect(Backbone.Model.prototype.initialize).toHaveBeenCalledWith(jasmine.objectContaining({
-      'sort-by': 'completion_rate'}));
-  });
-
-  it('passes query params sort order to model if defined', function () {
-    controller(_.extend({ query: { sortorder: 'ascending' } }, fake_app), res);
-    client_instance.trigger('sync');
-    expect(Backbone.Model.prototype.initialize).toHaveBeenCalledWith(jasmine.objectContaining({
-      'sort-order': 'ascending'}));
   });
 
   it('passes query params filter to model if defined', function () {

--- a/spec/server-pure/mixins/spec.get_dashboard_and_render.js
+++ b/spec/server-pure/mixins/spec.get_dashboard_and_render.js
@@ -28,7 +28,8 @@ describe('get_dashboard_and_render', function () {
         'get': function(key) {
           return request_attrs[key];
         }
-      }
+      },
+      originalUrl: ''
     };
     fakeStatusCall = jasmine.createSpy('status'); 
     fake_response = {status: fakeStatusCall};
@@ -36,7 +37,9 @@ describe('get_dashboard_and_render', function () {
   it('should set up the correct client_instance', function(){
     var client_instance = get_dashboard_and_render(fake_request, fake_response, fakeRenderContent);
     expect(StagecraftApiClient.prototype.initialize).toHaveBeenCalledWith(
-      {}, 
+      {
+        params: {}
+      },
       {
         ControllerMap: controllerMap,
         requestId: 'Xb35Gt',

--- a/styles/common/table.scss
+++ b/styles/common/table.scss
@@ -28,15 +28,15 @@ table {
       }
     }
 
-    &.desc a:after,
-    &.asc a:after {
+    &.descending a:after,
+    &.ascending a:after {
       content: "\00a0\00a0\25BC";
       font-size: 8px;
       position: absolute;
       top: 0.7em;
     }
 
-    &.asc a:after {
+    &.ascending a:after {
       content: "\00a0\00a0\25B2";
     }
 


### PR DESCRIPTION
This PR is to fix some legacy tech debt from spotlight - the sort function is now progressively enhanced and will work with and without Javascript.
[Agile planner ticket](https://www.agileplannerapp.com/boards/15088/cards/9292)

## Changes
1. Pick up any querystring variables and mix them into the stagecraft client under a 'params' attribute. These can then be used in any component to override default settings eg. sort field and order
2. Move sort logic from client table view to the shared table view

## Sample URLs 
[Services data](https://www.preview.alphagov.co.uk/performance/services?sortby=number_of_transactions&sortorder=descending)
[Table within a grouped time series module](https://www.preview.alphagov.co.uk/performance/blood-donation-appointments/registration-and-appointment-volumes)
[Table module](https://www.preview.alphagov.co.uk/performance/site-activity-cabinet-office)