### PR TITLE
Removed category from grouped_timeseries.

### DIFF
--- a/app/common/modules/grouped_timeseries.js
+++ b/app/common/modules/grouped_timeseries.js
@@ -27,7 +27,6 @@ function (GroupedTimeseriesCollection, GroupedTimeshiftCollection) {
     collectionOptions: function () {
       return {
         valueAttr: this.model.get('value-attribute'),
-        category: this.model.get('category'),
         isOneHundredPercent: this.model.get('one-hundred-percent'),
         useStack: this.model.get('use_stack'),
         axisPeriod: this.model.get('axis-period'),

--- a/spec/shared/common/collections/spec.grouped_timeseries.js
+++ b/spec/shared/common/collections/spec.grouped_timeseries.js
@@ -72,7 +72,6 @@ function (GroupedTimeseries) {
           }
         },
         valueAttr: 'some:value',
-        category: 'some-category',
         axes: {
           x: {
             'label': 'Date',
@@ -173,7 +172,6 @@ function (GroupedTimeseries) {
             }
           },
           valueAttr: 'some:value',
-          category: 'some-category',
           axes: {
             x: {
               'label': 'Date',
@@ -213,7 +211,6 @@ function (GroupedTimeseries) {
           'data-type': 'some-type',
           'data-group': 'some-group',
           valueAttr: 'some:value',
-          category: 'some-category',
           period: 'month',
           axes: {
             x: {

--- a/spec/shared/common/collections/spec.grouped_timeshift.js
+++ b/spec/shared/common/collections/spec.grouped_timeshift.js
@@ -10,7 +10,6 @@ function (GroupedTimeshiftCollection, DataSource) {
       var collection = new GroupedTimeshiftCollection([], {
         valueAttr: 'value',
         period: 'week',
-        category: 'group',
         axes: {
           x: {
             'label': 'Date',
@@ -39,7 +38,6 @@ function (GroupedTimeshiftCollection, DataSource) {
       var collection = new GroupedTimeshiftCollection([], {
         valueAttr: 'value',
         period: 'week',
-        category: 'group',
         startAt: '2014-04-02T00:00:00',
         axes: {
           x: {
@@ -250,7 +248,6 @@ function (GroupedTimeshiftCollection, DataSource) {
         var collection = new GroupedTimeshiftCollection([], {
           valueAttr: 'value',
           period: 'week',
-          category: 'key',
           duration: 2,
           axes: {
             x: {
@@ -288,7 +285,6 @@ function (GroupedTimeshiftCollection, DataSource) {
         var collection = new GroupedTimeshiftCollection([], {
           valueAttr: 'value',
           period: 'week',
-          category: 'key',
           duration: 2,
           axes: {
             x: {
@@ -332,7 +328,6 @@ function (GroupedTimeshiftCollection, DataSource) {
         var collection = new GroupedTimeshiftCollection([], {
           valueAttr: 'value',
           period: 'week',
-          category: 'key',
           duration: 2,
           axes: {
             x: {


### PR DESCRIPTION
This is not used.

group_by has replaced this functionality.