### PR TITLE
Take big screen root URL from config

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -29,6 +29,7 @@ module.exports = {
       app.set('clientRequiresCors', global.config.clientRequiresCors);
       app.set('port', global.config.port);
       app.set('stagecraftUrl', global.config.stagecraftUrl);
+      app.set('bigScreenBaseURL', global.config.bigScreenBaseURL);
       app.use(morgan('dev'));
       app.use(compression());
       app.use('/spotlight', express['static'](path.join(rootDir, 'public')));

--- a/app/page_config.js
+++ b/app/page_config.js
@@ -14,6 +14,7 @@ function () {
       environment: req.app.get('environment'),
       backdropUrl: req.app.get('backdropUrl'),
       clientRequiresCors: req.app.get('clientRequiresCors'),
+      bigScreenBaseURL: req.app.get('bigScreenBaseURL'),
       requestId: req.get('Request-Id'),
       govukRequestId: req.get('GOVUK-Request-Id')
     };

--- a/app/server/templates/dashboard.html
+++ b/app/server/templates/dashboard.html
@@ -48,7 +48,7 @@
   {{# hasBigScreenView }}
     <div class="big-screen-link-container">
       <h3>View the dashboard</h3>
-      <a class="big-screen-link" href="https://www.performance.service.gov.uk/big-screen/{{ slug }}">Full screen mode</a>
+      <a class="big-screen-link" href="{{ bigScreenBaseURL }}/big-screen/{{ slug }}">Full screen mode</a>
     </div>
   {{/ hasBigScreenView }}
   </aside>

--- a/config/config.development.json
+++ b/config/config.development.json
@@ -6,5 +6,6 @@
   "screenshotServiceUrl": "http://localhost:3060",
   "govukHost": "www.alphagov.co.uk",
   "stagecraftUrl": "https://stagecraft.production.performance.service.gov.uk",
-  "statsdPrefix": "pp.apps.spotlight"
+  "statsdPrefix": "pp.apps.spotlight",
+  "bigScreenBaseURL": "https://www.performance.service.gov.uk"
 }

--- a/spec/server/spec.page_config.js
+++ b/spec/server/spec.page_config.js
@@ -10,7 +10,8 @@ function (PageConfig) {
       get.plan = function (prop) {
         return {
           assetPath: '/path/to/assets/',
-          govukHost: 'www.gov.uk'
+          govukHost: 'www.gov.uk',
+          bigScreenBaseURL: 'https://www.performance.service.gov.uk'
         }[prop];
       };
       var headers = jasmine.createSpy();
@@ -40,6 +41,10 @@ function (PageConfig) {
       it('contains assetPath property', function () {
         var commonConfig = PageConfig.commonConfig(req);
         expect(commonConfig.assetPath).toEqual('/path/to/assets/');
+      });
+      it('contains bigScreenBaseURL property', function () {
+        var commonConfig = PageConfig.commonConfig(req);
+        expect(commonConfig.bigScreenBaseURL).toEqual('https://www.performance.service.gov.uk');
       });
       it('contains assetPath property', function () {
         var commonConfig = PageConfig.commonConfig(req);


### PR DESCRIPTION
Use config from [pp-deployment](https://github.gds/gds/pp-deployment/pull/458) to set root URL for big screen link from dashboards.