### PR TITLE
Fix positioning of column title

### DIFF
--- a/styles/pages/servicespage.scss
+++ b/styles/pages/servicespage.scss
@@ -17,12 +17,13 @@
   }
 
   @include media(desktop) {
-    thead [data-key="number_of_transactions"] {
+    thead {
       position: relative;
-      a {
-        position: absolute;
-        width: 15em;
-        left: -9em;
+      [data-key="number_of_transactions"] {
+        a {
+          position: absolute;
+          right: 1.2em;
+        }
       }
     }
   }


### PR DESCRIPTION
The CSS positioning of the Completed transactions per year column title on the Services page was not responding well when table data is filtered. An alternative CSS positioning approach fixes this.