### PR TITLE
Bump Cheapseats (fix for dashboard JSON download errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {
-    "cheapseats": "git+https://github.com/alphagov/cheapseats#6aa58dd49beed19962a241f9c732836a319d2b8f",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats#4f744b6d748dce470b735351664ad54fd6e55fbf",
     "supervisor": "0.5.7"
   }
 }


### PR DESCRIPTION
Update cheapseats to latest version.