### PR TITLE
Fix tables

### DIFF
--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -179,7 +179,28 @@ function (View, Formatters) {
           return column;
         }, this);
         if (axes.x) {
-          if (axes.x.constructor === Array){
+          /*
+            As the x-axis can be either a single object or a list of columns
+            we need to determine whether the x-axis is an array.
+            There are multiple ways to determine whether an object is an array
+            in javascript:
+            1. Check if the constructor is of type Array:
+              axes.x.constructor === Array
+            2. Check if the x axis object is an array:
+              Array.isArray(axes.x)
+            3. Check if the x axis is an instance of array:
+              axes.x instanceof Array
+
+            However, none of these work consistently. Whilst the web site can
+            detect an array if any of these methods are used, the unit and
+            integration tests do not. The cheapseats tests only work with
+            options 1 and 3, and the unit tests only work with option 2.
+
+            length is property that is exclusive to arrays.
+            If an object doesn't have a length property, the expression returns
+            a falsy value.
+          */
+          if (axes.x.length > 0){
             _.each(axes.x, function(element){ cols.unshift(element);});
           }
           else {

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -179,14 +179,12 @@ function (View, Formatters) {
           return column;
         }, this);
         if (axes.x) {
-          cols.unshift(axes.x);
-          cols.unshift(
-            {
-              key: 'department_name',
-              label: 'Department',
-              format: 'sentence'
-            }
-          );
+          if (axes.x.constructor === Array){
+            _.each(axes.x, function(element){ cols.unshift(element);});
+          }
+          else {
+            cols.unshift(axes.x);
+          }
           this.options.firstColumnIsHeading = true;
         }
       }

--- a/app/server/controllers/services.js
+++ b/app/server/controllers/services.js
@@ -179,10 +179,17 @@ servicesController.showcaseServiceSlugs = [
 
 servicesController.serviceAxes = {
   axes: {
-    x: {
-      key: 'titleLink',
-      label: 'Service name'
-    },
+    x: [
+      {
+        key: 'titleLink',
+        label: 'Service name'
+      },
+      {
+        key: 'department_name',
+        label: 'Department',
+        format: 'sentence'
+      }
+    ],
     y: [
       {
         key: 'number_of_transactions',

--- a/app/server/controllers/simple-dashboard-list.js
+++ b/app/server/controllers/simple-dashboard-list.js
@@ -89,10 +89,17 @@ function controller (type, req, res) {
 
 controller.axesOptions = {
   axes: {
-    x: {
-      key: 'titleLink',
-      label: 'Dashboard name'
-    },
+    x: [
+      {
+        key: 'titleLink',
+        label: 'Dashboard name'
+      },
+      {
+        key: 'department_name',
+        label: 'Department',
+        format: 'sentence'
+      }
+    ],
     y: []
   }
 };

--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -4,7 +4,7 @@
       <h1 class="hero-banner-heading">Performance</h1>
 
       <div class="hero-banner-strapline">
-        This is where government departments publish performance data about their digital services
+        This is where government departments publish performance data about their services
       </div>
     </div>
   </div>

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -91,8 +91,8 @@ function (Table, View, Collection, Backbone, $) {
           valueAttr: 'value'
         };
         spyOn(collection, 'getTableRows').andReturn([
-          ['dept', '01/02/01', 'foo', 10, null],
-          ['agency', '04/03/12', 'bar', 5, null]
+          ['01/02/01', 'foo', 10, null],
+          ['04/03/12', 'bar', 5, null]
         ]);
       });
 
@@ -143,7 +143,7 @@ function (Table, View, Collection, Backbone, $) {
         table = new Table(tableOptions);
         table.render();
         expect(table.collection.getTableRows)
-          .toHaveBeenCalledWith(['department_name', 'timestamp', 'value', 'timeshift52:value', 'number_of_transactions'] , undefined);
+          .toHaveBeenCalledWith(['timestamp', 'value', 'timeshift52:value', 'number_of_transactions'] , undefined);
       });
 
       it('does not crash if no data is provided', function () {
@@ -155,7 +155,7 @@ function (Table, View, Collection, Backbone, $) {
       it('will append the timeshift duration to the column header', function () {
         table = new Table(tableOptions);
         table.render();
-        expect(table.$el.find('thead th').eq(3).text())
+        expect(table.$el.find('thead th').eq(2).text())
           .toEqual('onemore (52 weeks ago) Click to sort');
       });
 
@@ -163,12 +163,27 @@ function (Table, View, Collection, Backbone, $) {
         it('returns an array of consolidated axes data', function () {
           table = new Table(tableOptions);
           expect(table.getColumns()).toEqual([
-              { key: 'department_name', label: 'Department', format: 'sentence'},
               { key: 'timestamp', label: 'date' },
               { key: 'value', label: 'another' },
               { key: 'timeshift52:value', label: 'onemore', timeshift: 52 },
               { key: 'number_of_transactions', label: 'last' }
             ]);
+        });
+
+        it('allows the x-axis to be an array', function () {
+          tableOptions.collection.options.axes.x = [
+                { label: 'second value', key: 'second' },
+                { label: 'first value', key: 'first' }
+          ];
+
+          table = new Table(tableOptions);
+          expect(table.getColumns()).toEqual([
+                { key: 'first', label: 'first value' },
+                { key: 'second', label: 'second value' },
+                { key: 'value', label: 'another' },
+                { key: 'timeshift52:value', label: 'onemore', timeshift: 52 },
+                { key: 'number_of_transactions', label: 'last' }
+              ]);
         });
       });
 
@@ -178,7 +193,7 @@ function (Table, View, Collection, Backbone, $) {
         table.collection.options.axes.y[1].format = 'percent';
         table.render();
         expect(table.format).toHaveBeenCalledWith(10, 'percent');
-        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(3).text())
+        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(2).text())
           .toEqual('10%');
       });
 
@@ -188,7 +203,7 @@ function (Table, View, Collection, Backbone, $) {
         table.collection.options.axes.y[1].format = 'integer';
         table.render();
         expect(table.format).toHaveBeenCalledWith(10, 'integer');
-        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(3).hasClass('integer'))
+        expect(table.$el.find('tbody tr').eq(0).find('th,td').eq(2).hasClass('integer'))
           .toBe(true);
       });
 
@@ -202,18 +217,17 @@ function (Table, View, Collection, Backbone, $) {
       it('adds column keys as data attrs to header cells', function () {
         table = new Table(tableOptions);
         table.render();
-        expect(table.$('th:eq(0)').attr('data-key')).toEqual('department_name');
-        expect(table.$('th:eq(1)').attr('data-key')).toEqual('timestamp');
-        expect(table.$('th:eq(2)').attr('data-key')).toEqual('value');
-        expect(table.$('th:eq(3)').attr('data-key')).toEqual('timeshift52:value');
-        expect(table.$('th:eq(4)').attr('data-key')).toEqual('number_of_transactions');
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('timestamp');
+        expect(table.$('th:eq(1)').attr('data-key')).toEqual('value');
+        expect(table.$('th:eq(2)').attr('data-key')).toEqual('timeshift52:value');
+        expect(table.$('th:eq(3)').attr('data-key')).toEqual('number_of_transactions');
       });
 
       it('adds first key as data attrs to header cell if key is an array', function () {
         table = new Table(tableOptions);
         table.collection.options.axes.x.key = ['start', 'end'];
         table.render();
-        expect(table.$('th:eq(0)').attr('data-key')).toEqual('department_name');
+        expect(table.$('th:eq(0)').attr('data-key')).toEqual('start');
       });
 
       it('adds the row index as an attribute to the first cell in a row', function () {
@@ -271,7 +285,7 @@ function (Table, View, Collection, Backbone, $) {
           table = new Table(tableOptions);
           table.render();
           unsortedCols = table.$('thead th:not(.sort-column) .js-click-sort');
-          expect(unsortedCols.length).toEqual(4);
+          expect(unsortedCols.length).toEqual(3);
           expect(unsortedCols.first().text()).toEqual('Click to sort');
           expect(table.$('thead th.sort-column .js-click-sort').length).toEqual(0);
       });

--- a/tests/functional/services.js
+++ b/tests/functional/services.js
@@ -1,0 +1,48 @@
+module.exports = {
+  selectors: {
+    'filterTable': '#filtered-list table',
+    'textFilter': '#filter',
+    servicesCount: '.summary-figure-count',
+    servicesCountDescription: '.summary-figure-description'
+  },
+
+  beforeEach: function (client) {
+    client
+      .url('http://localhost:3057/performance/services')
+      .waitForElementVisible('body.js-enabled', 20000);
+  },
+
+  'Sections Exist': function (client) {
+    client
+      .assert.visible('#filter-wrapper')
+      .assert.visible('#filtered-list')
+      .end();
+  },
+
+  'Text filter': function (client) {
+    client
+      .assert.containsText(this.selectors.filterTable, 'Department for Business, Innovation & Skills')
+      .assert.containsText(this.selectors.filterTable, 'Debt Relief Order (DRO) applicatons')
+      .setValue(this.selectors.textFilter, ['prison', client.Keys.ENTER])
+      .waitForElementVisible(this.selectors.filterTable, 1000)
+      .assert.doesNotContainText(this.selectors.filterTable, 'Department for Business, Innovation & Skills')
+      .assert.doesNotContainText(this.selectors.filterTable, 'Debt Relief Order (DRO) applicatons')
+      .assert.containsText(this.selectors.filterTable, 'Ministry of Justice')
+      .assert.containsText(this.selectors.filterTable, 'Bookings for prison visits')
+      .end();
+  },
+
+  'Filtered services total count is correct': function (client) {
+    var test = this;
+    client
+      .assert.doesNotContainText(test.selectors.servicesCountDescription, 'containing')
+      .setValue(this.selectors.textFilter, ['prison', client.Keys.ENTER])
+      .getText(this.selectors.servicesCount, function(result) {
+          this
+            .assert.containsText(test.selectors.servicesCount, result.value)
+            .assert.containsText(test.selectors.servicesCountDescription, 'containing')
+            .end();
+      });
+  },
+
+};


### PR DESCRIPTION
All of the graphs on the dashboards are underpinned by a table.
If javascript is turned off the table is displayed instead of the graph.

The hack added to add a department name had broken this feature. The
code that renders tables is shared across spotlight. When the department
name was added to the table rendering code, it was also added behind the
scenes to every graph. The graphs still rendered correctly, but when
javascript was turned off, the table failed to render.

Added a  fix to allow the x axis of the graph/table to accept a list or
a single value. This is because whilst some of the config for the x and
y axes is held in spotlight, the majority of it is held in the module
config in stagecraft and can only be edited via the admin app.

Also add integration tests for the services page.