### PR TITLE
Fix 0 handling beyond the first value in the aggregate

### DIFF
--- a/app/common/collections/services.js
+++ b/app/common/collections/services.js
@@ -16,7 +16,7 @@ define([
             kpi = _.findWhere(aggregatedValues, {key: axisKey});
 
             if (kpi) {
-              if (val && number_of_transactions) {
+              if ((val || val === 0) && number_of_transactions) {
                 kpi.value += val;
                 kpi.valueTimesVolume += (val * model.get('number_of_transactions'));
                 // if the axisKey is total_cost then this has this potential
@@ -24,7 +24,7 @@ define([
                 // shouldn't matter.
                 kpi.volume += model.get('number_of_transactions');
                 kpi.valueCount++;
-              } else if (val && axisKey === 'total_cost') {
+              } else if ((val || val === 0) && axisKey === 'total_cost') {
                 kpi.value += val;
                 kpi.valueTimesVolume += val;
                 kpi.valueCount++;

--- a/spec/server-pure/views/spec.services.js
+++ b/spec/server-pure/views/spec.services.js
@@ -130,6 +130,65 @@ describe('Services View', function () {
       expect(view.formatAggregateValues()[5].key).toEqual('completion_rate');
     });
 
+    describe('with more than one service/transaction', function () {
+      beforeEach(function () {
+        model = new Backbone.Model({
+          axesOptions: servicesController.serviceAxes.axes
+        });
+
+        collection = new ServicesCollection([
+          {
+            title: 'Prescriptions: prepayment certificates issued',
+            department: {
+              title: 'Department of Health',
+              abbr: 'DH'
+            },
+            agency: {
+              title: 'NHS Business Services Authority',
+              abbr: 'NHSBSA'
+            },
+            completion_rate: 0.4,
+            number_of_transactions: 2000,
+            digital_takeup: 0.5 
+          },
+          {
+            title: 'Prescriptions: prepayment certificates issued',
+            department: {
+              title: 'Department of Health',
+              abbr: 'DH'
+            },
+            agency: {
+              title: 'NHS Business Services Authority',
+              abbr: 'NHSBSA'
+            },
+            completion_rate: 0.4,
+            number_of_transactions: 2000,
+            digital_takeup: 0 
+          }
+        ], servicesController.serviceAxes);
+
+        viewOptions = {
+          model: model,
+          collection: collection
+        };
+        view = new ServicesView(viewOptions);
+      });
+
+      afterEach(function () {
+        this.removeAllSpies();
+      });
+
+      it('adds a formatted value for kpis with a weighted_average', function () {
+        expect(view.formatAggregateValues()[0].formattedValue).toEqual('4,000');
+        expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
+        expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
+        expect(view.formatAggregateValues()[3].formattedValue).toEqual('25%');
+        expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
+        expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Previously we only added 0s to the weighting for the first value. This
was wrong and foolish of me.

Things now look like this. 

<img width="1170" alt="screen shot 2015-07-09 at 16 50 30" src="https://cloud.githubusercontent.com/assets/677893/8599874/bc0b7402-265a-11e5-80e2-79187f777542.png">
<img width="1217" alt="screen shot 2015-07-09 at 16 50 11" src="https://cloud.githubusercontent.com/assets/677893/8599876/be11b676-265a-11e5-8e50-c4159f2b5907.png">