### PR TITLE
Amend email text

### DIFF
--- a/app/server/templates/about.html
+++ b/app/server/templates/about.html
@@ -29,7 +29,7 @@
         <li>be open to the public</li>
       </ul>
 
-      <p>If you work on a government service we can help you create a dashboard &ndash; <a href="mailto:performance@digital.cabinet-office.gov.uk">email performance@digital.cabinet-office.gov.uk</a></p>
+      <p>If you work on a government service we can help you create a dashboard &ndash; email <a href="mailto:performance@digital.cabinet-office.gov.uk">performance@digital.cabinet-office.gov.uk</a></p>
 
     <h2>Open data</h2>
 


### PR DESCRIPTION
The text referencing the address to send email to for help creating a
dashboard looked a bit odd to me; the word 'email' was part of the HREF.

Moves the word 'email' outside the HREF. Has the nice advantage that Chrome
now recognises the HREF as an email address, rather than just yet another
URI.