### PR TITLE
Track download of Transactions Explorer CSV data

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,6 +177,7 @@ module.exports = function (grunt) {
         src: [
           'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
           'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
+          'node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/download-link-tracker.js',
           'app/client/analytics.js'
         ],
         dest: 'public/javascripts/analytics.js'

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -55,7 +55,7 @@
     </div>
     <h2 class="visuallyhidden">CSV file of full data set</h2>
     <div class="cols-row cols-row-no-margin vertical-spacing-bottom text-small">
-      <a href="/performance/data/transaction-volumes.csv">Download cost per transaction and volume data (CSV)</a>
+      <a rel="download" href="/performance/data/transaction-volumes.csv">Download cost per transaction and volume data (CSV)</a>
     </div>
   </div>
 
@@ -111,3 +111,14 @@
   <div class="heading-3 mq-small-only">Sort by:</div>
   <%= table %>
 </section>
+
+<% if (process.env.NODE_ENV == 'production') { %>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js""></script>
+
+<script>
+  $(document).ready(function() {
+      GOVUK.analyticsPlugins.downloadLinkTracker({selector: 'a[rel=download]'});
+    }
+  );
+</script>
+<% } %>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "errorhandler": "1.1.1",
     "express": "4.4.4",
     "glob": "4.0.2",
-    "govuk_frontend_toolkit": "4.0.0",
+    "govuk_frontend_toolkit": "4.9.1",
     "govuk_template_mustache": "0.12.0",
     "graceful-fs": "3.0.2",
     "grunt": "0.4.5",


### PR DESCRIPTION
We want to see how many people download the Transaction Explorer CSV data. See https://trello.com/c/PsUMu5iu/12-finding-out-how-many-use-the-csv-download

Note it was necessary to upgrade govuk_frontend_toolkit package in order to make use of download-link-tracker.js. The use of this also necessitates the pulling in of JQuery into the Services page.

