### PR TITLE
Fix - update the services filter before rendering

### DIFF
--- a/app/client/controllers/services.js
+++ b/app/client/controllers/services.js
@@ -24,6 +24,7 @@ define([
     renderView: function (options) {
       this.unfilteredCollection = new ServicesCollection(this.collection.models, this.collection.options);
 
+      this.updateCollectionFilter();
       options = _.extend({}, this.viewOptions(), options);
       if (!this.view) {
         this.view = new this.viewClass(options);


### PR DESCRIPTION
To prevent the view always rendering with the full set of models.