### PR TITLE
Bar graph labels - avoid overlapping

### DIFF
--- a/styles/common/bar_chart_with_number.scss
+++ b/styles/common/bar_chart_with_number.scss
@@ -3,6 +3,6 @@
     font-weight:bold;
   }
   .x-axis .tick text {
-    font-size: 12px;
+    font-size: 11px;
   }
 }


### PR DESCRIPTION
By bumping font size down slightly