### PR TITLE
Log status / error text of stagecraft request

### DIFF
--- a/app/stagecraft_api_client.js
+++ b/app/stagecraft_api_client.js
@@ -46,7 +46,13 @@ function (Model) {
           'GOVUK-Request-Id': this.govukRequestId,
           'Request-Id': this.requestId
         },
-        error: _.bind(function () {
+        error: _.bind(function (model, xhr) {
+          logger.info('failed to fetch stagecraft response',
+                      {
+                        'path': model.path,
+                        'status': xhr.status,
+                        'errorText': xhr.responseText
+                      });
           this.fetchFallback(options);
         }, this)
       }, options);


### PR DESCRIPTION
This is to help tracking down 404 errors in spotlight that we suspect
are related to stagecraft not responding correctly.