### PR TITLE
Homepage - check if showcase service is found before adding

### DIFF
--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -140,6 +140,27 @@ describe('Services Controller', function () {
     }));
   });
 
+  it('creates a list of showcase services', function () {
+    var showcaseServices;
+    controller('services', req, res);
+    client_instance.trigger('sync');
+    showcaseServices = ServicesView.prototype.initialize.calls[0].args[0].showcaseServices;
+    expect(_.pluck(showcaseServices, 'slug')).toEqual(controller.showcaseServiceSlugs);
+  });
+
+  it('only lists showcase services that have data', function () {
+    var showcaseServices,
+      dashboardList;
+    controller('services', req, res);
+    dashboardList = _.reject(client_instance.get('items'),
+      {slug: controller.showcaseServiceSlugs[0]});
+
+    client_instance.set('items', dashboardList);
+    client_instance.trigger('sync');
+    showcaseServices = ServicesView.prototype.initialize.calls[0].args[0].showcaseServices;
+    expect(_.pluck(showcaseServices, 'slug')).toEqual(controller.showcaseServiceSlugs.slice(1));
+  });
+
   it('renders the services view', function () {
     controller('services', req, res);
     client_instance.trigger('sync');


### PR DESCRIPTION
There are 4 predefined 'showcase' services to display at the top of the home page - 'prison-visits', 'book-practical-driving-test', 'carers-allowance', 'renew-patent'
There wasn't a proper check that each of these was present in the list of dashboards from the API, before adding to a list for rendering. This has now been corrected and error logging improved.