### PR TITLE
Specific caching directives for error HTML

### DIFF
--- a/app/extensions/controllers/controller.js
+++ b/app/extensions/controllers/controller.js
@@ -18,6 +18,8 @@ define([
     collectionOptions: function () {},
     collectionData: function () { return []; },
 
+    cacheOptions: function() { return 'public, max-age=600'; },
+
     renderView: function (options) {
       options = _.extend({}, this.viewOptions(), options);
 

--- a/app/process_request.js
+++ b/app/process_request.js
@@ -14,7 +14,7 @@ var renderContent = function (req, res, model) {
   });
 
   controller.once('ready', function () {
-    res.set('Cache-Control', 'public, max-age=600');
+    res.set('Cache-Control', controller.cacheOptions());
     if (model.get('published') !== true) {
       res.set('X-Robots-Tag', 'none');
     }

--- a/app/server/controllers/error.js
+++ b/app/server/controllers/error.js
@@ -4,5 +4,7 @@ var Controller = requirejs('extensions/controllers/controller');
 var ErrorView = require('../views/error');
 
 module.exports = Controller.extend({
+  cacheOptions: function() { return 'public, max-age=5'; },
+
   viewClass: ErrorView
 });

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -95,14 +95,16 @@ var renderContent = function (req, res, client_instance) {
         otherDashboards: otherDashboards,
         showcaseServices: showcaseServices
       });
+      // only mark good responses as being cacheable
+      res.set('Cache-Control', 'public, max-age=7200');
     } else {
       view = new ErrorView({
         model: model,
         collection: collection
       });
+      res.set('Cache-Control', 'public, max-age=5');
     }
     view.render();
-    res.set('Cache-Control', 'public, max-age=7200');
     res.send(view.html);
   });
 

--- a/spec/server-pure/controllers/spec.services.js
+++ b/spec/server-pure/controllers/spec.services.js
@@ -46,7 +46,9 @@ describe('Services Controller', function () {
 
 
     spyOn(PageConfig, 'commonConfig').andReturn({
-      config: 'setting'
+      config: 'setting',
+      assetPath: '/test-spotlight/',
+      assetDigest: 'testAssetDigest'
     });
     spyOn(Backbone.Model.prototype, 'initialize');
     spyOn(Backbone.Collection.prototype, 'initialize');
@@ -222,6 +224,15 @@ describe('Services Controller', function () {
     });
     client_instance.trigger('sync');
     expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=7200');
+  });
+
+  it('has a shorter explicit caching policy for errors', function () {
+    client_instance = controller('services', req, res);
+    client_instance.set({
+      'status': 500
+    });
+    client_instance.trigger('sync');
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=5');
   });
 
 });

--- a/spec/server-pure/spec.process_request.js
+++ b/spec/server-pure/spec.process_request.js
@@ -4,6 +4,7 @@ var processRequest = require('../../app/process_request');
 
 var Model = requirejs('extensions/models/model');
 var Controller = requirejs('extensions/controllers/controller');
+var ErrorController = require('../../app/server/controllers/error');
 var View = requirejs('extensions/views/view');
 
 describe('processRequest middleware', function () {
@@ -91,6 +92,20 @@ describe('processRequest middleware', function () {
       controller.html = 'test content';
       controller.trigger('ready');
       expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=600');
+    });
+
+    it('has an explicit caching policy for errors', function () {
+      var ConcreteController = ErrorController.extend({
+          render: jasmine.createSpy()
+        });
+
+      model = new Model({
+        controller: ConcreteController
+      });
+      var controller = processRequest.renderContent(req, res, model);
+      controller.html = 'test content';
+      controller.trigger('ready');
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=5');
     });
 
     it('instructs search engines not to index unpublished dashboards', function () {


### PR DESCRIPTION
If an attempt to render a dashboard fails, we should not cache the
response for the normal period. Instead, allow a small window to allow
the system to recover if it’s under load.