### PR TITLE
For grouped line graph, set min Y value to zero

### DIFF
--- a/app/client/views/visualisations/grouped-graph/line-graph.js
+++ b/app/client/views/visualisations/grouped-graph/line-graph.js
@@ -8,6 +8,8 @@ function (Graph, LineSet) {
 
     GroupClass: LineSet,
 
+    minYDomainExtent: 0,
+
     maxValue: function () {
       return _.reduce(this.getLines(), function (max, line) {
         return Math.max(max, this.collection.max(line.key) || 0);


### PR DESCRIPTION
So that modules with many low values have a sensible Y axis range.

Story - https://www.pivotaltracker.com/n/projects/911872/stories/89863070

![dashboard public services network government conveyance network performance gov uk](https://cloud.githubusercontent.com/assets/471250/6579414/0aa58936-c742-11e4-8bed-846888bc04da.png)
