### PR TITLE
CSS fixes

### DIFF
--- a/styles/common/impact-link.scss
+++ b/styles/common/impact-link.scss
@@ -1,19 +1,27 @@
+/**
+Didn't use core font generators here as needed control over line heights at desktop not mobile
+breakpoint, to keep base lines of large number and text in line
+*/
 .impact-link {
-  @include bold-19;
+  font-size: 19px;
+  font-weight: bold;
+  line-height: 1.1;
   text-decoration: none;
   display: block;
   white-space: nowrap;
 
   @include media(desktop) {
-    @include bold-24;
+    font-size: 24px;
   }
 
   .impact-link-figure {
-    @include bold-48;
+    font-size: 40px;
     display: inline-block;
     vertical-align: text-bottom;
+
     @include media(desktop) {
-      @include bold-60;
+      font-size: 60px;
+      line-height: 1.05;
     }
   }
 
@@ -26,3 +34,4 @@
   }
 
 }
+

--- a/styles/common/table.scss
+++ b/styles/common/table.scss
@@ -138,6 +138,9 @@ table tbody .sort-column {
       text-align: left;
       border-bottom: 0;
       padding: 3px 0;
+      &:first-child {
+        width: 100%;
+      }
     }
     tbody th, tbody td {
       display: block;
@@ -164,3 +167,4 @@ table tbody .sort-column {
     }
   }
 }
+

--- a/styles/pages/homepage.scss
+++ b/styles/pages/homepage.scss
@@ -8,8 +8,10 @@
 .homepage-showcase-item {
   @include bold-19;
   margin-bottom: 5px;
-  &:last-child {
-    margin-bottom: 0;
+  @include media(tablet) {
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -22,3 +24,4 @@
   width: 100%;
   max-width: 602px;
 }
+


### PR DESCRIPTION
- services page - sort headings on mobile - correct misaligned triangle
- home page - even out vertical spacing between showcase links on mobile
- home page - summary numbers - ensure smaller text is vertically aligned with number on smaller viewports
