### PR TITLE
Revert "Try running builds in io.js too"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-  - "iojs"
 install:
   - travis_retry npm install -g grunt-cli@0.1.9
   - travis_retry npm install


### PR DESCRIPTION
Reverts alphagov/spotlight#913

This was a bad idea. All builds fail now.