### PR TITLE
Dashboard template for 'other' dashboards

### DIFF
--- a/app/server/controllers/dashboard.js
+++ b/app/server/controllers/dashboard.js
@@ -6,6 +6,7 @@ var DashboardView = require('../views/dashboard');
 var ContentDashboardView = require('../views/dashboards/content');
 var TransactionDashboardView = require('../views/dashboards/transaction');
 var DeptDashboardView = require('../views/dashboards/department');
+var OtherDashboardView = require('../views/dashboards/other');
 
 module.exports = Controller.extend({
 
@@ -21,6 +22,8 @@ module.exports = Controller.extend({
       this.viewClass = DeptDashboardView;
     } else if (type === 'content') {
       this.viewClass = ContentDashboardView;
+    } else if (type === 'other') {
+      this.viewClass = OtherDashboardView;
     }
   },
 

--- a/app/server/templates/dashboard.html
+++ b/app/server/templates/dashboard.html
@@ -18,12 +18,12 @@
 
     <div class='related-pages'>
 
-      {{# relatedPages.transaction }}
+      {{# relatedPages.transaction.url }}
       <div class="related-transaction" itemscope itemtype="{{ schemaOrgItemType }}">
         <h3>Visit this service</h3>
         <a itemprop="name" href="{{{ relatedPages.transaction.url }}}">{{ relatedPages.transaction.title }}</a>
       </div>
-      {{/ relatedPages.transaction }}
+      {{/ relatedPages.transaction.url }}
 
       {{# relatedPages.other.length }}
       <div class="related-other">

--- a/app/server/views/dashboards/other.js
+++ b/app/server/views/dashboards/other.js
@@ -1,0 +1,16 @@
+var DashboardView = require('../dashboard');
+
+module.exports = DashboardView.extend({
+
+  getContext: function () {
+    var context = DashboardView.prototype.getContext.apply(this, arguments);
+    return _.extend(context, {
+      hasFooter: true
+    });
+  },
+
+  getTagline: function () {
+    return this.model.get('description');
+  }
+
+});

--- a/spec/server-pure/controllers/spec.dashboard.js
+++ b/spec/server-pure/controllers/spec.dashboard.js
@@ -1,10 +1,10 @@
 var requirejs = require('requirejs');
 
 var Dashboard = require('../../../app/server/controllers/dashboard');
-var DashboardView = require('../../../app/server/views/dashboard');
 var ContentDashboardView = require('../../../app/server/views/dashboards/content');
 var TransactionDashboardView = require('../../../app/server/views/dashboards/transaction');
 var DeptDashboardView = require('../../../app/server/views/dashboards/department');
+var OtherDashboardView = require('../../../app/server/views/dashboards/other');
 
 var Controller = requirejs('extensions/controllers/controller');
 var Model = requirejs('extensions/models/model');
@@ -56,7 +56,7 @@ describe('Dashboard', function () {
       controller = new Dashboard({
         model: model
       });
-      expect(controller.viewClass).toEqual(DashboardView);
+      expect(controller.viewClass).toEqual(OtherDashboardView);
 
     });
 

--- a/spec/server-pure/views/spec.dashboard.js
+++ b/spec/server-pure/views/spec.dashboard.js
@@ -3,6 +3,7 @@ var requirejs = require('requirejs');
 var DashboardView = require('../../../app/server/views/dashboard');
 var ContentDashboardView = require('../../../app/server/views/dashboards/content');
 var TransactionDashboardView = require('../../../app/server/views/dashboards/transaction');
+var OtherDashboardView = require('../../../app/server/views/dashboards/other');
 var DeptDashboardView = require('../../../app/server/views/dashboards/department');
 
 var Model = requirejs('extensions/models/model');
@@ -449,5 +450,43 @@ describe('DeptDashboardView', function () {
     });
 
   });
+
+});
+
+
+describe('OtherDashboardView', function () {
+
+  var view, model;
+  beforeEach(function () {
+    model = new Model({
+      foo: 'bar',
+      'dashboard-type': 'other',
+      title: 'Cabinet Office IT',
+      description: 'Test description',
+      department: {
+        title: 'Cabinet Office'
+      }
+    });
+    view = new OtherDashboardView({
+      model: model,
+      contentTemplate: jasmine.createSpy().andReturn('rendered')
+    });
+    spyOn(view, 'loadTemplate').andReturn('rendered');
+  });
+
+  describe('getTagline', function () {
+
+    it('returns the description', function () {
+      expect(view.getTagline()).toEqual('Test description');
+    });
+
+  });
+
+  it('displays a footer on detailed dashboards', function () {
+    view.getContent();
+    var context = view.loadTemplate.argsForCall[0][1];
+    expect(context.hasFooter).toEqual(true);
+  });
+
 
 });


### PR DESCRIPTION
New template type for 'Other' dashboards.
- description duplicated to section below main heading (replacing tagline)
- footer displayed by default

also -
- link to service only shown if URL supplied from API (bug fix for all dashboard templates)

