### PR TITLE
Ensure that models with a _end_at can't be from the future!

### DIFF
--- a/app/extensions/collections/collection.js
+++ b/app/extensions/collections/collection.js
@@ -4,9 +4,10 @@ define([
   'extensions/mixins/date-functions',
   'extensions/mixins/collection-processors',
   'extensions/models/model',
-  'extensions/models/data_source'
+  'extensions/models/data_source',
+  'moment-timezone'
 ],
-function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
+function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource, moment) {
 
   var Collection = Backbone.Collection.extend({
 
@@ -74,6 +75,14 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
           }
         }, this);
       }
+
+      //remove models from the collection that are in the future
+      _.remove(data, function (item) {
+        return (item._end_at &&
+          moment(item._end_at).isAfter(moment().utc()));
+      });
+
+
       return data;
     },
 
@@ -387,7 +396,7 @@ function (Backbone, SafeSync, DateFunctions, Processors, Model, DataSource) {
       return this.length > 0;
     },
 
-    lastDefined: function () {
+    lastDefined: function (attr) {
       return this.defined.apply(this, arguments).pop();
     },
 

--- a/spec/shared/extensions/collections/spec.collection.js
+++ b/spec/shared/extensions/collections/spec.collection.js
@@ -708,6 +708,47 @@ function (Collection, Model, DataSource, Backbone, moment, groupedFixture, multi
 
       });
 
+      describe('data in the future', function () {
+        var collection;
+        var futureDate = moment().utc().add(1, 'day').format();
+
+        var collectionArray = [
+          {
+            '_count': 1.0,
+            '_end_at': '2015-05-25T00:00:00+00:00',
+            '_start_at': '2015-05-18T00:00:00+00:00',
+            'visitors:sum': 11390.0
+          },
+          {
+            '_count': 2.0,
+            '_end_at': '2015-06-08T00:00:00+00:00',
+            '_start_at': '2015-06-01T00:00:00+00:00',
+            'visitors:sum': 22850.0
+          },
+          {
+            '_count': 1.0,
+            '_end_at': futureDate,
+            '_start_at': '2015-05-25T00:00:00+00:00',
+            'visitors:sum': 12069.0
+          }
+        ];
+
+        beforeEach(function () {
+          collection = new Collection(collectionArray);
+        });
+
+        it('the collection should not contain models from the future', function () {
+          var parsedData = collection.parse({data: collectionArray});
+
+          expect(parsedData.length).toEqual(2);
+          expect(parsedData[0]._count).toEqual(1);
+          expect(parsedData[0]['visitors:sum']).toEqual(11390);
+
+          expect(parsedData[1]._count).toEqual(2);
+          expect(parsedData[1]['visitors:sum']).toEqual(22850);
+        });
+      });
+
     });
 
     describe('trim', function () {
@@ -900,6 +941,72 @@ function (Collection, Model, DataSource, Backbone, moment, groupedFixture, multi
       });
     });
 
+    describe('defined', function () {
+      var collection;
+      beforeEach(function () {
+        collection = new Collection([
+          {
+            '_count': 1.0,
+            '_end_at': '2015-05-25T00:00:00+00:00',
+            '_start_at': '2015-05-18T00:00:00+00:00',
+            'visitors:sum': 11390.0
+          },
+          {
+            '_count': 1.0,
+            '_end_at': '2015-06-01T00:00:00+00:00',
+            '_start_at': '2015-05-25T00:00:00+00:00',
+            'visitors:sum': 12069.0
+          },
+          {
+            '_end_at': '2015-06-08T00:00:00+00:00',
+            '_start_at': '2015-06-01T00:00:00+00:00',
+            'visitors:sum': 22850.0
+          }
+        ]);
+      });
+
+      it('returns a list of models that have that attribute defined', function () {
+        expect(collection.defined('_count').length).toEqual(2);
+      });
+
+      it('it returns a list of modules that have those attributes defined (in an array)', function () {
+        expect(collection.defined(['_count', 'visitors:sum']).length).toEqual(3);
+      });
+
+      it('it returns a list of modules that have those attributes defined', function () {
+        expect(collection.defined('_count', 'visitors:sum').length).toEqual(3);
+      });
+    });
+
+    describe('lastDefined', function () {
+      var collection;
+
+      var collectionArray = [
+        {
+          '_count': 1.0,
+          '_end_at': '2015-05-25T00:00:00+00:00',
+          '_start_at': '2015-05-18T00:00:00+00:00',
+          'visitors:sum': 11390.0
+        },
+        {
+          '_end_at': '2015-06-08T00:00:00+00:00',
+          '_start_at': '2015-06-01T00:00:00+00:00',
+          'visitors:sum': 22850.0
+        }
+      ];
+
+      beforeEach(function () {
+        collection = new Collection(collectionArray);
+      });
+
+      it('should return the last defined model that matches the key', function () {
+        expect(collection.lastDefined('visitors:sum').toJSON()).toEqual({
+          '_end_at': '2015-06-08T00:00:00+00:00',
+          '_start_at': '2015-06-01T00:00:00+00:00',
+          'visitors:sum': 22850.0
+        });
+      });
+    });
 
 
   });


### PR DESCRIPTION
This is because the end period can be in outside the current date period (therefore we shouldn't show it)

Added tests to prove how defined works

We assume that if there is no end_at we're not dealing with a period... it's just a value at that time (slight hack but seems to be the least damaging to the code base.)

We filter the collection at parse() to ensure that the collection has no models from the future (should be done in backdrop).