### PR TITLE
Remove Google Analytics classic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,9 +170,8 @@ module.exports = function (grunt) {
       },
       dist: {
         src: [
-          'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js',
           'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
-          'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/tracker.js',
+          'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
           'app/client/analytics.js'
         ],
         dest: 'public/javascripts/analytics.js'

--- a/app/client/analytics.js
+++ b/app/client/analytics.js
@@ -2,23 +2,22 @@
   'use strict';
 
   // Load Google Analytics libraries
-  GOVUK.Tracker.load();
+  GOVUK.Analytics.load();
 
   // Use document.domain in dev, preview and staging so that tracking works
   // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
   var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
   // Configure profiles, setup custom vars, track initial pageview
-  GOVUK.analytics = new GOVUK.Tracker({
-    universalId: 'UA-26179049-7',
-    classicId: 'UA-26179049-1',
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-26179049-1',
     cookieDomain: cookieDomain
   });
 
   // Set custom dimensions before tracking pageviews
 
   if (window.devicePixelRatio) {
-    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio);
   }
 
   // Track initial pageview

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "errorhandler": "1.1.1",
     "express": "4.4.4",
     "glob": "4.0.2",
-    "govuk_frontend_toolkit": "3.2.0",
+    "govuk_frontend_toolkit": "4.0.0",
     "govuk_template_mustache": "0.12.0",
     "graceful-fs": "3.0.2",
     "grunt": "0.4.5",


### PR DESCRIPTION
__To be deployed 2 June.__

On 2 June we plan to deprecate Google Analytics classic on GOV.UK, from then on we will only use Universal analytics. Google Analytics classic data collection techniques are being deprecated by Google. We should no longer support classic and new tracking should use only Universal.

Following on from https://github.com/alphagov/govuk_frontend_toolkit/pull/194
Part of https://www.pivotaltracker.com/story/show/93002726

* Bump govuk_frontend_toolkit to pull in latest analytics
* Remove references to classic tracker
* Remove classic specific arguments (eg custom variable name and scope)
* Update references of `GOVUK.Tracker` to `GOVUK.Analytics`

(Changes made in https://github.com/alphagov/spotlight/pull/953 used as a reference)

cc @easternbloc