### PR TITLE
Include fallback URLs in "Bar Chart with Number" widget template

### DIFF
--- a/app/server/templates/modules/bar_chart_with_number.html
+++ b/app/server/templates/modules/bar_chart_with_number.html
@@ -1,4 +1,7 @@
 <div class="single-decker-graph">
   <p class="impact-number most-recent-number"></p>
-  <div class="graph timeseries-graph bar"></div>
+  <div class="graph timeseries-graph bar"{{#fallbackUrl}}data-src="{{fallbackUrl}}?selector=.graph-wrapper"{{/fallbackUrl}}>
+    {{#fallbackUrl}}<noscript><img src="{{fallbackUrl}}?selector=.graph-wrapper"/></noscript>{{/fallbackUrl}}
+    </div>
 </div>
+


### PR DESCRIPTION
"Bar Chart with Number" widget didn't have fallback URLs in the template so on IE8 etc. only the number, not the bar chart is displayed.

This version of the template with the fallback URL also uses a selector to exclude the Number region so it isn't displayed twice.

Before:
![screenshot from 2015-03-02 16 54 13](https://cloud.githubusercontent.com/assets/81432/6436052/7d32d10c-c0fd-11e4-87cf-c5a33edfbb2a.png)

After:
![screenshot from 2015-03-02 16 51 17](https://cloud.githubusercontent.com/assets/81432/6436055/827293fa-c0fd-11e4-9ac7-13caf69606d0.png)
