### PR TITLE
Fix broken Jasmine tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,10 +2,15 @@ var _ = require('lodash');
 
 var getRequirejsConfig = function () {
   var requirejsConfig;
+  // Define a temporary function so that we can 'read' in the application settings.
+  // The settings file assumes the existence of a function called 'define'.
   global.define = function (config) {
     requirejsConfig = config({ isBuild: true });
   };
+  // Read the settings
   require('./app/config');
+  // Remove the function
+  delete global.define;
 
   return _.extend(requirejsConfig, {
     baseUrl: 'app',


### PR DESCRIPTION
The jasmine_node tests were failing when trying to require the jquery node module (required in spec/helpers.js). Deep in its dependency tree is a module called json-schema which has a file called validate.js. This file checks for the existence of a function called 'define' in the global namespace and if it doesn't exist it creates one. The Gruntfile.js file was creating a function of this name in order to read in the application settings file (app/config.js) and its existence was causing validate.js to fail.

The problem has been fixed by removing the 'define' function from the global namespace after it has served its purpose in Gruntfile.js.

Note - this error has only recently started to occur. I'm unable to explain why the tests were not breaking before.
