### PR TITLE
Cheapseats - allow subset of dashboards to be run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
     - master
 env:
   - TEST_CMD: test:unit
-  # - TEST_CMD: shell:cheapseats:--range:0..1
+  - TEST_CMD: shell:cheapseats
   - TEST_CMD: test:functional:ci
 # Add back in when we're out of emergency mode
 #   - TEST_CMD: shell:cheapseats:--range:0..50

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,7 +126,7 @@ module.exports = function (grunt) {
             consolidate: true
           }
         }
-      },
+      }
     },
     // Sets up server-side Jasmine node tests
     // Lints our JavaScript
@@ -223,8 +223,17 @@ module.exports = function (grunt) {
       }
     },
     shell: {
-      // Runs cheapseats tests
+      // Runs subset of cheapseats tests
       cheapseats: {
+        options: {
+          failOnError: true,
+          stderr: true,
+          stdout: true
+        },
+        command: addArgs('node ./node_modules/cheapseats/index.js --reporter dot-retry --standalone --path --quickrun ./')
+      },
+      // Runs all cheapseats tests
+      cheapseats_full_run: {
         options: {
           failOnError: true,
           stderr: true,

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Tests are divided into ones that work on both client and server (`test/spec/shar
 
 - `grunt jasmine_node` executes shared and server Jasmine tests in Node.js
 - `grunt jasmine` executes shared and client Jasmine tests in PhantomJS
-- `grunt shell:cheapseats` executes feature tests using [cheapseats][]
+- `grunt shell:cheapseats` executes feature tests using [cheapseats][] with a small subset of dashboards, for speed
+- `grunt shell:cheapseats_full_run` runs cheapseats with all dashboards
 - `grunt test:functional` executes functional tests using [nightwatch][https://github.com/beatfactor/nightwatch]
 
 ##### Functional tests #####

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,4 +4,4 @@ set -e
 npm install
 
 grunt test:unit
-grunt shell:cheapseats:--range:0..1
+grunt shell:cheapseats

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {
-    "cheapseats": "git+https://github.com/alphagov/cheapseats#4f744b6d748dce470b735351664ad54fd6e55fbf",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats#61a6fda212c00272cd3fa708e77fe545a24467d1",
     "supervisor": "0.5.7"
   }
 }


### PR DESCRIPTION
For a balance of good coverage and speed for CI, add a flag to allow Cheapseats to be run with a small subset of dashboards. 
- command line flag for cheapseats (--quickrun). Updated travis and jenkins scripts to use this.
- new grunt task - cheapseats_quick_run
