### PR TITLE
Allow the y axis of a graph to just be a percentage

### DIFF
--- a/app/client/views/graph/yaxis.js
+++ b/app/client/views/graph/yaxis.js
@@ -17,13 +17,15 @@ function (require, Axis) {
     },
     tickFormat: function () {
       var currency = this.graph.formatOptions && this.graph.formatOptions.type === 'currency';
-      if (this.scales.y.tickValueList) {
-        return this.numberListFormatter(this.scales.y.tickValueList,  currency);
-      }
-      if (this.graph.formatOptions && this.graph.formatOptions.type === 'duration') {
+      if ((this.graph.formatOptions && this.graph.formatOptions.type === 'duration') ||
+          this.graph.formatOptions === 'percent' ||
+          (this.graph.formatOptions && this.graph.formatOptions.type === 'percent')) {
         return _.bind(function (d) {
           return this.format(d, this.graph.formatOptions);
         }, this);
+      }
+      if (this.scales.y.tickValueList) {
+        return this.numberListFormatter(this.scales.y.tickValueList,  currency);
       }
     },
     tickValues: function () {

--- a/app/client/views/visualisations/bar-chart/bar-chart.js
+++ b/app/client/views/visualisations/bar-chart/bar-chart.js
@@ -20,14 +20,7 @@ function (Graph, XAxis, Bar, Hover) {
           }
         },
         yaxis: {
-          view: this.sharedComponents.yaxis,
-          options: (this.formatOptions === 'percent' || this.formatOptions.type === 'percent') ? {
-            tickFormat: function () {
-              return function (d) {
-                return that.format(d, that.formatOptions);
-              };
-            }
-          } : {}
+          view: this.sharedComponents.yaxis
         },
         bar: { view: Bar },
         hover: { view: Hover }

--- a/spec/client/views/views/graph/spec.yaxis.js
+++ b/spec/client/views/views/graph/spec.yaxis.js
@@ -138,6 +138,21 @@ function (YAxis, Graph, Collection) {
 
         expect(view.format).toHaveBeenCalledWith(1000, view.graph.formatOptions);
       });
+
+      it('uses the standard formatter with formatOptions when its a percentage', function () {
+        var view = viewForValues(0, 10, true, 10);
+        spyOn(view, 'format');
+        view.scales.y.tickValueList = undefined;
+        view.graph.formatOptions = 'percent';
+
+        var formatter = view.tickFormat();
+
+        expect(typeof formatter).toEqual('function');
+
+        formatter(0.1);
+
+        expect(view.format).toHaveBeenCalledWith(0.1, view.graph.formatOptions);
+      });
     });
 
 


### PR DESCRIPTION
We currently only support percentage formatting in a  grouped timeseries using the setting "one-hundred-percent" this PR allows you to just plot lots of percentages on a graph (multuple series won't add up to 100% so it could be confusing to the user).

This is something that @cliffshepp requested so anyone thinking hmmm not sure this is a good idea should talk to him!

:zap::zap::zap: