### PR TITLE
Do no ignore 0s in weighted average

### DIFF
--- a/app/client/views/services-kpi.js
+++ b/app/client/views/services-kpi.js
@@ -28,7 +28,7 @@ function (View, accessibility) {
       var aggregateVals = this.collection.getAggregateValues();
 
       _.each(aggregateVals, function (kpi) {
-        if (kpi.weighted_average) {
+        if (kpi.weighted_average || kpi.weighted_average === 0) {
           kpi.formattedValue = this.format(kpi.weighted_average, kpi.format);
         }
       }, this);

--- a/app/common/collections/services.js
+++ b/app/common/collections/services.js
@@ -12,33 +12,59 @@ define([
           _.each(axes, function (axis) {
             var axisKey = axis.key;
             var val = model.get(axisKey);
+            var number_of_transactions = model.get('number_of_transactions');
             kpi = _.findWhere(aggregatedValues, {key: axisKey});
 
             if (kpi) {
-              if (val) {
+              if (val && number_of_transactions) {
                 kpi.value += val;
-                if (model.get('number_of_transactions')) {
-                  kpi.valueTimesVolume += (val * model.get('number_of_transactions'));
-                  kpi.volume += model.get('number_of_transactions');
-                  kpi.valueCount++;
-                }
+                kpi.valueTimesVolume += (val * model.get('number_of_transactions'));
+                // if the axisKey is total_cost then this has this potential
+                // to be undefined + n which is NaN but total_cost is not weighted so this
+                // shouldn't matter.
+                kpi.volume += model.get('number_of_transactions');
+                kpi.valueCount++;
+              } else if (val && axisKey === 'total_cost') {
+                kpi.value += val;
+                kpi.valueTimesVolume += val;
+                kpi.valueCount++;
               }
             } else {
-              aggregatedValues.push({
-                key: axisKey,
-                label: axis.label,
-                isWeighted: true,
-                value: val || 0,
-                valueTimesVolume: (val * model.get('number_of_transactions')) || 0,
-                volume: (val) ? model.get('number_of_transactions') : 0,
-                valueCount: (val && model.get('number_of_transactions')) ? 1 : 0,
-                format: {
-                  type: axis.format.type || axis.format,
-                  sigfigs: 3,
-                  magnitude: true,
-                  abbr: true
-                }
-              });
+              if ((val || val === 0) && number_of_transactions) {
+                aggregatedValues.push({
+                  key: axisKey,
+                  label: axis.label,
+                  isWeighted: true,
+                  value: val,
+                  valueTimesVolume: val * number_of_transactions,
+                  volume: number_of_transactions,
+                  valueCount: 1,
+                  format: {
+                    type: axis.format.type || axis.format,
+                    sigfigs: 3,
+                    magnitude: true,
+                    abbr: true
+                  }
+                });
+              } else if ((val || val === 0) && axisKey === 'total_cost') {
+                // Total cost is a special case - it does not need
+                // number_of_transactions as it doesn't get weighted.
+                aggregatedValues.push({
+                  key: axisKey,
+                  label: axis.label,
+                  isWeighted: true,
+                  value: val,
+                  valueTimesVolume: val,
+                  volume: undefined,
+                  valueCount: 1,
+                  format: {
+                    type: axis.format.type || axis.format,
+                    sigfigs: 3,
+                    magnitude: true,
+                    abbr: true
+                  }
+                });
+              }
             }
           });
         });

--- a/app/server/views/services.js
+++ b/app/server/views/services.js
@@ -47,7 +47,7 @@ module.exports = BaseView.extend({
     aggVals = this.filterCollection.getAggregateValues();
 
     _.each(aggVals, function (kpi) {
-      if (kpi.weighted_average) {
+      if (kpi.weighted_average || kpi.weighted_average === 0) {
         kpi.formattedValue = this.format(kpi.weighted_average, kpi.format);
       }
     }, this);

--- a/app/support/stagecraft_stub/responses/dashboards.json
+++ b/app/support/stagecraft_stub/responses/dashboards.json
@@ -1,0 +1,1534 @@
+{
+  "items": [
+    {
+      "slug": "accelerated-possession-eviction",
+      "title": "Civil claims: evicting a tenant using accelerated possession",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "bis-accounts-filing",
+      "title": "Company accounts filed",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Companies House",
+        "abbr": "CH"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-annual-returns",
+      "title": "Company annual returns filed",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Companies House",
+        "abbr": "CH"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-bulk-register-updates-brus-bankruptcy-dlgs",
+      "title": "Land Registry: bulk register updates and bankruptcy dealings",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-apprenticeship-vacancies-applications",
+      "title": "Apprenticeships: applications for vacancies",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Skills Funding Agency",
+        "abbr": "SFA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-land-register-updates-including-transfers-of-ownership",
+      "title": "Land Registry: updates to the register and bankruptcy dealings",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-learning-record-service-unique-learner-numbers-ulns-created",
+      "title": "Learning Record Service: unique learner numbers (ULNs) created",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Skills Funding Agency",
+        "abbr": "SFA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-other-document-filing-filing-transactions",
+      "title": "Companies House: other document filing",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Companies House",
+        "abbr": "CH"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-official-copies-from-land-registry",
+      "title": "Land Registry: requests for official copies of records",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-search-of-the-index-map-land-registry",
+      "title": "Land Registry: searches for title numbers",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-search-of-whole-land-registry",
+      "title": "Land Registry: searches of whole register",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-student-finance-applications-full-time-study",
+      "title": "Student finance: applications for full-time study",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Student Loans Company",
+        "abbr": "SLC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-title-register-views",
+      "title": "Land Registry: title register views",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "bis-title-plan-views",
+      "title": "Land Registry: title plan views",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Land Registry",
+        "abbr": "HMLR"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "book-practical-driving-test",
+      "title": "Practical driving test bookings",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "carers-allowance",
+      "title": "Carer's Allowance applications",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "carers-allowance",
+      "title": "Carer's Allowance applications",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "carers-allowance",
+      "title": "Carer's Allowance applications",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "change-practical-driving-test",
+      "title": "Practical driving test changes and cancellations",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "co-signing-an-e-petition",
+      "title": "e-petition signatures",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "agency": {
+        "title": "Government Digital Service",
+        "abbr": "GDS"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "defra-cattle-tracing-system-movements",
+      "title": "Cattle Tracing System: cattle births, deaths and movements",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "agency": {
+        "title": "Rural Payments Agency",
+        "abbr": "RPA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "defra-fishing-rod-licences-applications",
+      "title": "Fishing rod licences: applications",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "agency": {
+        "title": "Environment Agency",
+        "abbr": "EA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "defra-single-payment-scheme-sps-claims",
+      "title": "Single Payment Scheme (SPS) claims",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "agency": {
+        "title": "Rural Payments Agency",
+        "abbr": "RPA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-amend-driving-licence-details",
+      "title": "Driving licences: changes",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-amend-or-remove-endorsements-or-fixed-penalty-details",
+      "title": "Driving licences: fixed penalties and endorsements changed or removed",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-amend-practical-driving-test",
+      "title": "Practical driving test: changes to bookings",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-apply-for-a-provisional-driving-licence",
+      "title": "Provisional driving licence applications",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-amend-vehicle-registration-details",
+      "title": "Vehicle registration certificates: changes",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-assign-a-personalised-registration-number-to-a-vehicle",
+      "title": "Personalised registration: assign numbers to vehicles",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-book-practical-driving-test",
+      "title": "Practical driving test: bookings",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-book-theory-driving-test",
+      "title": "Driving theory test: bookings",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-check-a-vehicles-details",
+      "title": "Vehicle tax: checks by third-parties",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-check-other-drivers-details",
+      "title": "Driving licences: third-party checks",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-check-your-own-vehicles-details",
+      "title": "Vehicle tax: checks made by individuals",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-notifications-sent-via-electronic-service-delivery-for-abnormal-loads-esdal",
+      "title": "Electronic Service Delivery for Abnormal Loads (ESDAL): notifications",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Highways Agency",
+        "abbr": "HA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-register-a-vehicle",
+      "title": "Vehicle registrations",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-renew-driving-licence",
+      "title": "Driving licences: renewals",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-report-change-of-ownership-of-vehicle",
+      "title": "Vehicle registration: changes of ownership",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-replace-driving-licence",
+      "title": "Driving licences: replacements",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-report-destroyed-or-seriously-damaged-vehicle",
+      "title": "Destroyed or damaged vehicles reported",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dft-request-vehicle-tax-refund",
+      "title": "Vehicle tax: refunds",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-blood-donation-appointments",
+      "title": "Blood donation appointments",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS Blood and Transplant",
+        "abbr": "NHSBT"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-choose-book",
+      "title": "Choose and Book: outpatient appointments",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS England",
+        "abbr": "NHS England"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-european-health-insurance-card-ehic-applications",
+      "title": "European Health Insurance Card (EHIC): applications",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS Business Services Authority",
+        "abbr": "NHSBSA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-organ-donor-register-registrations",
+      "title": "Organ donations: registrations",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS Blood and Transplant",
+        "abbr": "NHSBT"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-prepayment-certificates-issued",
+      "title": "Prescriptions: prepayment certificates issued",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS Business Services Authority",
+        "abbr": "NHSBSA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dh-written-gp-referrals-to-first-outpatient-appointment",
+      "title": "Written GP referrals to first outpatient appointment",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "agency": {
+        "title": "NHS England",
+        "abbr": "NHS England"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-adviser-interventions-jobsearch-advice",
+      "title": "Job search adviser interventions",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-attendance-allowance-claims-maintained",
+      "title": "Attendance Allowance: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-carers-allowance-claims-maintained",
+      "title": "Carer's Allowance: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-child-maintenance",
+      "title": "Child maintenance transactions",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-disability-living-allowance-dla-claims-maintained",
+      "title": "Disability Living Allowance (DLA): existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-incapacity-benefit-employment-support-allowance-esa-claims-maintained",
+      "title": "Incapacity Benefit/ Employment and Support Allowance (ESA): claims maintained",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-employment-support-allowance-esa-new-claims",
+      "title": "Employment and Support Allowance (ESA): new claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-income-support-claims-maintained",
+      "title": "Income Support: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-jobsearch-reviews-signing-on",
+      "title": "Jobsearch reviews (signing on)",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-jobseekers-allowance-jsa-claims-maintained",
+      "title": "Jobseeker's Allowance: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-jobseekers-allowance-jsa-new-claims",
+      "title": "Jobseeker's Allowance (JSA): new claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-overseas-state-pension-claims-maintained",
+      "title": "State Pension: existing overseas claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-pension-credit-claims-maintained",
+      "title": "Pension Credit: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-social-fund-grants-loans",
+      "title": "Social Fund grants and loans",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-state-pension-claims-maintained",
+      "title": "State Pension: existing claims",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-universal-jobmatch-cv-uploads",
+      "title": "Universal Jobmatch: CV uploads",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-universal-jobmatch-jobseeker-accounts-created",
+      "title": "Universal Jobmatch: jobseeker accounts created",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "dwp-universal-jobmatch-vacancies-placed-by-employers",
+      "title": "Universal Jobmatch: vacancies placed by employers",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "g-cloud",
+      "title": "G-Cloud",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "other"
+    },
+    {
+      "slug": "hmrc-agent-authorisation",
+      "title": "HMRC agent authorisations",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-child-benefit",
+      "title": "Child Benefit transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-construction-industry-scheme",
+      "title": "Construction Industry Scheme transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-customs",
+      "title": "Customs transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-corporation-tax",
+      "title": "Corporation Tax transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-debt-management",
+      "title": "Debt collection transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-excise-movement-control-service",
+      "title": "Excise Movement Control Service transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-kana",
+      "title": "HMRC transactions handled by email (KANA)",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-national-insurance",
+      "title": "National Insurance transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-pay-as-you-earn-paye",
+      "title": "PAYE transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-payments-received-by-hmrc-banking",
+      "title": "Payments received by HMRC",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-payments-made-by-hmrc-banking",
+      "title": "Payments made by HMRC",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-self-assessment",
+      "title": "Self Assessment transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-stamp-duty-land-tax",
+      "title": "Stamp Duty Land Tax transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-stamp-duty-reserve-tax",
+      "title": "Stamp Duty Reserve Tax transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-tax-credits",
+      "title": "Tax Credits transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "hmrc-vat",
+      "title": "VAT transactions",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "home-office-enhanced-criminal-records-checks",
+      "title": "Enhanced criminal records checks",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "agency": {
+        "title": "Disclosure and Barring Service",
+        "abbr": "DBS"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "home-office-ordering-certificates-births-adoptions-marriages-civil-partnerships-deaths",
+      "title": "Birth, adoption, death, marriage and civil partnership certificates ordered",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "agency": {
+        "title": "HM Passport Office",
+        "abbr": "HMPO"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "home-office-passenger-arrivals-at-border",
+      "title": "Passenger arrivals at the border",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "home-office-passport-applications",
+      "title": "Passport applications",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "agency": {
+        "title": "HM Passport Office",
+        "abbr": "HMPO"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "home-office-visas-immigration-applications",
+      "title": "Visa applications",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "lasting-power-of-attorney",
+      "title": "Lasting Power of Attorney registrations",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "agency": {
+        "title": "Office of the Public Guardian",
+        "abbr": "OPG"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "licensing",
+      "title": "Licensing",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "moj-court-fine-payments",
+      "title": "Court fine payments",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "agency": {
+        "title": "HM Courts & Tribunals Service",
+        "abbr": "HMCTS"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "moj-legal-aid-applications-criminal-cases",
+      "title": "Legal aid in criminal cases: acts of assistance",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "agency": {
+        "title": "Legal Aid Agency",
+        "abbr": "LAA"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "moj-money-claims",
+      "title": "Money claims",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "agency": {
+        "title": "HM Courts & Tribunals Service",
+        "abbr": "HMCTS"
+      },
+      "dashboard-type": "high-volume-transaction"
+    },
+    {
+      "slug": "pay-foreign-marriage-certificates",
+      "title": "Certificate to get married abroad: payments",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "pay-legalisation-drop-off",
+      "title": "Document legalisation: payments for drop-off service",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "pay-legalisation-post",
+      "title": "Document legalisation: payments for service by post",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "pay-register-birth-abroad",
+      "title": "Register a birth abroad: payments",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "pay-register-death-abroad",
+      "title": "Register a death abroad: payments",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "practical-driving-test",
+      "title": "Practical driving test (public users)",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Standards Agency",
+        "abbr": "DVSA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "prison-visits",
+      "title": "Prison visit bookings",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "agency": {
+        "title": "National Offender Management Service",
+        "abbr": "NOMS"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "register-to-vote",
+      "title": "Voter registration",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "renew-patent",
+      "title": "Patent renewals",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "agency": {
+        "title": "Intellectual Property Office",
+        "abbr": "IPO"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "site-activity-attorney-generals-office",
+      "title": "Attorney General's Office",
+      "department": {
+        "title": "Attorney General's Office",
+        "abbr": "AGO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-cabinet-office",
+      "title": "Cabinet Office",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-business-innovation-skills",
+      "title": "Department for Business, Innovation and Skills",
+      "department": {
+        "title": "Department for Business, Innovation and Skills",
+        "abbr": "BIS"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-communities-and-local-government",
+      "title": "Department for Communities and Local Government",
+      "department": {
+        "title": "Department for Communities and Local Government",
+        "abbr": "DCLG"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-culture-media-sport",
+      "title": "Department for Culture, Media and Sport",
+      "department": {
+        "title": "Department for Culture, Media and Sport",
+        "abbr": "DCMS"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-education",
+      "title": "Department for Education",
+      "department": {
+        "title": "Department for Education",
+        "abbr": "DfE"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-environment-food-rural-affairs",
+      "title": "Department for Environment, Food and Rural Affairs",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-international-development",
+      "title": "Department for International Development",
+      "department": {
+        "title": "Department for International Development",
+        "abbr": "DFID"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-transport",
+      "title": "Department for Transport",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-for-work-pensions",
+      "title": "Department for Work and Pensions",
+      "department": {
+        "title": "Department for Work and Pensions",
+        "abbr": "DWP"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-of-energy-climate-change",
+      "title": "Department of Energy and Climate Change",
+      "department": {
+        "title": "Department of Energy and Climate Change",
+        "abbr": "DECC"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-department-of-health",
+      "title": "Department of Health",
+      "department": {
+        "title": "Department of Health",
+        "abbr": "DH"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-deputy-prime-ministers-office",
+      "title": "The Deputy Prime Minister's Office",
+      "department": {
+        "title": "The Deputy Prime Minister's Office",
+        "abbr": "DPMO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-driver-and-vehicle-licensing-agency",
+      "title": "Driver & Vehicle Licensing Agency",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-driver-and-vehicle-standards-agency",
+      "title": "Driver & Vehicle Standards Agency",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-driving-standards-agency",
+      "title": "Driving Standards Agency",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-environment-agency",
+      "title": "Environment Agency",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "agency": {
+        "title": "Environment Agency",
+        "abbr": "EA"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-foreign-commonwealth-office",
+      "title": "Foreign & Commonwealth Office",
+      "department": {
+        "title": "Foreign and Commonwealth Office",
+        "abbr": "FCO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-hm-prison-service",
+      "title": "HM Prison Service",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-hm-revenue-customs",
+      "title": "HM Revenue & Customs",
+      "department": {
+        "title": "HM Revenue and Customs",
+        "abbr": "HMRC"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-hm-treasury",
+      "title": "HM Treasury",
+      "department": {
+        "title": "HM Treasury",
+        "abbr": "HMT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-home-office",
+      "title": "Home Office",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-ministry-of-defence",
+      "title": "Ministry of Defence",
+      "department": {
+        "title": "Ministry of Defence",
+        "abbr": "MOD"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-ministry-of-justice",
+      "title": "Ministry of Justice",
+      "department": {
+        "title": "Ministry of Justice",
+        "abbr": "MOJ"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-northern-ireland-office",
+      "title": "Northern Ireland Office",
+      "department": {
+        "title": "Northern Ireland Office",
+        "abbr": "NIO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-office-of-the-advocate-general-for-scotland",
+      "title": "Office of the Advocate General for Scotland",
+      "department": {
+        "title": "Office of the Advocate General for Scotland",
+        "abbr": "OAG"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-performance-platform",
+      "title": "Activity on the Performance Platform",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-office-of-the-leader-of-the-house-of-lords",
+      "title": "Office of the Leader of the House of Lords",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-prime-ministers-office-10-downing-street",
+      "title": "Prime Minister's Office, 10 Downing Street",
+      "department": {
+        "title": "Prime Minister's Office",
+        "abbr": "PMO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-scotland-office",
+      "title": "Scotland Office",
+      "department": {
+        "title": "Scotland Office",
+        "abbr": "SO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-the-charity-commission-for-england-and-wales",
+      "title": "The Charity Commission",
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-the-office-of-the-leader-of-the-house-of-commons",
+      "title": "Office of the Leader of the House of Commons",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-uk-export-finance",
+      "title": "UK Export Finance",
+      "department": {
+        "title": "UK Export Finance",
+        "abbr": "UKEF"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-uk-trade-investment",
+      "title": "UK Trade & Investment",
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-uk-visas-and-immigration",
+      "title": "UK Visas and Immigration",
+      "department": {
+        "title": "Home Office",
+        "abbr": "Home Office"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-vehicle-and-operator-services-agency",
+      "title": "Vehicle & Operator Services Agency",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity",
+      "title": "Activity on GOV.UK",
+      "department": {
+        "title": "Cabinet Office",
+        "abbr": "CO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "site-activity-wales-office",
+      "title": "Wales Office",
+      "department": {
+        "title": "Wales Office",
+        "abbr": "WO"
+      },
+      "dashboard-type": "content"
+    },
+    {
+      "slug": "sorn",
+      "title": "SORN (Statutory Off Road Notification) applications",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "tax-disc",
+      "title": "Vehicle tax renewals",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "vehicle-licensing",
+      "title": "Vehicle licensing",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "dashboard-type": "service-group"
+    },
+    {
+      "slug": "view-driving-licence",
+      "title": "Driving licence views",
+      "department": {
+        "title": "Department for Transport",
+        "abbr": "DFT"
+      },
+      "agency": {
+        "title": "Driver and Vehicle Licensing Agency",
+        "abbr": "DVLA"
+      },
+      "dashboard-type": "transaction"
+    },
+    {
+      "slug": "waste-carrier-or-broker-registration",
+      "title": "Waste carrier registration",
+      "department": {
+        "title": "Department for Environment, Food and Rural Affairs",
+        "abbr": "Defra"
+      },
+      "agency": {
+        "title": "Environment Agency",
+        "abbr": "EA"
+      },
+      "dashboard-type": "transaction"
+    }
+  ],
+  "page-type": "browse"
+}

--- a/spec/server-pure/views/spec.services.js
+++ b/spec/server-pure/views/spec.services.js
@@ -112,6 +112,11 @@ describe('Services View', function () {
   describe('formatAggregateValues', function () {
 
     it('adds a formatted value for kpis with a weighted_average', function () {
+      expect(view.formatAggregateValues()[0].formattedValue).toEqual('2,000');
+      expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[3].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
       expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
     });
 


### PR DESCRIPTION
if the weighted average of something is 0 (sometimes happens with
  filtered services pages) then we currently do not display it. Not 100%
  about whether we need to change both of these if statements I should
  admit but this does this trick.

I don't think there are any existing tests but possibly it could handle some.