### PR TITLE
Ability to turn off total label in grouped timeseries

### DIFF
--- a/app/client/views/graph/graph.js
+++ b/app/client/views/graph/graph.js
@@ -365,6 +365,7 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, Hover, Tooltip, Missi
       return View.prototype.remove.apply(this, arguments);
     },
 
+    //TODO: these methods should all be some sort of default options
     isOneHundredPercent: function () {
       return false;
     },

--- a/app/client/views/graph/graph.js
+++ b/app/client/views/graph/graph.js
@@ -371,6 +371,10 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, Hover, Tooltip, Missi
 
     hasTotalLine: function () {
       return false;
+    },
+
+    hasTotalLabel: function () {
+      return true;
     }
 
   });

--- a/app/client/views/graph/graph.js
+++ b/app/client/views/graph/graph.js
@@ -51,8 +51,8 @@ function (View, d3, XAxis, YAxis, YAxisRight, Line, Stack, Hover, Tooltip, Missi
       this.componentInstances = [];
       var defaultComponentOptions = this.getDefaultComponentOptions();
       _.each(this.prop('components'), function (definition) {
-        var options = _.extend({}, defaultComponentOptions, definition.options);
-        this.componentInstances.push(new definition.view(options));
+        var defOptions = _.extend({}, defaultComponentOptions, definition.options);
+        this.componentInstances.push(new definition.view(defOptions));
       }, this);
 
       $(window).on('resize.' + this.cid, _.bind(this.render, this));

--- a/app/client/views/graph/linelabel.js
+++ b/app/client/views/graph/linelabel.js
@@ -148,7 +148,9 @@ function (Component) {
 
       var summary = '<span class="timeperiod">' + output + '</span>';
 
-      if (!this.graph.isOneHundredPercent() && !this.graph.hasTotalLine()) {
+      if (!this.graph.isOneHundredPercent() &&
+        !this.graph.hasTotalLine() &&
+        this.graph.hasTotalLabel()) {
         var total = model.get('total:' + this.graph.valueAttr);
         var formattedTotal = total ? this.format(total, this.getFormatOptions()) : '(no data)';
         summary += ('<span class="total">Total: <strong>' + formattedTotal + '</strong></span>');

--- a/app/client/views/visualisations/grouped-graph/grouped-graph.js
+++ b/app/client/views/visualisations/grouped-graph/grouped-graph.js
@@ -91,6 +91,10 @@ function (Graph, LineLabel) {
       return _.any(this.getLines(), function (line) {
         return this.collection.defined(line.key).length > 0;
       }, this);
+    },
+
+    hasTotalLabel: function () {
+      return _.isUndefined(this.showTotalLabel) ? true : this.showTotalLabel;
     }
 
   });

--- a/app/client/views/visualisations/grouped_timeseries.js
+++ b/app/client/views/visualisations/grouped_timeseries.js
@@ -14,7 +14,8 @@ function (View, StackedGraph, LineGraph) {
           view: graph,
           options: {
             valueAttr: this.valueAttr,
-            formatOptions: this.formatOptions
+            formatOptions: this.formatOptions,
+            showTotalLabel: this.showTotalLabel
           }
         }
       };

--- a/app/common/modules/grouped_timeseries.js
+++ b/app/common/modules/grouped_timeseries.js
@@ -49,7 +49,8 @@ function (GroupedTimeseriesCollection, GroupedTimeshiftCollection) {
     visualisationOptions: function () {
       return {
         valueAttr: this.model.get('value-attribute'),
-        formatOptions: this.model.get('format')
+        formatOptions: this.model.get('format'),
+        showTotalLabel: this.model.get('show-total-label')
       };
     }
 

--- a/app/common/modules/grouped_timeseries.js
+++ b/app/common/modules/grouped_timeseries.js
@@ -28,7 +28,6 @@ function (GroupedTimeseriesCollection, GroupedTimeshiftCollection) {
       return {
         valueAttr: this.model.get('value-attribute'),
         category: this.model.get('category'),
-        showTotalLines: this.model.get('show-total-lines'),
         isOneHundredPercent: this.model.get('one-hundred-percent'),
         useStack: this.model.get('use_stack'),
         axisPeriod: this.model.get('axis-period'),

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -68,6 +68,9 @@ function (LineLabel, Collection, Model) {
           hasTotalLine: function () {
             return false;
           },
+          hasTotalLabel: function () {
+            return true;
+          },
           modelToDate: function () {
             return '2014-01-01';
           },
@@ -309,6 +312,13 @@ function (LineLabel, Collection, Model) {
 
           it('does not render a total for graphs with a total line', function () {
             graph.hasTotalLine = function () { return true; };
+            lineLabel.render();
+            var textLabel = lineLabel.$el.find('figcaption .total');
+            expect(textLabel.length).toEqual(0);
+          });
+
+          it('does not render a total when hasTotalLabel is false', function () {
+            graph.hasTotalLabel = function () { return false; };
             lineLabel.render();
             var textLabel = lineLabel.$el.find('figcaption .total');
             expect(textLabel.length).toEqual(0);

--- a/spec/client/views/views/graph/spec.stacked-linelabel.js
+++ b/spec/client/views/views/graph/spec.stacked-linelabel.js
@@ -33,6 +33,9 @@ function (LineLabel, Collection, Model) {
         hasTotalLine: function () {
           return false;
         },
+        hasTotalLabel: function () {
+          return true;
+        },
         getYPos: function (i, attr) { return collection.at(i).get(attr) ? 2 * collection.at(i).get(attr) : null; },
         getY0Pos: function (i, attr) { return collection.at(i).get(attr); },
         modelToDate: function () {


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/15088/cards/9374

It can be disabled by setting `show-total-label` to false in the dashboard.