### PR TITLE
Sanitize user input

### DIFF
--- a/app/server/mixins/get_dashboard_and_render.js
+++ b/app/server/mixins/get_dashboard_and_render.js
@@ -1,12 +1,19 @@
 var requirejs = require('requirejs');
+var url = require('url');
+var sanitizer = require('sanitizer');
+var StagecraftApiClient = requirejs('stagecraft_api_client');
 
 var controllerMap = require('../../server/controller_map')();
-var StagecraftApiClient = requirejs('stagecraft_api_client');
-var url = require('url');
+
+var sanitizeObject = function (object) {
+  return _.mapValues(object, function(value) {
+    return sanitizer.escape(value);
+  });
+};
 
 var buildStagecraftApiClient = function (req) {
   var this_client_instance = new StagecraftApiClient({
-    params: url.parse(req.originalUrl, true).query
+    params: sanitizeObject(url.parse(req.originalUrl, true).query)
   }, {
     ControllerMap: controllerMap,
     requestId: req.get('Request-Id'),

--- a/spec/server-pure/mixins/spec.get_dashboard_and_render.js
+++ b/spec/server-pure/mixins/spec.get_dashboard_and_render.js
@@ -31,6 +31,7 @@ describe('get_dashboard_and_render', function () {
       },
       originalUrl: ''
     };
+
     fakeStatusCall = jasmine.createSpy('status');
     fake_response = {status: fakeStatusCall};
   });
@@ -39,6 +40,23 @@ describe('get_dashboard_and_render', function () {
     expect(StagecraftApiClient.prototype.initialize).toHaveBeenCalledWith(
       {
         params: {}
+      },
+      {
+        ControllerMap: controllerMap,
+        requestId: 'Xb35Gt',
+        govukRequestId: '1231234123'
+      });
+    expect(client_instance.stagecraftUrlRoot).toEqual('urlURL/public/dashboards');
+  });
+  it('should escape XSS attempts in queries', function(){
+    fake_request.originalUrl = 'http://localhost:3057/performance/central-government-websites?sortby=percentOfTotal(count:sum)%22%27--!%3E%3C/Title/%3C/Style/%3C/script/%3C/Textarea/%3C/Noscr%20ipt/%3C/Pre/%3C/Xmp%3E%3CSvg/Onload=confirm`OPENBUGBOUNTY`%3E&sortorder=descending';
+    var client_instance = get_dashboard_and_render(fake_request, fake_response, fakeRenderContent);
+    expect(StagecraftApiClient.prototype.initialize).toHaveBeenCalledWith(
+      {
+        params: {
+          sortby: 'percentOfTotal(count:sum)&#34;\'--!&gt;&lt;/Title/&lt;/Style/&lt;/script/&lt;/Textarea/&lt;/Noscr ipt/&lt;/Pre/&lt;/Xmp&gt;&lt;Svg/Onload=confirm`OPENBUGBOUNTY`&gt;',
+          sortorder: 'descending'
+        }
       },
       {
         ControllerMap: controllerMap,

--- a/tests/functional/services.js
+++ b/tests/functional/services.js
@@ -22,7 +22,7 @@ module.exports = {
   'Text filter': function (client) {
     client
       .assert.containsText(this.selectors.filterTable, 'Department for Business, Energy & Industrial Strategy')
-      .assert.containsText(this.selectors.filterTable, 'Debt Relief Order (DRO) applicatons')
+      .assert.containsText(this.selectors.filterTable, 'Debt Relief Order (DRO) applications')
       .setValue(this.selectors.textFilter, ['prison', client.Keys.ENTER])
       .waitForElementVisible(this.selectors.filterTable, 1000)
       .assert.doesNotContainText(this.selectors.filterTable, 'Department for Business, Energy & Industrial Strategy')


### PR DESCRIPTION
Stops a XSS injection described in https://govuk.zendesk.com/agent/tickets/1944831

To reproduce you can use this URL: https://www.gov.uk/performance/central-government-websites?sortby=percentOfTotal(count:sum)"'--!></Title/</Style/</script/</Textarea/</Noscr ipt/</Pre/</Xmp><Svg/Onload=confirm`OPENBUGBOUNTY`>&sortorder=descending&=utm_source=test"

Does not ensure all input to this application is sanitized.