### PR TITLE
Fix - weighted averages now computed to correct number of decimal places

### DIFF
--- a/app/common/collections/services.js
+++ b/app/common/collections/services.js
@@ -52,6 +52,7 @@ define([
         var kpi, weightedAverage;
 
         _.each(axes, function (axis) {
+          var decimalPlaces;
           kpi = _.findWhere(aggregatedValues, {key: axis.key});
 
           if (kpi) {
@@ -60,8 +61,9 @@ define([
               kpi.weighted_average = kpi.value;
             } else {
               if (kpi.volume) {
+                decimalPlaces = (kpi.format.type === 'percent') ? 3 : 1;
                 weightedAverage = (kpi.valueTimesVolume / kpi.volume);
-                kpi.weighted_average = parseFloat(weightedAverage.toFixed(1));
+                kpi.weighted_average = parseFloat(weightedAverage.toFixed(decimalPlaces));
               }
             }
             kpi.allRowsHaveValues = (kpi.valueCount === this.length);

--- a/spec/shared/common/collections/spec.services.js
+++ b/spec/shared/common/collections/spec.services.js
@@ -152,20 +152,20 @@ define([
         beforeEach(function () {
           this.collection = new Collection(dashboardData, servicesAxes);
           weightedAverages = this.collection.applyWeightedAverages([{
-              key: 'digital_takeup',
-              label: 'Digital take-up',
-              isWeighted: true,
-              value: 1.4,
-              valueTimesVolume: 1570,
-              volume: 3900,
-              valueCount: 3,
-              format: {
-                type: 'percent',
-                sigfigs: 3,
-                magnitude: true,
-                abbr: true
-              }
-            },
+            'key': 'digital_takeup',
+            'label': 'Digital take-up',
+            'isWeighted': true,
+            'value': 1.8901081855159454,
+            'valueTimesVolume': 1324601.0754938435,
+            'volume': 1369650,
+            'valueCount': 2,
+            'format': {
+              'type': 'percent',
+              'sigfigs': 3,
+              'magnitude': true,
+              'abbr': true
+            }
+          },
             {
               key: 'user_satisfaction_score',
               label: 'User satisfaction',
@@ -248,7 +248,7 @@ define([
             digital_takeup = weightedAverages[0];
 
           expect(cost_per_transaction.weighted_average).toEqual(10.3);
-          expect(digital_takeup.weighted_average).toBeCloseTo(0.4);
+          expect(digital_takeup.weighted_average).toBeCloseTo(0.97);
         });
 
         it('sets the weighted_average to be the total value for number_of_transactions', function () {


### PR DESCRIPTION
Test case - /performance/services?filter=stud&sortby=digital_takeup&sortorder=descending
Before - Digital takeup was 100%
After - Digital takeup was 96.7%