### PR TITLE
Use _ templates for summary figure pages.

### DIFF
--- a/app/client/views/summary-figure.js
+++ b/app/client/views/summary-figure.js
@@ -8,9 +8,9 @@ function (View, _, $) {
   return View.extend({
 
     templates: {
-      filter: ' containing <span class="emphasis filter-value">"$1"</span><button class="btn-remove btn-inline" data-filter="filter" type="button">×</button>',
-      departmentFilterTitle: ' provided by <span class="emphasis filter-value">$1</span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>',
-      serviceGroupFilterTitle: ' within <span class="emphasis filter-value">$1</span><button class="btn-remove btn-inline" data-filter="service-group" type="button">×</button>'
+      filter: ' containing <span class="emphasis filter-value">"<%- filter %>"</span><button class="btn-remove btn-inline" data-filter="filter" type="button">×</button>',
+      departmentFilterTitle: ' provided by <span class="emphasis filter-value"><%- filter %></span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>',
+      serviceGroupFilterTitle: ' within <span class="emphasis filter-value"><%- filter %></span><button class="btn-remove btn-inline" data-filter="service-group" type="button">×</button>'
     },
 
     events: {
@@ -40,7 +40,8 @@ function (View, _, $) {
       _.each(this.templates, function(template, key) {
         var val = this.model.get(key);
         if (val) {
-          filterDescription += template.replace('$1', val);
+          var compiled = _.template(template);
+          filterDescription += compiled({ filter: val });
         }
       }, this);
       this.$el.find('.summary-figure-description')

--- a/spec/client/views/spec.summary-figure.js
+++ b/spec/client/views/spec.summary-figure.js
@@ -41,6 +41,15 @@ define([
           expect(this.summary.$el.find('.filter-value').length).toEqual(0);
         });
 
+        it('stops someone from injecting HTML!', function() {
+          this.summary.model.set('filter', '<h1>I am a hacker!</h1>');
+          this.summary.collection.reset([{}]);
+          expect(this.summary.$el.find('.filter-value').html()).toEqual('"&lt;h1&gt;I am a hacker!&lt;/h1&gt;"');
+          this.summary.model.set('filter', '');
+          this.summary.collection.reset([{}]);
+          expect(this.summary.$el.find('.filter-value').length).toEqual(0);
+        });
+
         it('updates when department filter changes', function() {
           this.summary.model.set('departmentFilterTitle', 'test2');
           this.summary.collection.reset([{}]);


### PR DESCRIPTION
This is to ensure we don't let people inject html into our results pages.

It's not a big XSS but it's still not very nice that this is currently happening.

TESTS!