### PR TITLE
The drop-down lists to select services by department are inconsistent with those on the rest of gov.uk

### DIFF
--- a/app/server/templates/dashboard.html
+++ b/app/server/templates/dashboard.html
@@ -126,12 +126,12 @@
       {{/ service }}
 
       {{# agency }}
-      <h3>Agency:</h3>
+      <h3>Other department or public body:</h3>
       <p class="footer-text">{{ agency.title }}</p>
       {{/ agency }}
 
       {{# department }}
-      <h3>Department:</h3>
+      <h3>Ministerial department:</h3>
       <p class="footer-text">{{ department.title }}</p>
       {{/ department }}
 

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -11,8 +11,8 @@
     <div class="cols3">
       <label for="department" id="filter-department"><span aria-hidden="true">Department</span><span class="visuallyhidden">Select a department or agency to filter services by</span></label>
       <select id="department" name="department">
-        <option value="">All departments and agencies</option>
-        <optgroup label="Departments">
+        <option value="">All departments</option>
+        <optgroup label="Ministerial departments">
           <% _.each(departments, function (department) { %>
           <option value="<%= department.slug %>"
           <% if (department.slug === departmentFilter) { %>selected<% } %>><%= department.title
@@ -20,7 +20,7 @@
           <% }); %>
         </optgroup>
         <% if (agencies.length) {%>
-        <optgroup label="Agencies">
+        <optgroup label="Other departments &amp; public bodies">
           <% _.each(agencies, function (agency) { %>
           <option value="agency:<%= agency.slug %>"
           <% if ('agency:' + agency.slug === departmentFilter) { %>selected<% } %>><%= agency.title

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "xmlhttprequest": "1.6.0"
   },
   "devDependencies": {
-    "cheapseats": "git+https://github.com/alphagov/cheapseats#69d31d8a12607bbd43b0350904cdc57891a3c37f",
+    "cheapseats": "git+https://github.com/alphagov/cheapseats#63ce6caecd6e5a772c248fe3f9fa03fd30121327",
     "performanceplatform-js-style-configs": "0.0.2",
     "supervisor": "0.5.7"
   }


### PR DESCRIPTION
Changed the copy in the list headers to:

Departments to Ministerial departments
Agencies to Other departments & public bodies

Also changed the footer of the dashboards:

Department to Ministerial department
Agency to Other department or public body