### PR TITLE
Remove prototypes link from header navigation

### DIFF
--- a/app/server/templates/page-components/navigation.html
+++ b/app/server/templates/page-components/navigation.html
@@ -9,7 +9,6 @@
         <li><a href="/performance/web-traffic">Web traffic data</a></li>
         <li><a href="http://performance-platform.readthedocs.org/">Get a dashboard</a></li>
         <li><a href="/performance/about">About</a></li>
-        <li><a href="/performance/prototypes">Prototypes</a></li>
         <li><a href="https://gdsdata.blog.gov.uk/category/archived/performance-platform/">Blog</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Remove link to prototypes page while the data team considers what to do with the prototypes accessible via Performance Platform.