### PR TITLE
Remove data from home page and services page

### DIFF
--- a/app/client/views/services.js
+++ b/app/client/views/services.js
@@ -22,9 +22,6 @@ function (Modernizr, View, TableView, SummaryFigureView, ServicesKPIS, $, _) {
       'submit #filter-wrapper': 'filterFormSubmit',
       'change #department': function() {
         this.filter('department');
-      },
-      'change #service-group': function() {
-        this.filter('service-group');
       }
     }),
 

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -186,7 +186,7 @@ function (View, Formatters) {
               label: 'Department',
               format: 'sentence'
             }
-          )
+          );
           this.options.firstColumnIsHeading = true;
         }
       }

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -180,6 +180,13 @@ function (View, Formatters) {
         }, this);
         if (axes.x) {
           cols.unshift(axes.x);
+          cols.unshift(
+            {
+              key: 'department_name',
+              label: 'Department',
+              format: 'sentence'
+            }
+          )
           this.options.firstColumnIsHeading = true;
         }
       }

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -13,6 +13,8 @@ var PageConfig = requirejs('page_config');
 
 var get_dashboard_and_render = require('../mixins/get_dashboard_and_render');
 
+var tools = require('./tools');
+
 var dataSource = {
   'data-group': 'service-aggregates',
   'data-type': 'latest-dataset-values',
@@ -125,13 +127,7 @@ function formatCollectionData(services) {
   _.each(services, function (service) {
     _.extend(service, kpis);
     service.titleLink = '<a href="/performance/' + service.slug + '">' + service.title + '</a>';
-    if ("department" in service){
-      service.department_name = service.department.title
-    } else if ("agency" in service) {
-      service.department_name = service.agency.title
-    } else {
-      service.department_name = '<abbr title="Unknown">—</abbr>'
-    }
+    service.department_name = tools.get_department_name(service);
   });
 
   return services;

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -125,7 +125,15 @@ function formatCollectionData(services) {
   _.each(services, function (service) {
     _.extend(service, kpis);
     service.titleLink = '<a href="/performance/' + service.slug + '">' + service.title + '</a>';
+    if ("department" in service){
+      service.department_name = service.department.title
+    } else if ("agency" in service) {
+      service.department_name = service.agency.title
+    } else {
+      service.department_name = '<abbr title="Unknown">—</abbr>'
+    }
   });
+
   return services;
 }
 

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -182,48 +182,8 @@ servicesController.serviceAxes = {
     y: [
       {
         key: 'number_of_transactions',
-        label: 'Transactions per year',
+        label: 'Completed transactions per year',
         format: 'integer'
-      },
-      {
-        key: 'total_cost',
-        label: 'Annual cost',
-        format: 'currency'
-      },
-      {
-        label: 'Cost per transaction',
-        key: 'cost_per_transaction',
-        format: {
-          type: 'currency',
-          pence: true
-        }
-      },
-      {
-        label: 'Digital take-up',
-        key: 'digital_takeup',
-        format: {
-          type: 'percent',
-          dps: 1,
-          fixed: 1
-        }
-      },
-      {
-        label: 'User satisfaction',
-        key: 'user_satisfaction_score',
-        format: {
-          type: 'percent',
-          dps: 1,
-          fixed: 1
-        }
-      },
-      {
-        label: 'Completion rate',
-        key: 'completion_rate',
-        format: {
-          type: 'percent',
-          dps: 1,
-          fixed: 1
-        }
       }
     ]
   }

--- a/app/server/controllers/simple-dashboard-list.js
+++ b/app/server/controllers/simple-dashboard-list.js
@@ -10,6 +10,8 @@ var ErrorView = require('../views/error');
 var DashboardCollection = requirejs('common/collections/dashboards');
 var PageConfig = requirejs('page_config');
 
+var tools = require('./tools');
+
 function controllerSettings(type) {
   switch (type) {
     case 'web-traffic':
@@ -37,6 +39,7 @@ var renderContent = function (req, res, client_instance) {
 
   _.each(contentDashboards, function (service) {
     service.titleLink = '<a href="/performance/' + service.slug + '">' + service.title + '</a>';
+    service.department_name = tools.get_department_name(service);
   });
 
   collection = new DashboardCollection(contentDashboards, controller.axesOptions);

--- a/app/server/controllers/tools.js
+++ b/app/server/controllers/tools.js
@@ -1,0 +1,12 @@
+module.exports = {
+    get_department_name: function (service) {
+        if ("department" in service){
+          department_name = service.department.title;
+        } else if ("agency" in service) {
+          department_name = service.agency.title;
+        } else {
+          department_name = '<abbr title="Unknown">—</abbr>';
+        }
+        return department_name;
+    }
+};

--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -4,7 +4,7 @@
       <h1 class="hero-banner-heading">Performance</h1>
 
       <div class="hero-banner-strapline">
-        Performance data for government services
+        This is where government departments publish performance data about their digital services
       </div>
     </div>
   </div>
@@ -13,100 +13,66 @@
     <h2 class="visuallyhidden" id="header-dashboard-counts">Dashboard counts</h2>
 
     <div class="column-third">
+      <h2 class="vertical-margin-top-small">See how well services are doing</h2>
       <a class="impact-link services-link" href="/performance/services">
         <span class="impact-link-figure services-count"><%= serviceCount %></span> <span class="impact-link-label">service dashboards</span>
       </a>
     </div>
     <div class="column-third">
+      <h2 class="vertical-margin-top-small">See how many people are using services</h2>
       <a class="impact-link" href="/performance/web-traffic">
         <span class="impact-link-figure"><%= webTrafficCount %></span> <span
               class="impact-link-label">web traffic dashboards</span>
       </a>
     </div>
     <div class="column-third">
+      <h2 class="vertical-margin-top-small">See other stats about government services</h2>
       <a class="impact-link" href="/performance/other">
         <span class="impact-link-figure"><%= otherCount %></span> <span class="impact-link-label">other dashboards</span>
       </a>
     </div>
   </div>
 
-  <div class="homepage-showcase" aria-labelledby="selected-dashboards">
-    <h2 class="visuallyhidden" id="selected-dashboards">Selected dashboards</h2>
-    <% _.each(showcaseServices, function (service, index) { %>
-    <div class="brand-interactive outdent-to-full-width vertical-spacing-small grid-row">
-      <div class="column-third">
-        <h3 class="heading-2"><a class="link-unstyled showcase-heading-link-<%= index %>" href="/performance/<%= service.slug %>"><%= service.title %></a></h3>
-      </div>
-      <div class="column-third">
-        <div class="homepage-showcase-item">
-          <a class="link-unstyled" href="/performance/<%= service.slug %>#cost-per-transaction">
-            <span class="homepage-showcase-figure"><%= service.cost_per_transaction %></span> per transaction
-          </a>
-        </div>
-        <div class="homepage-showcase-item">
-          <a class="link-unstyled" href="/performance/<%= service.slug %>#digital_takeup">
-            <span class="homepage-showcase-figure"><%= service.digital_takeup %></span> use the digital service
-          </a>
-        </div>
-      </div>
-      <div class="column-third">
-        <div class="homepage-showcase-item">
-          <a class="link-unstyled" href="/performance/<%= service.slug %>#user-satisfaction-score">
-            <span class="homepage-showcase-figure"><%= service.user_satisfaction_score %></span> users satisfied
-          </a>
-        </div>
-        <div class="homepage-showcase-item">
-          <a class="link-unstyled" href="/performance/<%= service.slug %>#completion-rate">
-            <span class="homepage-showcase-figure"><%= service.completion_rate %></span> complete successfully
-          </a>
-        </div>
-      </div>
-    </div>
-    <hr>
-    <% }); %>
+  <div class="vertical-padding-medium" aria-labelledby="measuring-services">
+    <h1 class="vertical-margin-top-small heading-small">What we measure</h1>
+    <p class="vertical-margin-small">To understand how government services are performing we measure 4 metrics.</p>
   </div>
-  <div class="vertical-spacing-small"><a class="link-large" href="/performance/services">See data on all <%= serviceCount %> services</a></div>
-
-  <h2 class="visuallyhidden">Highest performing services</h2>
   <div class="grid-row">
-    <div class="column-half vertical-margin-top-small top-services-cost" aria-labelledby="top-services-cost">
+    <div class="column-quarter vertical-margin-top-small top-services-cost" aria-labelledby="top-services-cost">
       <div class="icon-top-services">
         <img src="<%= assetPath %>images/<%= assetDigest['cost-per-transaction.svg'] %>" alt="" />
       </div>
       <h2 class="vertical-margin-small" id="top-services-cost">Cost per transaction</h2>
-      <p class="text-small">How much do government services cost the taxpayer per user?</p>
-      <%= tableCost %>
-      <p><a class="text-small" href="/performance/services?sortby=cost_per_transaction&sortorder=ascending#filtered-list">See all</a></p>
+      <p>The average cost to government of each transaction.</p>
     </div>
-    <div class="column-half vertical-margin-top-small top-services-satisfaction" aria-labelledby="top-services-satisfaction">
+    <div class="column-quarter vertical-margin-top-small top-services-satisfaction" aria-labelledby="top-services-satisfaction">
       <div class="icon-top-services">
         <img src="<%= assetPath %>images/<%= assetDigest['user-satisfaction.svg'] %>" alt="" />
       </div>
       <h2 class="vertical-margin-small" id="top-services-satisfaction">User satisfaction</h2>
-      <p class="text-small">How satisfied are the people who use government services?</p>
-      <%= tableSatisfaction %>
-      <p><a class="text-small" href="/performance/services?sortby=user_satisfaction_score&sortorder=descending#filtered-list">See all</a></p>
+      <p>Satisfaction is calculated by asking people to rate a service once they've finished using it.</p>
     </div>
-  </div>
-  <div class="grid-row">
-    <div class="column-half vertical-margin-top-small top-services-completion" aria-labelledby="top-services-completion">
+    <div class="column-quarter vertical-margin-top-small top-services-completion" aria-labelledby="top-services-completion">
       <div class="icon-top-services">
         <img src="<%= assetPath %>images/<%= assetDigest['completion-rate.svg'] %>" alt="" />
       </div>
       <h2 class="vertical-margin-small" id="top-services-completion">Completion rate</h2>
-      <p class="text-small">How many people manage to use government services successfully?</p>
-      <%= tableCompletion %>
-      <p><a class="text-small" href="/performance/services?sortby=completion_rate&sortorder=descending#filtered-list">See all</a></p>
+      <p>The percentage of people who successfully complete a government service.</p>
     </div>
-    <div class="column-half vertical-margin-top-small top-services-takeup" aria-labelledby="top-services-takeup">
+    <div class="column-quarter vertical-margin-top-small top-services-takeup" aria-labelledby="top-services-takeup">
       <div class="icon-top-services">
         <img src="<%= assetPath %>images/<%= assetDigest['digital-takeup.svg'] %>" alt="" />
       </div>
       <h2 class="vertical-margin-small" id="top-services-takeup">Digital take-up</h2>
-      <p class="text-small">How many people use government digital services?</p>
-      <%= tableDigital %>
-      <p><a class="text-small" href="/performance/services?sortby=digital_takeup&sortorder=descending#filtered-list">See all</a></p>
+      <p>The percentage of people using government services online compared to other methods (eg phone or post).</p>
     </div>
   </div>
-
+  <div class="vertical-padding-small" aria-labelledby="measuring-services">
+    <div class="vertical-spacing-small"><a href="https://www.gov.uk/service-manual/measurement/index.html">Find out about how these metrics are defined and measured</a></div>
+    <hr>
+  </div>
+  <div class="vertical-padding-medium" aria-labelledby="get-a-dashboard">
+    <h2 class="vertical-margin-top-small" id="get-a-dashboard">Are you responsible for publishing data about your service?</h2>
+    <p><a href="http://performance-platform.readthedocs.org">Get a dashboard</a></p>
+  </div>
 </div>

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -3,12 +3,12 @@
 <form id="filter-wrapper" method="get" action="">
   <div id="faceted-search" class="cols-row cols-row-no-margin vertical-spacing-bottom">
     <h2 class="visuallyhidden">Filter services by keyword, service or department</h2>
-    <div class="cols3">
+    <div class="cols2">
       <label for="filter" id="filter-keywords">Service name contains</label>
       <input id="filter" placeholder="Example: <%= example %>" name="filter" value="<%= filter %>" type="search" />
     </div>
     <% if (departments.length) {%>
-    <div class="cols3">
+    <div class="cols2">
       <label for="department" id="filter-department"><span aria-hidden="true">Department</span><span class="visuallyhidden">Select a department or agency to filter services by</span></label>
       <select id="department" name="department">
         <option value="">All departments</option>
@@ -31,18 +31,6 @@
       </select>
     </div>
     <% }%>
-    <div class="cols3">
-      <label for="service-group" id="filter-service-group"><span aria-hidden="true">Service group</span><span class="visuallyhidden">Select a service group to filter services by</span></label>
-      <select id="service-group" name="service-group">
-        <option value="">All service groups</option>
-        <% _.each(serviceGroups, function (serviceGroup) { %>
-        <option
-                value="<%= serviceGroup.slug %>"<% if (serviceGroup.slug === serviceGroupFilter) { %>selected<% } %>>
-        <%= serviceGroup.title
-        %></option>
-        <% }); %>
-      </select>
-    </div>
 
     <input type="submit" value="Filter services" id="filter-submit-button"/>
   </div>
@@ -61,9 +49,6 @@
       <% } %>
       <% if (departmentFilterTitle) {%>
         provided by <span class="emphasis"><%= departmentFilterTitle %></span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>
-      <% } %>
-      <% if (serviceGroupFilterTitle) {%>
-        within <span class="emphasis"><%= serviceGroupFilterTitle %></span><button class="btn-remove btn-inline" data-filter="service-group" type="button">×</button>
       <% } %>
     </span>
   </div>
@@ -110,13 +95,6 @@
         </div>
       </div>
     </section>
-    <%
-    // 3 modules per row
-    if (index === 2) {
-    %>
-    </div>
-    <div class="cols-row cols-row-no-margin">
-    <% } %>
     <% }); %>
   </div>
 

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -42,7 +42,7 @@
   <div class="cols2">
     <h2 class="visuallyhidden">Number of services</h2>
     <p class="visuallyhidden">The services list can be filtered by keyword and department or agency.</p>
-    <div class="impact-number summary-figure">
+    <div class="impact-number summary-figure cols-row cols-row-no-margin">
       <strong class="align-top impact-figure-with-desc summary-figure-count"><%= filteredCount %></strong>
       <span class="impact-number-description summary-figure-description">
         <span class="summary-figure-unit emphasis">services</span>
@@ -52,6 +52,10 @@
           provided by <span class="emphasis"><%= departmentFilterTitle %></span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>
         <% } %>
       </span>
+    </div>
+    <h2 class="visuallyhidden">CSV file of full data set</h2>
+    <div class="cols-row cols-row-no-margin vertical-spacing-bottom">
+      <a href="/performance/data/transaction-volumes.csv">Download the full data set (CSV)</a>
     </div>
   </div>
 

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -38,66 +38,68 @@
 
 </form>
 
-<div class="vertical-spacing-bottom">
-  <h2 class="visuallyhidden">Number of services</h2>
-  <p class="visuallyhidden">The services list can be filtered by keyword and department or agency.</p>
-  <div class="impact-number summary-figure">
-    <strong class="align-top impact-figure-with-desc summary-figure-count"><%= filteredCount %></strong>
-    <span class="impact-number-description summary-figure-description">
-      <span class="summary-figure-unit emphasis">services</span>
-      <% if (filter) {%>containing <span class="emphasis">"<%= filter %>"</span><button class="btn-remove btn-inline" data-filter="filter" type="button">×</button>
-      <% } %>
-      <% if (departmentFilterTitle) {%>
-        provided by <span class="emphasis"><%= departmentFilterTitle %></span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>
-      <% } %>
-    </span>
+<div class="services vertical-spacing-bottom">
+  <div class="cols2">
+    <h2 class="visuallyhidden">Number of services</h2>
+    <p class="visuallyhidden">The services list can be filtered by keyword and department or agency.</p>
+    <div class="impact-number summary-figure">
+      <strong class="align-top impact-figure-with-desc summary-figure-count"><%= filteredCount %></strong>
+      <span class="impact-number-description summary-figure-description">
+        <span class="summary-figure-unit emphasis">services</span>
+        <% if (filter) {%>containing <span class="emphasis">"<%= filter %>"</span><button class="btn-remove btn-inline" data-filter="filter" type="button">×</button>
+        <% } %>
+        <% if (departmentFilterTitle) {%>
+          provided by <span class="emphasis"><%= departmentFilterTitle %></span><button class="btn-remove btn-inline" data-filter="department" type="button">×</button>
+        <% } %>
+      </span>
+    </div>
   </div>
-</div>
 
-<div class="service-kpis">
-  <h2 class="visuallyhidden">Totals and averages for filtered services</h2>
-  <div class="cols-row cols-row-no-margin">
-    <% _.each(aggregateVals, function (kpi, index) { %>
-    <section class="module kpi cols3 <%= kpi.key %>">
-      <h3 class="heading-2"><%= kpi.label %></h3>
-      <div class="visualisation">
-        <div class="visualisation-inner">
-          <div class="stat">
-            <p class="single-stat-headline impact-number">
-              <% if (kpi.formattedValue) {%>
-                <strong><%= kpi.formattedValue %></strong>
+  <div class="cols2 service-kpis">
+    <h2 class="visuallyhidden">Totals and averages for filtered services</h2>
+    <div class="cols-row cols-row-no-margin">
+      <% _.each(aggregateVals, function (kpi, index) { %>
+      <div class="vertical-spacing-bottom module kpi <%= kpi.key %>">
+        <h3 class="heading-2"><%= kpi.label %></h3>
+        <div class="visualisation">
+          <div class="visualisation-inner">
+            <div class="stat">
+              <p class="single-stat-headline impact-number">
+                <% if (kpi.formattedValue) {%>
+                  <strong><%= kpi.formattedValue %></strong>
+                <% } else { %>
+                  <strong class="no-data">no data</strong>
+                <% } %>
+              </p>
+            </div>
+          </div>
+
+          <div class="text-small visualisation-moreinfo<% if (!kpi.formattedValue) {%> hidden<% } %>">
+            <% if (filteredCount > 1) { %>
+            <% if (kpi.isWeighted) { %>
+              weighted average
+            <% } else { %>
+              total
+            <% } %> for
+            <% } %>
+            <a href="#filtered-list" class="js-sort-by" data-sort-by="<%= kpi.key %>">
+            <% if (kpi.allRowsHaveValues === true) { %>
+              <% if (filteredCount === 1) { %>
+                1 service
               <% } else { %>
-                <strong class="no-data">no data</strong>
+                all <%= filteredCount %> services
               <% } %>
-            </p>
+            <% } else { %>
+            <%= kpi.valueCount %> services out of <%= filteredCount %>
+            <% } %>
+            </a>
           </div>
         </div>
-
-        <div class="visualisation-moreinfo<% if (!kpi.formattedValue) {%> hidden<% } %>">
-          <% if (filteredCount > 1) { %>
-          <% if (kpi.isWeighted) { %>
-            weighted average
-          <% } else { %>
-            total
-          <% } %> for
-          <% } %>
-          <a href="#filtered-list" class="js-sort-by" data-sort-by="<%= kpi.key %>">
-          <% if (kpi.allRowsHaveValues === true) { %>
-            <% if (filteredCount === 1) { %>
-              1 service
-            <% } else { %>
-              all <%= filteredCount %> services
-            <% } %>
-          <% } else { %>
-          <%= kpi.valueCount %> services out of <%= filteredCount %>
-          <% } %>
-          </a>
-        </div>
       </div>
-    </section>
-    <% }); %>
-  </div>
+      <% }); %>
+    </div>
 
+  </div>
 </div>
 
 <section class="filtered-list visualisation-table" id="filtered-list">

--- a/app/server/views/homepage.js
+++ b/app/server/views/homepage.js
@@ -66,10 +66,6 @@ module.exports = BaseView.extend({
       webTrafficCount: this.contentDashboards.length,
       otherCount: this.otherDashboards.length,
       showcaseServices: this.showcaseServices,
-      tableCost: this.renderServicesTable('cost_per_transaction', 'ascending'),
-      tableSatisfaction: this.renderServicesTable('user_satisfaction_score'),
-      tableCompletion: this.renderServicesTable('completion_rate'),
-      tableDigital: this.renderServicesTable('digital_takeup')
     }, this.model.toJSON()));
 
   }

--- a/spec/client/common/views/spec.services.js
+++ b/spec/client/common/views/spec.services.js
@@ -48,11 +48,6 @@ define([
         label: 'home-office',
         nonInteraction: true
       });
-      this.$el.find('#service-group').val('service1').trigger('change');
-      expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ppServices', 'service-group', {
-        label: 'service1',
-        nonInteraction: true
-      });
     });
 
   });

--- a/spec/server-pure/views/spec.homepage.js
+++ b/spec/server-pure/views/spec.homepage.js
@@ -64,34 +64,4 @@ describe('Homepage View', function () {
 
   });
 
-  describe('formatKpis', function () {
-
-    it('replaces kpi values with formatted versions', function () {
-      view.formatKpis(services);
-      expect(services[0].completion_rate).toEqual('40.0%');
-    });
-
-  });
-
-  describe('renderServicesTable', function() {
-
-    it('renders a table for the specified KPI', function() {
-      var html = view.renderServicesTable('completion_rate');
-      expect(global.$(html).find('tbody tr').length).toEqual(2);
-    });
-
-    it('sorts the table in descending order by default', function() {
-      var html = view.renderServicesTable('number_of_transactions');
-      expect(global.$(html).find('tbody tr:eq(0) [data-key="number_of_transactions"]').text()).toEqual('140,000');
-      expect(global.$(html).find('tbody tr:eq(1) [data-key="number_of_transactions"]').text()).toEqual('2,000');
-    });
-
-    it('sorts the table in ascending order if specified', function() {
-      var html = view.renderServicesTable('cost_per_transaction', 'ascending');
-      expect(global.$(html).find('tbody tr:eq(0) [data-key="cost_per_transaction"]').text()).toEqual('£0.06');
-      expect(global.$(html).find('tbody tr:eq(1) [data-key="cost_per_transaction"]').text()).toEqual('£3.46');
-    });
-
-  });
-
 });

--- a/spec/server-pure/views/spec.services.js
+++ b/spec/server-pure/views/spec.services.js
@@ -99,20 +99,10 @@ describe('Services View', function () {
 
     it('adds a formatted value for kpis with a weighted_average', function () {
       expect(view.formatAggregateValues()[0].formattedValue).toEqual('2,000');
-      expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
-      expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
-      expect(view.formatAggregateValues()[3].formattedValue).toEqual('0%');
-      expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
-      expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
     });
 
     it('ensures all results are present even for ones with no values', function () {
       expect(view.formatAggregateValues()[0].key).toEqual('number_of_transactions');
-      expect(view.formatAggregateValues()[1].key).toEqual('total_cost');
-      expect(view.formatAggregateValues()[2].key).toEqual('cost_per_transaction');
-      expect(view.formatAggregateValues()[3].key).toEqual('digital_takeup');
-      expect(view.formatAggregateValues()[4].key).toEqual('user_satisfaction_score');
-      expect(view.formatAggregateValues()[5].key).toEqual('completion_rate');
     });
 
     describe('with more than one service/transaction', function () {
@@ -165,11 +155,6 @@ describe('Services View', function () {
 
       it('adds a formatted value for kpis with a weighted_average', function () {
         expect(view.formatAggregateValues()[0].formattedValue).toEqual('4,000');
-        expect(view.formatAggregateValues()[1].formattedValue).toBeUndefined();
-        expect(view.formatAggregateValues()[2].formattedValue).toBeUndefined();
-        expect(view.formatAggregateValues()[3].formattedValue).toEqual('25%');
-        expect(view.formatAggregateValues()[4].formattedValue).toBeUndefined();
-        expect(view.formatAggregateValues()[5].formattedValue).toEqual('40%');
       });
 
     });

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -91,8 +91,8 @@ function (Table, View, Collection, Backbone, $) {
           valueAttr: 'value'
         };
         spyOn(collection, 'getTableRows').andReturn([
-          ['01/02/01', 'foo', 10, null],
-          ['04/03/12', 'bar', 5, null]
+          ['dept', '01/02/01', 'foo', 10, null],
+          ['agency', '04/03/12', 'bar', 5, null]
         ]);
       });
 
@@ -135,7 +135,7 @@ function (Table, View, Collection, Backbone, $) {
       it('will render with "no data" when a row has null values', function () {
         table = new Table(tableOptions);
         table.render();
-        expect(table.$el.find('tbody tr').eq(0).find('td').eq(3).text())
+        expect(table.$el.find('tbody tr').eq(0).find('td').eq(4).text())
           .toEqual('');
       });
 
@@ -143,7 +143,7 @@ function (Table, View, Collection, Backbone, $) {
         table = new Table(tableOptions);
         table.render();
         expect(table.collection.getTableRows)
-          .toHaveBeenCalledWith(['timestamp', 'value', 'timeshift52:value', 'number_of_transactions'] , undefined);
+          .toHaveBeenCalledWith(['department_name', 'timestamp', 'value', 'timeshift52:value', 'number_of_transactions'] , undefined);
       });
 
       it('does not crash if no data is provided', function () {
@@ -155,7 +155,7 @@ function (Table, View, Collection, Backbone, $) {
       it('will append the timeshift duration to the column header', function () {
         table = new Table(tableOptions);
         table.render();
-        expect(table.$el.find('thead th').eq(2).text())
+        expect(table.$el.find('thead th').eq(3).text())
           .toEqual('onemore (52 weeks ago) Click to sort');
       });
 
@@ -163,6 +163,7 @@ function (Table, View, Collection, Backbone, $) {
         it('returns an array of consolidated axes data', function () {
           table = new Table(tableOptions);
           expect(table.getColumns()).toEqual([
+              { key: 'department_name', label: 'Department', format: 'sentence'},
               { key: 'timestamp', label: 'date' },
               { key: 'value', label: 'another' },
               { key: 'timeshift52:value', label: 'onemore', timeshift: 52 },
@@ -177,7 +178,7 @@ function (Table, View, Collection, Backbone, $) {
         table.collection.options.axes.y[1].format = 'percent';
         table.render();
         expect(table.format).toHaveBeenCalledWith(10, 'percent');
-        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(2).text())
+        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(3).text())
           .toEqual('10%');
       });
 
@@ -187,7 +188,7 @@ function (Table, View, Collection, Backbone, $) {
         table.collection.options.axes.y[1].format = 'integer';
         table.render();
         expect(table.format).toHaveBeenCalledWith(10, 'integer');
-        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(2).hasClass('integer'))
+        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(3).hasClass('integer'))
           .toBe(true);
       });
 
@@ -201,17 +202,18 @@ function (Table, View, Collection, Backbone, $) {
       it('adds column keys as data attrs to header cells', function () {
         table = new Table(tableOptions);
         table.render();
-        expect(table.$('th:eq(0)').attr('data-key')).toEqual('timestamp');
-        expect(table.$('th:eq(1)').attr('data-key')).toEqual('value');
-        expect(table.$('th:eq(2)').attr('data-key')).toEqual('timeshift52:value');
-        expect(table.$('th:eq(3)').attr('data-key')).toEqual('number_of_transactions');
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('department_name');
+        expect(table.$('th:eq(1)').attr('data-key')).toEqual('timestamp');
+        expect(table.$('th:eq(2)').attr('data-key')).toEqual('value');
+        expect(table.$('th:eq(3)').attr('data-key')).toEqual('timeshift52:value');
+        expect(table.$('th:eq(4)').attr('data-key')).toEqual('number_of_transactions');
       });
 
       it('adds first key as data attrs to header cell if key is an array', function () {
         table = new Table(tableOptions);
         table.collection.options.axes.x.key = ['start', 'end'];
         table.render();
-        expect(table.$('th:eq(0)').attr('data-key')).toEqual('start');
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('department_name');
       });
 
       it('adds the row index as an attribute to the first cell in a row', function () {
@@ -269,7 +271,7 @@ function (Table, View, Collection, Backbone, $) {
           table = new Table(tableOptions);
           table.render();
           unsortedCols = table.$('thead th:not(.sort-column) .js-click-sort');
-          expect(unsortedCols.length).toEqual(3);
+          expect(unsortedCols.length).toEqual(4);
           expect(unsortedCols.first().text()).toEqual('Click to sort');
           expect(table.$('thead th.sort-column .js-click-sort').length).toEqual(0);
       });

--- a/styles/common/kpi.scss
+++ b/styles/common/kpi.scss
@@ -79,7 +79,6 @@
   }
 
   .service-kpis {
-    border-top: 1px solid $grey-2;
     section.kpi {
       border-top: 0 none;
     }

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -60,6 +60,12 @@ a[rel="external"] {
   @include external-link-19;
 }
 
+.heading-small {
+  @include bold-36;
+  margin-top: 45px/24px * 1em;
+  margin-bottom: 15px/24px * 1em;
+}
+
 .link-unstyled {
   text-decoration: none;
   &:link,

--- a/tests/functional/home-page.js
+++ b/tests/functional/home-page.js
@@ -25,19 +25,5 @@ module.exports = {
       });
   },
 
-  '4 showcase services are present': function (client) {
-    client.elements('css selector', this.selectors.showcaseService, function(result) {
-      this.assert.equal(result.value.length, 4);
-      this.end();
-    });
-  },
-
-  'Top 5 services are present': function (client) {
-    client.elements('css selector', this.selectors.topServicesCostItems, function(result) {
-        this.assert.equal(result.value.length, 5);
-        this.end();
-      });
-  }
-
 };
 


### PR DESCRIPTION
The data about services on the /performance home page and the services page can be incorrect and misleading, and doesn't match the data on the individual dashboard. 
To remove some the confusion, the performance homepage has been changed into a navigation page and the descriptions for each KPI has been updated. 
Also, the aggregate KPI data has been removed from the services page.

The only place service performance data should be displayed now is on the individual dashboards

Pivotal: https://www.pivotaltracker.com/story/show/111592970
Pivotal: https://www.pivotaltracker.com/story/show/111591258