### PR TITLE
Heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app/server.js
+web: ./node_modules/grunt-cli/bin/grunt build:production && node app/server

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "govuk_template_mustache": "0.12.0",
     "graceful-fs": "3.0.2",
     "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.5.0",
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-copy": "0.5.0",


### PR DESCRIPTION
Heroku crashes due to the digest not being published.

This adds a grunt build before it starts the app.