### PR TITLE
Remove the word "transactional" from page link

### DIFF
--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -64,7 +64,7 @@
     </div>
     <% }); %>
   </div>
-  <div class="vertical-spacing-small"><a class="link-large" href="/performance/services">See data on all <%= serviceCount %> transactional services</a></div>
+  <div class="vertical-spacing-small"><a class="link-large" href="/performance/services">See data on all <%= serviceCount %> services</a></div>
 
   <h2 class="visuallyhidden">Highest performing services</h2>
   <div class="grid-row">


### PR DESCRIPTION
We have referred to services throughout our homepage. This was the only reference where "transactional services" remained. This is to remove that and gain consistency across the homepage.