### PR TITLE
Fixes no-data when selecting current month.

### DIFF
--- a/app/client/views/date-picker.js
+++ b/app/client/views/date-picker.js
@@ -38,7 +38,7 @@ define([
         to = to.endOf(this.interval);
 
         if (to.isAfter(now)) {
-          to = now;
+          to = now.subtract(1, 'day');
         }
 
         if (period === 'week') {

--- a/spec/client/common/views/spec.date-picker.js
+++ b/spec/client/common/views/spec.date-picker.js
@@ -130,7 +130,7 @@ define([
 
         expect(collection.dataSource.setQueryParam).toHaveBeenCalledWith({
           start_at: '2013-06-01T00:00:00Z',
-          end_at: '2014-07-18T01:02:03Z'
+          end_at: '2014-07-17T01:02:03Z'
         });
 
       });


### PR DESCRIPTION
Our collectors run once a day so daily data is always one day behind.

If you select the current month then we need to roll back a day from (now) so that we don't show no data for the current month...