### PR TITLE
Run fewer cheapseats tests in ci-new

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,4 +3,6 @@ set -e
 
 npm install
 
-npm test
+grunt test:unit
+grunt shell:cheapseats:--range:0..1
+grunt test:functional:ci 


### PR DESCRIPTION
ci-new is currently failing frequently and blocking deploys. Until we
can make it more robust we will run fewer cheapseats tests and test more
manually