### PR TITLE
Graph css fixes

### DIFF
--- a/app/client/views/graph/linelabel.js
+++ b/app/client/views/graph/linelabel.js
@@ -80,7 +80,10 @@ function (Component) {
       events[eventName + ' li'] = function (e) {
         var target = $(e.currentTarget);
         var index = $(this.figcaption.node()).find('li').index(target);
-        this.selectLine(this.positions[index].key);
+        var pos = _.findWhere(this.positions, {
+          lineIndex: index
+        });
+        this.selectLine(pos.key);
         e.stopPropagation();
       };
 
@@ -221,7 +224,7 @@ function (Component) {
       var positions = [];
       var scale = this.scales.y;
       var that = this;
-      selection.each(function (line) {
+      selection.each(function (line, lineIndex) {
         var y = that.getYIdeal(line.key);
 
         var size = $(this).height();
@@ -229,18 +232,17 @@ function (Component) {
         positions.push({
           ideal: scale(y),
           size: size,
-          key: line.key
+          key: line.key,
+          lineIndex: lineIndex
         });
       });
-
-      this.positions = _.clone(positions);
 
       positions = positions.sort(function (a, b) {
         return a.ideal - b.ideal;
       });
 
       // optimise positions
-      positions = this.calcPositions(positions, {
+      positions = this.positions = this.calcPositions(positions, {
         min: this.overlapLabelTop + this.summaryHeight,
         max: this.graph.innerHeight + this.overlapLabelBottom
       });

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -602,13 +602,15 @@ function (LineLabel, Collection, Model) {
         expect(startPositions[0]).toEqual({
           ideal: 49, // yScale was applied to '_count' attribute of last element in line 'a'
           size: 20,
-          key: 'a'
+          key: 'a',
+          lineIndex: 0
         });
         expect(lineLabel.scales.y).toHaveBeenCalledWith(8);
         expect(startPositions[1]).toEqual({
           ideal: 64, // yScale was applied to '_count' attribute of last element in line 'b'
           size: 20,
-          key: 'b'
+          key: 'b',
+          lineIndex: 1
         });
 
         expect($(wrapper.selectAll('li')[0][0]).prop('style').top).toEqual('20px');
@@ -624,13 +626,15 @@ function (LineLabel, Collection, Model) {
         expect(startPositions[0]).toEqual({
           ideal: 16, // yScale was applied to '_count' attribute of penultimate element in line 'a'
           size: 20,
-          key: 'a'
+          key: 'a',
+          lineIndex: 0
         });
         expect(lineLabel.scales.y).toHaveBeenCalledWith(5);
         expect(startPositions[1]).toEqual({
           ideal: 25, // yScale was applied to '_count' attribute of penultimate element in line 'b'
           size: 20,
-          key: 'b'
+          key: 'b',
+          lineIndex: 1
         });
       });
 

--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -583,7 +583,7 @@ figure.graph {
           width: 28%;
         }
         &.labels-for-total li {
-          width: 42%;
+          width: 38%;
         }
       }
     }

--- a/styles/common/graph.scss
+++ b/styles/common/graph.scss
@@ -306,11 +306,6 @@ figure.graph {
         font-size: 14px;
       }
 
-      .value {
-        font-size: 21px;
-        font-weight: bold;
-      }
-
       .timeperiod {
         display: block;
         border-bottom: 1px solid $grey-2;


### PR DESCRIPTION
- Fix bug in grouped time series graph legends where, at narrow viewports only, you can hover over one label and a different one highlights.
- Fix issue caused by [this commit](https://github.com/alphagov/spotlight/commit/56ecbc9e8f90acc9eba2467fcb1eaffee2e2d025) where legend labels on [this dashboard](/performance/student-finance-england-full-time-study-applications/volumetrics) were using a too-large font size.
- Legend labels - reduce likelihood of wrapping