### PR TITLE
Fix ignore 0s in service page totals

### DIFF
--- a/app/client/views/services-kpi.js
+++ b/app/client/views/services-kpi.js
@@ -28,7 +28,7 @@ function (View, accessibility) {
       var aggregateVals = this.collection.getAggregateValues();
 
       _.each(aggregateVals, function (kpi) {
-        if (kpi.weighted_average) {
+        if (kpi.weighted_average || kpi.weighted_average === 0) {
           kpi.formattedValue = this.format(kpi.weighted_average, kpi.format);
         }
       }, this);

--- a/app/common/collections/services.js
+++ b/app/common/collections/services.js
@@ -12,33 +12,59 @@ define([
           _.each(axes, function (axis) {
             var axisKey = axis.key;
             var val = model.get(axisKey);
+            var number_of_transactions = model.get('number_of_transactions');
             kpi = _.findWhere(aggregatedValues, {key: axisKey});
 
             if (kpi) {
-              if (val) {
+              if (val && number_of_transactions) {
                 kpi.value += val;
-                if (model.get('number_of_transactions')) {
-                  kpi.valueTimesVolume += (val * model.get('number_of_transactions'));
-                  kpi.volume += model.get('number_of_transactions');
-                  kpi.valueCount++;
-                }
+                kpi.valueTimesVolume += (val * model.get('number_of_transactions'));
+                // if the axisKey is total_cost then this has this potential
+                // to be undefined + n which is NaN but total_cost is not weighted so this
+                // shouldn't matter.
+                kpi.volume += model.get('number_of_transactions');
+                kpi.valueCount++;
+              } else if (val && axisKey === 'total_cost') {
+                kpi.value += val;
+                kpi.valueTimesVolume += val;
+                kpi.valueCount++;
               }
             } else {
-              aggregatedValues.push({
-                key: axisKey,
-                label: axis.label,
-                isWeighted: true,
-                value: val || 0,
-                valueTimesVolume: (val * model.get('number_of_transactions')) || 0,
-                volume: (val) ? model.get('number_of_transactions') : 0,
-                valueCount: (val && model.get('number_of_transactions')) ? 1 : 0,
-                format: {
-                  type: axis.format.type || axis.format,
-                  sigfigs: 3,
-                  magnitude: true,
-                  abbr: true
-                }
-              });
+              if ((val || val === 0) && number_of_transactions) {
+                aggregatedValues.push({
+                  key: axisKey,
+                  label: axis.label,
+                  isWeighted: true,
+                  value: val,
+                  valueTimesVolume: val * number_of_transactions,
+                  volume: number_of_transactions,
+                  valueCount: 1,
+                  format: {
+                    type: axis.format.type || axis.format,
+                    sigfigs: 3,
+                    magnitude: true,
+                    abbr: true
+                  }
+                });
+              } else if ((val || val === 0) && axisKey === 'total_cost') {
+                // Total cost is a special case - it does not need
+                // number_of_transactions as it doesn't get weighted.
+                aggregatedValues.push({
+                  key: axisKey,
+                  label: axis.label,
+                  isWeighted: true,
+                  value: val,
+                  valueTimesVolume: val,
+                  volume: undefined,
+                  valueCount: 1,
+                  format: {
+                    type: axis.format.type || axis.format,
+                    sigfigs: 3,
+                    magnitude: true,
+                    abbr: true
+                  }
+                });
+              }
             }
           });
         });

--- a/app/server/views/services.js
+++ b/app/server/views/services.js
@@ -47,7 +47,7 @@ module.exports = BaseView.extend({
     aggVals = this.filterCollection.getAggregateValues();
 
     _.each(aggVals, function (kpi) {
-      if (kpi.weighted_average) {
+      if (kpi.weighted_average || kpi.weighted_average === 0) {
         kpi.formattedValue = this.format(kpi.weighted_average, kpi.format);
       }
     }, this);

--- a/spec/client/views/spec.services-kpi.js
+++ b/spec/client/views/spec.services-kpi.js
@@ -262,6 +262,36 @@ define([
           expect(this.summary.$el.find('.visualisation-moreinfo').text()).toEqual('total for all 3 services');
 
         });
+
+        it('shows 0 when then weighted average is 0', function () {
+          var $el = $('<div><div class="number_of_transactions"><div class="impact-number"><strong>35%</strong></div></div></div>');
+
+          ServicesCollection.prototype.getAggregateValues.andReturn([{
+            'key': 'number_of_transactions',
+            'title': 'Transactions per year',
+            'value': 0,
+            'valueTimesVolume': 0,
+            'valueCount': 1,
+            'allRowsHaveValues': true,
+            'weighted_average': 0,
+            'format': {
+              'type': 'percent',
+              'sigfigs': 3,
+              'magnitude': true,
+              'abbr': true
+            }
+          }]);
+
+          this.summary = new ServicesKPIView({
+            el: $el,
+            model: new Model(),
+            collection: new ServicesCollection([], servicesAxes)
+          });
+          this.summary.collection.reset([{}, {}, {}]);
+
+          expect(this.summary.$el.find('strong').html()).toEqual('0%');
+
+        });
       });
     });
 

--- a/spec/server-pure/views/spec.services.js
+++ b/spec/server-pure/views/spec.services.js
@@ -27,7 +27,8 @@ describe('Services View', function () {
         abbr: 'NHSBSA'
       },
       completion_rate: 0.4,
-      number_of_transactions: 2000
+      number_of_transactions: 2000,
+      digital_takeup: 0 
     }], servicesController.serviceAxes);
 
     viewOptions = {
@@ -115,7 +116,7 @@ describe('Services View', function () {
       expect(view.formatAggregateValues()[0].formattedValue).toEqual('2,000');
       expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
       expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
-      expect(view.formatAggregateValues()[3].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[3].formattedValue).toEqual('0%');
       expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
       expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
     });

--- a/spec/server-pure/views/spec.services.js
+++ b/spec/server-pure/views/spec.services.js
@@ -112,6 +112,11 @@ describe('Services View', function () {
   describe('formatAggregateValues', function () {
 
     it('adds a formatted value for kpis with a weighted_average', function () {
+      expect(view.formatAggregateValues()[0].formattedValue).toEqual('2,000');
+      expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[3].formattedValue).toBeUndefined();
+      expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
       expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
     });
 


### PR DESCRIPTION
if the weighted average of something is 0 (sometimes happens with
  filtered services pages) then we currently do not display it. Not 100%
  about whether we need to change both of these if statements I should
  admit but this does this trick.

This uncovered a further bug:

Previously we would always initialize the aggregrates for the services
page with 0s, however if no data was found for an service page aggregate
kpi then this would show up as 0 on the page itself in the case of
number of transactions and total cost because of the way these avoid the weighted_average logic.

This changes the logic so that if no kpi is yet defined we first check
there is actually volume information before adding it to aggregates.
This has the problem that even if there is a value it will not be
counted in the weighted average because we cannot say what proportion of
the average it represents but it seems better then displaying data when
none is actually provided. We leave a special case for total_cost (and
number of transactions though we don't need to specify this) as it
doesn't require weighting.

There are tests showing how this second bug is fixed through the services view. This also shows the 0 handling. It's not very well isolated but that would require I think adding a new load of tests rather than the quite small intervention here. A more isolated test has also been added for the client side service-kpi view.