### PR TITLE
Fix link to json summary not updating when dates are changed.

### DIFF
--- a/app/client/views/json-summary.js
+++ b/app/client/views/json-summary.js
@@ -1,0 +1,29 @@
+define([
+  'extensions/views/view'
+], function (View) {
+  return View.extend({
+
+    initialize: function () {
+
+        this.listenTo(this.collection, 'reset add remove', this.render);
+    },
+
+    render: function(){
+
+        var jsonUpdated = this.collection.url();
+        var jsonLink;
+
+        var $newEl;
+        var $oldEl = this.$el;
+
+        jsonLink = '<a href="' + jsonUpdated + '">JSON</a>';
+        $newEl = $(jsonLink);
+
+        this.setElement($newEl);
+        $oldEl.replaceWith($newEl);
+
+        return this;
+    }
+
+ });
+});

--- a/app/client/views/module.js
+++ b/app/client/views/module.js
@@ -1,8 +1,9 @@
 define([
   'common/views/module',
   'client/views/table',
-  'client/views/date-picker'
-], function (ModuleView, Table, DatePicker) {
+  'client/views/date-picker',
+  'client/views/json-summary'
+], function (ModuleView, Table, DatePicker, JsonSummary) {
 
   return ModuleView.extend({
 
@@ -23,6 +24,9 @@ define([
             view: this.datePickerClass
           };
         }
+        views['.json-summary'] = {
+            view: JsonSummary
+        };
       }
       return _.extend(ModuleView.prototype.views.apply(this, arguments), views);
     }

--- a/app/server/templates/module.html
+++ b/app/server/templates/module.html
@@ -37,7 +37,7 @@
 <aside class="more-info download" role="complementary">
   <h2 id="download">Download the data</h2>
   <ul>
-    <li><a href="<%= jsonUrl %>">JSON</a></li>
+    <li class="json-summary"><a href="<%= jsonUrl %>">JSON</a></li>
     <% if (fallbackUrl) { %><li><a href="<%= fallbackUrl %>?selector=.visualisation-inner">PNG</a></li><% } %>
   </ul>
 </aside>

--- a/spec/client/views/spec.json-summary.js
+++ b/spec/client/views/spec.json-summary.js
@@ -1,0 +1,36 @@
+define([
+  'client/views/json-summary',
+  'extensions/models/model',
+  'extensions/collections/collection',
+  'jquery'
+],
+function (JsonSummary, Model, Collection, $) {
+  describe('JsonSummary', function () {
+    var view, $el, model, collection;
+
+    collection =  new Collection();
+
+    beforeEach(function () {
+      $el = $('<li class="json-summary"></li>');
+      $el.html('<a href="<jsonUrl>">JSON</a>');
+      view = new JsonSummary({
+        el: $el,
+        model: model,
+        collection: collection
+      });
+    });
+
+    describe('render', function () {
+      it('should update element to add new url assigned', function () {
+        spyOn(collection, 'url').andReturn('newUrl');
+        var $oldEl = view.$el;
+        view.render();
+        expect($oldEl).not.toEqual(view.$el);
+        expect(view.$el.attr('href')).toContain('newUrl');
+      });
+
+    });
+
+  });
+});
+


### PR DESCRIPTION
Update link to json summary in the client view based on selection in date picker.  Keeping
old json link based on server side as a fallback for when javascript isn't enabled.