### PR TITLE
Fix formatOptions problems.

### DIFF
--- a/app/client/views/graph/linelabel.js
+++ b/app/client/views/graph/linelabel.js
@@ -104,11 +104,15 @@ function (Component) {
     },
 
     getFormatOptions: function () {
+      var formatOptions = _.isString(this.graph.formatOptions) ?  {
+        type: this.graph.formatOptions
+      } : this.graph.formatOptions;
+
       return _.extend({
           type: 'number',
           magnitude: true,
           pad: true
-        }, this.graph.formatOptions);
+        }, formatOptions);
     },
 
     renderValuePercentage: function (value, percentage) {

--- a/spec/client/views/views/graph/spec.linelabel.js
+++ b/spec/client/views/views/graph/spec.linelabel.js
@@ -732,6 +732,48 @@ function (LineLabel, Collection, Model) {
 
     });
 
+    describe('getFormatOptions', function () {
+      var line;
+      beforeEach(function () {
+        line = new LineLabel({
+          interactive: false,
+          collection: new Collection([]),
+          graph: {}
+        });
+      });
+
+      it('will return format defaults', function () {
+        expect(line.getFormatOptions()).toEqual({
+          type : 'number',
+          magnitude : true,
+          pad : true
+        });
+      });
+
+      it('will extend the format options with the formatOptions from the dashboard', function () {
+        line.graph.formatOptions = {
+          type: 'currency',
+          dps: 2
+        };
+        expect(line.getFormatOptions()).toEqual({
+          type : 'currency',
+          magnitude : true,
+          pad : true,
+          dps : 2
+        });
+      });
+
+      it('will extend the format options when formatOptions is a string', function () {
+        line.graph.formatOptions = 'percent';
+        expect(line.getFormatOptions()).toEqual({
+          type : 'percent',
+          magnitude : true,
+          pad : true
+        });
+      });
+
+    });
+
     describe('calcPositions', function () {
 
       var line;


### PR DESCRIPTION
When format is specified as `format: 'currency'` shorthand the property is not used.

This fix puts it in line with how formatting is done elsewhere on spotlight.

If format is specified like so:

`format: 'percent'`

Spotlight mixes it into the format defaults.

If it's:

```
format: {
  type: 'percent'
}
```

It will also mix that into the defaults.

Added tests around this as there were none.