### PR TITLE
Parse config file as Mustache

### DIFF
--- a/app/environment_config.js
+++ b/app/environment_config.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var Mustache = require('Mustache');
 
 module.exports = {
   configure: function (env, options) {
@@ -13,7 +14,11 @@ module.exports = {
       env = 'development_personal';
     }
 
-    var config = JSON.parse(fs.readFileSync(path.join('config', configFileName(env))));
+    var fileContents = fs.readFileSync(path.join('config', configFileName(env)), 'utf8');
+
+    var renderedMustache = Mustache.render(fileContents, {govukAppDomain: process.env.GOVUK_APP_DOMAIN})
+
+    var config = JSON.parse(renderedMustache);
 
     var filteredOptions = _.pick(options, _.keys(config));
     return _.extend(config, filteredOptions);

--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,10 +1,12 @@
 {
   "assetPath": "/spotlight/",
   "port": 3057,
+  {{=<% %>=}}
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
+  <%={{ }}=%>
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
-  "govukHost": "www.alphagov.co.uk",
+  "govukHost": "www.{{ govukAppDomain }}",
   "stagecraftUrl": "https://stagecraft.production.performance.service.gov.uk",
   "statsdPrefix": "pp.apps.spotlight",
   "bigScreenBaseURL": "https://www.performance.service.gov.uk"


### PR DESCRIPTION
This commit parses the config file as Mustache and replaces instances of `govukAppDomain` with the environment variable GOVUK_APP_DOMAIN.

This is useful for our preview and staging config files because instead of hardcoding `alphagov.co.uk` we can easily move to a new hostname.

The syntax on lines 4 and 6 is a little bit confusing. What it's doing is reassigning the Mustache tokens to be `<% %>` so that on line 5 we can include Mustache which isn't parsed (literal Mustache tags).

These tags are parsed later in the application, in `data_source.js:26`.