### PR TITLE
Restore sticky headers to services table

### DIFF
--- a/app/client/views/services.js
+++ b/app/client/views/services.js
@@ -26,7 +26,6 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
         '.visualisation-table': {
           view: TableView,
           options: {
-            scrollable: false,
             collapseOnNarrowViewport: true,
             caption: 'List of services, which can be filtered and sorted',
             saveSortInUrl: true


### PR DESCRIPTION
Headers should stick as you scroll the table body, in the same way as all other tables on the site.