### PR TITLE
Services page analytics events

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function (grunt) {
     // Lints our JavaScript
     jshint: {
       browser: {
-        src: ['app/client/*.js', 'spec/client/*.js'],
+        src: ['app/client/**/*.js', 'spec/client/**/*.js'],
         options: {
           reporter: require('jshint-stylish'),
           jshintrc: true,
@@ -141,7 +141,7 @@ module.exports = function (grunt) {
       },
       node: {
         src: ['app/**/*.js', 'app/**/*.json', 'spec/**/*.js', 'tools/**/*.js',
-          '!app/client/*.js', '!spec/client/*.js'],
+          '!app/client/**/*.js', '!spec/client/**/*.js'],
         options: {
           reporter: require('jshint-stylish'),
           jshintrc: true,

--- a/app/client/views/services-kpi.js
+++ b/app/client/views/services-kpi.js
@@ -10,8 +10,10 @@ function (View, accessibility) {
       'click .js-sort-by': 'updateSort'
     },
 
-    initialize: function () {
+    initialize: function (options) {
       View.prototype.initialize.apply(this, arguments);
+      this.options = options || {};
+
       this.listenTo(this.collection, 'reset', _.bind(function() {
         var unit = this.model.get('noun');
         if (this.collection.length !== 1) {
@@ -114,6 +116,13 @@ function (View, accessibility) {
             $target.attr('tabindex', -1).focus();
           });
 
+      }
+
+      if (this.options.analytics && this.options.analytics.category) {
+        GOVUK.analytics.trackEvent(this.analytics.category, 'summaryLinkClicked', {
+          label: newSortField,
+          nonInteraction: true
+        });
       }
     },
 

--- a/app/client/views/services.js
+++ b/app/client/views/services.js
@@ -9,11 +9,19 @@ define([
 function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
   return View.extend({
 
+    analyticsCategory: 'ppServices',
+
     events: _.extend({}, View.prototype.events, {
-      'keyup #filter': 'filter',
-      'search #filter': 'filter',
+      'keyup #filter': function() {
+        this.filter('filter');
+      },
+      'search #filter': function() {
+        this.filter('filter');
+      },
       'submit #filter-wrapper': 'filterFormSubmit',
-      'change #department': 'filter',
+      'change #department': function() {
+        this.filter('departmentFilter');
+      },
       'click .filter-remove': 'removeFilter'
     }),
 
@@ -28,14 +36,22 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
           options: {
             collapseOnNarrowViewport: true,
             caption: 'List of services, which can be filtered and sorted',
-            saveSortInUrl: true
+            saveSortInUrl: true,
+            analytics: {
+              category: this.analyticsCategory
+            }
           }
         },
         '.summary-figure': {
           view: SummaryFigureView
         },
         '.service-kpis': {
-          view: ServicesKPIS
+          view: ServicesKPIS,
+          options: {
+            analytics: {
+              category: this.analyticsCategory
+            }
+          }
         }
       };
     },
@@ -45,7 +61,7 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
       this.filter();
     },
 
-    filter: function () {
+    filter: function (type) {
       var filterVal = this.$('#filter').val(),
         deptFilterVal = this.$('#department').val();
 
@@ -69,12 +85,21 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $) {
         params = $.param(params);
         window.history.replaceState(null, null, '?' + params);
       }
+
+      this.filterAnalytics(type, this.model.get(type));
     },
 
     removeFilter: function (event) {
       var filter = $(event.target).data('filter');
       this.$('#' + filter).val('');
       this.model.set(filter + 'Filter', null);
+    },
+
+    filterAnalytics: function(type, value) {
+      GOVUK.analytics.trackEvent(this.analyticsCategory, type, {
+        label: value,
+        nonInteraction: true
+      });
     }
 
   });

--- a/app/client/views/table.js
+++ b/app/client/views/table.js
@@ -40,10 +40,10 @@ function (TableView, Modernizr, accessibility, $, _) {
     },
 
     events: {
-      'click .js-sort': 'sortCol'
+      'click .js-sort': 'sortColumnClicked'
     },
 
-    sortCol: function (e) {
+    sortColumnClicked: function (e) {
       e.preventDefault();
 
       var th = $(e.target).closest('th'),
@@ -66,6 +66,14 @@ function (TableView, Modernizr, accessibility, $, _) {
       this.screenreaderAnnounceSortChange(sortBy, this.model.get('sort-order'));
       if (this.options.saveSortInUrl) {
         this.updateUrlWithSort();
+      }
+
+      if (this.options.analytics && this.options.analytics.category) {
+        GOVUK.analytics.trackEvent(this.analytics.category, 'sort', {
+          label: this.model.get('sort-by'),
+          value: this.model.get('sort-order') === 'ascending' ? 0 : 1,
+          nonInteraction: true
+        });
       }
     },
 

--- a/spec/client/common/views/spec.services.js
+++ b/spec/client/common/views/spec.services.js
@@ -5,27 +5,45 @@ define([
 
   describe('Services View', function () {
 
-    var $el;
-
     beforeEach(function () {
       spyOn(window.history, 'replaceState');
-      $el = $('<div><input id="filter"/><select id="department"><option value="">All</option><option value="home-office">Home Office</option></select></div>');
+      window.GOVUK = {
+        analytics: {
+          trackEvent: function () {}
+        }
+      };
+      this.$el = $('<div><input id="filter" value="passport"/><select id="department"><option value="">All</option><option value="home-office">Home Office</option></select></div>');
+      this.view = new ServicesView({
+        el: this.$el,
+        model: new Backbone.Model()
+      });
     });
 
     it('uses the history API to update the URL after filtering', function () {
-      $el.find('#filter').val('passport');
-      var view = new ServicesView({
-        el: $el,
-        model: new Backbone.Model()
-      });
-      view.filter();
+      this.view.filter();
       expect(window.history.replaceState).toHaveBeenCalledWith(null, null, '?filter=passport');
-      $el.find('#department').val('home-office');
-      view.filter();
+      this.$el.find('#department').val('home-office');
+      this.view.filter();
       expect(window.history.replaceState).toHaveBeenCalledWith(null, null, '?filter=passport&department=home-office');
-      $el.find('#filter').val('');
-      view.filter();
+      this.$el.find('#filter').val('');
+      this.view.filter();
       expect(window.history.replaceState).toHaveBeenCalledWith(null, null, '?department=home-office');
+    });
+
+    it('sends filter events to analytics', function() {
+
+      spyOn(window.GOVUK.analytics, 'trackEvent');
+      this.$el.find('#filter').val('carer').trigger('search');
+      expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'filter', {
+        label: 'carer',
+        nonInteraction: true
+      });
+
+      this.$el.find('#department').val('home-office').trigger('change');
+      expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'departmentFilter', {
+        label: 'home-office',
+        nonInteraction: true
+      });
     });
 
   });

--- a/spec/client/views/spec.services-kpi.js
+++ b/spec/client/views/spec.services-kpi.js
@@ -172,6 +172,31 @@ define([
           this.summary.$el.find('.js-sort-by').click();
           expect(this.summary.model.get('sort-order')).toEqual('ascending');
         });
+
+
+        it('sends sort events to analytics', function() {
+          var $el = $('<div><div class="digital_takeup"><div class="visualisation-moreinfo">weighted average for <a href="#filtered-list" class="js-sort-by" data-sort-by="number_of_transactions"><span class="value-count">17</span> out of <span class="filtered-count">116</span></a></div></div></div>');
+
+          ServicesCollection.prototype.getAggregateValues.andReturn([]);
+
+          this.summary = new ServicesKPIView({
+            el: $el,
+            model: new Model({
+              'sort-by': 'cost_per_transaction'
+            }),
+            collection: new ServicesCollection([], servicesAxes),
+            analytics: {
+              category: 'ppServices'
+            }
+          });
+
+          spyOn(window.GOVUK.analytics, 'trackEvent');
+          this.summary.$el.find('.js-sort-by').click();
+          expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'summaryLinkClicked', {
+            label: 'number_of_transactions',
+            nonInteraction: true
+          });
+        });
       });
 
 

--- a/spec/client/views/spec.table.js
+++ b/spec/client/views/spec.table.js
@@ -104,6 +104,11 @@ function (Table, BaseTable, Collection, Model, $, Modernizr) {
           '<tr><td class="" width="">2014-07-03T13:23:04+00:00</td>' +
           '<td class="" width="">hello world</td></tr></tbody></table>'
         );
+        window.GOVUK = {
+          analytics: {
+            trackEvent: function () {}
+          }
+        };
         table = new Table({
           el: $el,
           model: new Model(),
@@ -124,7 +129,10 @@ function (Table, BaseTable, Collection, Model, $, Modernizr) {
               y: [{ label: 'another', key: 'value' }]
             }
           }),
-          saveSortInUrl: true
+          saveSortInUrl: true,
+          analytics: {
+            category: 'ppServices'
+          }
         });
 
         table.render();
@@ -210,6 +218,28 @@ function (Table, BaseTable, Collection, Model, $, Modernizr) {
           expect(dateColumn().find('.js-click-sort').length).toEqual(1);
         });
 
+      it('sends sort events to analytics', function() {
+
+        spyOn(window.GOVUK.analytics, 'trackEvent');
+        dateColumn().find('a').click();
+        expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'sort', {
+          label: '_timestamp',
+          value: 1,
+          nonInteraction: true
+        });
+        valueColumn().find('a').click();
+        expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'sort', {
+          label: 'value',
+          value: 1,
+          nonInteraction: true
+        });
+        valueColumn().find('a').click();
+        expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'sort', {
+          label: 'value',
+          value: 0,
+          nonInteraction: true
+        });
+      });
 
     });
 


### PR DESCRIPTION
Analytics events sent for the following user actions:
- Filter list of services by text or department dropdown
- Sort table by column headings
- Click links below summary figures to sort table

All will appear under the events category 'ppServices'