### PR TITLE
Revert survey link

### DIFF
--- a/app/server/templates/dashboard.html
+++ b/app/server/templates/dashboard.html
@@ -1,6 +1,7 @@
 <header>
-  {{{ get_in_touch }}}
+
   <main>
+
     <h1>
       {{# strapline }}<span class="strapline">{{ strapline }}</span>{{/ strapline }}
       {{ header }}

--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -8,7 +8,7 @@
       </div>
     </div>
   </div>
-  <%= get_in_touch %>
+
   <div class="vertical-padding-medium-top grid-row" aria-labelledby="header-dashboard-counts">
     <h2 class="visuallyhidden" id="header-dashboard-counts">Dashboard counts</h2>
 

--- a/app/server/templates/homepage.html
+++ b/app/server/templates/homepage.html
@@ -32,15 +32,12 @@
       <p class="lead vertical-margin-top-small">See other stats about government services</p>
     </div>
 
-    <div class="column">
-      <p>
-        Are you responsible for publishing data about your service?
-        <a href="http://performance-platform.readthedocs.org">Get a dashboard</a>
-      </p>
+    <div class="column-two-thirds">
+      <a href="http://performance-platform.readthedocs.org">Find out about how to get a dashboard to publish your data</a>
     </div>
   </div>
 
-  <div class="vertical-padding-medium-top vertical-margin-top-small vertical-spacing-bottom" aria-labelledby="measuring-services">
+  <div class="vertical-padding-medium-top" aria-labelledby="measuring-services">
     <h1 class="vertical-margin-top-small heading-small">Measuring how services are performing</h1>
     <div class="grid-row">
       <div class="column-half vertical-margin-medium top-services-cost" aria-labelledby="top-services-cost">
@@ -63,7 +60,7 @@
         <h2 class="vertical-margin-small" id="top-services-takeup">Digital take-up</h2>
         <p class="lead">The percentage of people using government services online compared to other methods (eg phone or post).</p>
       </div>
-      <div class="column">
+      <div class="column-two-thirds">
         <a href="https://www.gov.uk/service-manual/measurement/index.html" aria-labelledby="measuring-services">Find out about how these metrics are defined and measured</a>
       </div>
   </div>

--- a/app/server/templates/page-components/get_in_touch.html
+++ b/app/server/templates/page-components/get_in_touch.html
@@ -1,4 +1,4 @@
 <div id="get-in-touch" class="vertical-margin-medium" aria-labelledby="get-in-touch">
-  <p class="lead">Performance GOV.UK is changing. If you are a user of this data, please <a href="https://www.surveymonkey.co.uk/r/performanceUserSurvey">get in touch</a>.</p>
-  <hr>
+    <p class="lead">Performance GOV.UK is changing. If you are a user of this data, please get in touch.</p>
+    <hr>
 </div>

--- a/app/server/templates/page-components/get_in_touch.html
+++ b/app/server/templates/page-components/get_in_touch.html
@@ -1,4 +1,4 @@
 <div id="get-in-touch" class="vertical-margin-medium" aria-labelledby="get-in-touch">
-    <p class="lead">Performance on GOV.UK is changing. If you're users of the data, please get in touch.</p>
+    <p class="lead">There are going to be changes in how service performance data is published. If you use information from this Performance website regularly, please get in touch.</p>
     <hr>
 </div>

--- a/app/server/templates/page-components/get_in_touch.html
+++ b/app/server/templates/page-components/get_in_touch.html
@@ -1,4 +1,4 @@
 <div id="get-in-touch" class="vertical-margin-medium" aria-labelledby="get-in-touch">
-    <p class="lead">Performance GOV.UK is changing. If you are a user of this data, please get in touch.</p>
+    <p class="lead">Performance on GOV.UK is changing. If you're users of the data, please get in touch.</p>
     <hr>
 </div>

--- a/app/server/templates/page-components/get_in_touch.html
+++ b/app/server/templates/page-components/get_in_touch.html
@@ -1,4 +1,0 @@
-<div id="get-in-touch" class="vertical-margin-medium" aria-labelledby="get-in-touch">
-    <p class="lead">There are going to be changes in how service performance data is published. If you use information from this Performance website regularly, please get in touch.</p>
-    <hr>
-</div>

--- a/app/server/templates/services.html
+++ b/app/server/templates/services.html
@@ -1,5 +1,5 @@
-<%= get_in_touch %>
 <header><h1><%= heading %></h1></header>
+
 <form id="filter-wrapper" method="get" action="">
   <div id="faceted-search" class="cols-row cols-row-no-margin vertical-spacing-bottom">
     <h2 class="visuallyhidden">Filter services by keyword, service or department</h2>

--- a/app/server/templates/simple-dashboard-list.html
+++ b/app/server/templates/simple-dashboard-list.html
@@ -1,5 +1,5 @@
-<%= get_in_touch %>
 <header><h1><%= heading %></h1></header>
+
 <form id="filter-wrapper" class="services cols-row cols-row-no-margin" method="get" action="">
 
   <div id="faceted-search">

--- a/app/server/views/dashboard.js
+++ b/app/server/views/dashboard.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs');
+
 var View = require('./govuk');
 var template = path.resolve(__dirname, '../templates/dashboard.html');
 var pptTemplate = path.resolve(__dirname, '../templates/module-page.html');
@@ -65,7 +65,6 @@ module.exports = View.extend({
     context.schemaOrgItemType = this.getSchemaOrgItemType();
     context.tagline = this.getTagline();
     context.hasFooter = false;
-    context.get_in_touch = fs.readFileSync(path.resolve(__dirname, '../templates/page-components/get_in_touch.html'));
 
     return context;
   },

--- a/app/server/views/homepage.js
+++ b/app/server/views/homepage.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var requirejs = require('requirejs');
-var fs = require('fs');
 var templatePath = path.resolve(__dirname, '../templates/homepage.html');
 
 var Backbone = require('backbone');
@@ -67,7 +66,6 @@ module.exports = BaseView.extend({
       webTrafficCount: this.contentDashboards.length,
       otherCount: this.otherDashboards.length,
       showcaseServices: this.showcaseServices,
-      get_in_touch: fs.readFileSync(path.resolve(__dirname, '../templates/page-components/get_in_touch.html'))
     }, this.model.toJSON()));
 
   }

--- a/app/server/views/services.js
+++ b/app/server/views/services.js
@@ -1,6 +1,5 @@
 var requirejs = require('requirejs');
 var path = require('path');
-var fs = require('fs');
 
 var BaseView = require('./govuk');
 var TableView = requirejs('extensions/views/table');
@@ -82,8 +81,7 @@ module.exports = BaseView.extend({
     }, {
       heading: this.heading,
       example: this.example,
-      noun: this.model.get('noun'),
-      get_in_touch: fs.readFileSync(path.resolve(__dirname, '../templates/page-components/get_in_touch.html'))
+      noun: this.model.get('noun')
     }));
 
   }

--- a/styles/common/layout.scss
+++ b/styles/common/layout.scss
@@ -88,11 +88,6 @@ $vertical-unit: $gutter-half;
   margin-bottom: 5px;
 }
 
-.vertical-margin-medium {
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
 .outdent-to-full-width {
   @extend %outdent-to-full-width;
 }

--- a/styles/elements/_layout.scss
+++ b/styles/elements/_layout.scss
@@ -66,7 +66,3 @@
 .column-two-thirds {
   @include grid-column( 2/3 );
 }
-
-.column {
-  @include grid-column( 1 );
-}

--- a/styles/pages/homepage.scss
+++ b/styles/pages/homepage.scss
@@ -3,8 +3,11 @@
   .column-third {
     margin-bottom: 1.2em;
   }
-}
 
+  .column-two-thirds {
+    margin-bottom: 2em;
+  }
+}
 .homepage #global-header-bar {
   display: none;
 }


### PR DESCRIPTION
Remove the Get In Touch banner containing a link to a user survey that was used to determine how  people have been using the Performance Platform.