### PR TITLE
Ensure we 404 on a bad query param request.

### DIFF
--- a/app/process_request.js
+++ b/app/process_request.js
@@ -5,6 +5,7 @@ var PageConfig = requirejs('page_config');
 var get_dashboard_and_render = require('./server/mixins/get_dashboard_and_render');
 
 var renderContent = function (req, res, model) {
+
   model.set(PageConfig.commonConfig(req));
 
   var ControllerClass = model.get('controller');
@@ -29,8 +30,14 @@ var renderContent = function (req, res, model) {
 
 var setup = function (req, res) {
   var client_instance = setup.get_dashboard_and_render(req, res, setup.renderContent);
-  client_instance.set('script', true);
-  client_instance.setPath(req.url.replace('/performance', ''));
+  if (req.path.indexOf('&') > 0) {
+    client_instance.set('status', 404);
+    client_instance.set('controller', client_instance.controllers.error);
+    client_instance.trigger('error');
+  } else {
+    client_instance.set('script', true);
+    client_instance.setPath(req.path.replace('/performance', ''));
+  }
 };
 
 setup.renderContent = renderContent;

--- a/spec/server-pure/spec.process_request.js
+++ b/spec/server-pure/spec.process_request.js
@@ -30,6 +30,7 @@ describe('processRequest middleware', function () {
       get: headers,
       originalUrl: 'test url',
       route: {},
+      path: '/performance/carers-allowance',
       url: '/performance/carers-allowance'
     };
     res = {
@@ -51,6 +52,16 @@ describe('processRequest middleware', function () {
     it('removes the /performance part of the slug when setting the path', function () {
       processRequest(req, res);
       expect(client.setPath).toHaveBeenCalledWith('/carers-allowance');
+    });
+
+    it('it will 404 on requests with & that are not query params', function () {
+      req.path = '/performance/carers-allowance&';
+      //we need to create a fake controller map here as process_request links to the error controller on 404
+      client.controllers = {
+        error: true
+      };
+      processRequest(req, res);
+      expect(client.get('status')).toEqual(404);
     });
 
   });


### PR DESCRIPTION
Before we would always pass all traffic through to stagecraft and let that work out if a url was valid.

We now ensure that urls like ```/performance/carers-allowance&quot``` do not get passed through to stagecraft and instead just 404 like they should.