### PR TITLE
Services page accessibility

### DIFF
--- a/app/client/views/services-kpi.js
+++ b/app/client/views/services-kpi.js
@@ -104,7 +104,14 @@ function (View, accessibility) {
         'sort-order': newSortOrder
       });
 
-      $target.length && $('html, body').animate({ scrollTop: $target.offset().top});
+      if ($target.length) {
+        $('html, body').animate(
+          { scrollTop: $target.offset().top},
+          function() {
+            $target.attr('tabindex', -1).focus();
+          });
+
+      }
     },
 
     render: function () {

--- a/app/client/views/services-kpi.js
+++ b/app/client/views/services-kpi.js
@@ -1,7 +1,8 @@
 define([
-  'extensions/views/view'
+  'extensions/views/view',
+    'client/accessibility'
 ],
-function (View) {
+function (View, accessibility) {
 
   return View.extend({
 
@@ -11,7 +12,11 @@ function (View) {
 
     initialize: function () {
       View.prototype.initialize.apply(this, arguments);
-      this.listenTo(this.collection, 'reset', this.render);
+      this.listenTo(this.collection, 'reset', _.bind(function() {
+        accessibility.updateLiveRegion('Totals and averages updated for ' + this.collection.length
+        );
+        this.render();
+      }, this));
     },
 
     getAggregateValues: function () {

--- a/app/client/views/table.js
+++ b/app/client/views/table.js
@@ -100,6 +100,17 @@ function (TableView, Modernizr, accessibility, $) {
         ths.removeClass(classDesc);
         ths.removeAttr('aria-sort');
 
+        ths
+          .find('.js-click-sort')
+          .remove()
+          .end()
+          .find('.js-sort')
+          .append(' <span class="js-click-sort visuallyhidden">Click to sort</span>');
+
+        th
+          .find('.js-click-sort')
+          .remove();
+
         if (sortOrder === 'descending') {
           th.addClass(classDesc);
           th.attr('aria-sort', 'descending');

--- a/app/client/views/table.js
+++ b/app/client/views/table.js
@@ -26,11 +26,7 @@ function (TableView, Modernizr, accessibility, $) {
       this.sortFields = _.object(_.pluck(this.sortFields, 'key'), this.sortFields);
 
       this.listenTo(this.collection, 'sort', this.render);
-
-      this.listenTo(this.collection, 'reset', _.bind(function() {
-        accessibility.updateLiveRegion(this.collection.length + ' transactions in list');
-        this.render();
-      }, this));
+      this.listenTo(this.collection, 'reset', this.render);
 
       this.listenTo(this.model, 'change:sort-by change:sort-order', function () { this.sort(); });
       this.listenTo(this.model, 'sort-changed-external', _.bind(function(data) {

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -60,7 +60,9 @@ function (View, Formatters) {
         sortOrder = this.model && this.model.get('sort-order'),
         sortUrlParam,
         sortBy = this.model && this.model.get('sort-by'),
-        headCls;
+        sortOrderAttr,
+        headCls,
+        clickLabel;
 
       head += _.map(this.getColumns(), function (column) {
         var label = column.label;
@@ -76,12 +78,20 @@ function (View, Formatters) {
         } else {
           sortUrlParam = 'ascending';
         }
-        cls = (sortBy === key) ? sortOrder + ' sort-column ' : '';
+        if (sortBy === key) {
+          cls = sortOrder + ' sort-column ';
+          clickLabel = '';
+          sortOrderAttr = sortOrder;
+        } else {
+          cls = '';
+          clickLabel = ' <span class="js-click-sort visuallyhidden">Click to sort</span>';
+          sortOrderAttr = '';
+        }
 
         if (column.format) {
           cls += _.isString(column.format) ? column.format : column.format.type;
         }
-        return '<th scope="col" data-key="' + key + '" class="' + cls + '" aria-sort="' + cls + '" role="columnheader"><a class="js-sort" href="?sortby=' + key + '&sortorder=' + sortUrlParam + '" role="button">' + label + ' <span class="visuallyhidden">Click to sort</span></a></th>';
+        return '<th scope="col" data-key="' + key + '" class="' + cls + '" aria-sort="' + sortOrderAttr + '" role="columnheader"><a class="js-sort" href="?sortby=' + key + '&sortorder=' + sortUrlParam + '" role="button">' + label + clickLabel + '</a></th>';
       }, this).join('\n');
       headCls = (this.options.hideHeader) ? 'visuallyhidden' : '';
       return '<thead class="' + headCls + '"><tr>' + head + '</tr></thead>';

--- a/spec/client/views/spec.table.js
+++ b/spec/client/views/spec.table.js
@@ -200,6 +200,17 @@ function (Table, BaseTable, Collection, Model, $, Modernizr) {
         expect(Table.prototype.replaceUrlParams.calls.length).toEqual(0);
       });
 
+      it('adds a click to sort label for screenreaders to all columns except the sorted one',
+        function() {
+          dateColumn().find('a').click();
+          expect(dateColumn().find('.js-click-sort').length).toEqual(0);
+          expect(valueColumn().find('.js-click-sort').length).toEqual(1);
+          valueColumn().find('a').click();
+          expect(valueColumn().find('.js-click-sort').length).toEqual(0);
+          expect(dateColumn().find('.js-click-sort').length).toEqual(1);
+        });
+
+
     });
 
     describe('render', function () {

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -235,7 +235,7 @@ function (Table, View, Collection, Backbone, $) {
           .toEqual('?sortby=timestamp&sortorder=descending');
       });
 
-      it('add a link to the default column to sort by ascending', function() {
+      it('adds a link to the default column to sort by ascending', function() {
         table = new Table(tableOptions);
         table.render();
         expect(table.$('thead th.descending a').attr('href'))
@@ -262,6 +262,17 @@ function (Table, View, Collection, Backbone, $) {
         expect(result).toEqual(true);
       });
 
+      it('adds a click to sort label for screenreaders to all columns except the sorted one',
+        function() {
+          var unsortedCols;
+
+          table = new Table(tableOptions);
+          table.render();
+          unsortedCols = table.$('thead th:not(.sort-column) .js-click-sort');
+          expect(unsortedCols.length).toEqual(3);
+          expect(unsortedCols.first().text()).toEqual('Click to sort');
+          expect(table.$('thead th.sort-column .js-click-sort').length).toEqual(0);
+      });
 
     });
 


### PR DESCRIPTION
Accessibility recommendations from Leonie Watson - 

1 - Unsorted state.
This is a minor nit. When a column is unsorted the hidden “Click to sort” information is helpful. Once the column has been sorted it isn’t needed though because screen readers will take the sorted state from the aria-sorted attribute. 
Recommend removing the hidden text once a column has been sorted.
 
2 - Link function..
When a link such as “94 services out of 115” is activated, it causes the table to be sorted and for the table to be scrolled into view. Keyboard focus remains on the link though.
Recommend moving keyboard focus to the table when one of these links is activated.

In terms of the live region announcement, keeping it short is a good idea. Your suggestion to indicate what/where something has changed seems like a good one. For example “10 records, totals and averages have been updated”.