### PR TITLE
Remove govukHost config value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ branches:
   only:
     - master
 env:
+  - GOVUK_WEBSITE_ROOT: 'https://www.gov.uk'
   - TEST_CMD: test:unit
   - TEST_CMD: shell:cheapseats
   - TEST_CMD: test:functional:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ branches:
   only:
     - master
 env:
+  global:
   - GOVUK_WEBSITE_ROOT: 'https://www.gov.uk'
+  matrix:
   - TEST_CMD: test:unit
   - TEST_CMD: shell:cheapseats
   - TEST_CMD: test:functional:ci

--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -32,7 +32,6 @@ module.exports = {
       app.set('assetDigest', JSON.parse(fs.readFileSync(path.join(rootDir, 'public', 'asset-digest.json'), {encoding: 'utf8'})));
       app.set('backdropUrl', global.config.backdropUrl);
       app.set('externalBackdropUrl', global.config.externalBackdropUrl);
-      app.set('govukHost', global.config.govukHost);
       app.set('clientRequiresCors', global.config.clientRequiresCors);
       app.set('port', global.config.port);
       app.set('stagecraftUrl', global.config.stagecraftUrl);

--- a/app/page_config.js
+++ b/app/page_config.js
@@ -1,7 +1,7 @@
 define([],
 function () {
   var getGovUkUrl = function (req) {
-    return ['https://', req.app.get('govukHost'), req.originalUrl].join('');
+    return [process.env.GOVUK_WEBSITE_ROOT, req.originalUrl].join('');
   };
 
   var commonConfig = function (req) {

--- a/config/config.development.json
+++ b/config/config.development.json
@@ -3,7 +3,6 @@
   "port": 3057,
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
-  "govukHost": "www.alphagov.co.uk",
   "stagecraftUrl": "https://stagecraft.production.performance.service.gov.uk",
   "bigScreenBaseURL": "https://www.performance.service.gov.uk"
 }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export GOVUK_WEBSITE_ROOT=https://www.gov.uk
+
 npm install
 
 npm run test:unit

--- a/spec/server/spec.page_config.js
+++ b/spec/server/spec.page_config.js
@@ -10,7 +10,6 @@ function (PageConfig) {
       get.plan = function (prop) {
         return {
           assetPath: '/path/to/assets/',
-          govukHost: 'www.gov.uk',
           bigScreenBaseURL: 'https://www.performance.service.gov.uk'
         }[prop];
       };


### PR DESCRIPTION
This should use the GOVUK_WEBSITE_ROOT environment variable instead which is always set correctly.