### PR TITLE
Cache template sources

### DIFF
--- a/app/server/mixins/templater.js
+++ b/app/server/mixins/templater.js
@@ -1,4 +1,14 @@
 var fs = require('fs');
+var cache = require('memory-cache');
+
+var fetchTemplate = function (path) {
+  var template = cache.get(path);
+  if (template === null) {
+    var templateSource =  fs.readFileSync(path).toString();
+    template = cache.put(path, templateSource);
+  }
+  return template;
+};
 
 module.exports = {
 
@@ -16,7 +26,7 @@ module.exports = {
     data = data || {};
     type = type || 'underscore';
 
-    var template = fs.readFileSync(path);
+    var template = fetchTemplate(path);
 
     if (type === 'mustache') {
       return require('mustache').render(template.toString(), data);
@@ -27,4 +37,5 @@ module.exports = {
     }
 
   }
+
 };

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jshint-stylish": "0.2.0",
     "jsonschema": "0.4.0",
     "lodash": "2.4.1",
+    "memory-cache": "0.1.6",
     "moment-timezone": "0.2.4",
     "morgan": "1.1.1",
     "mustache": "0.8.2",

--- a/spec/server-pure/mixins/spec.templater.js
+++ b/spec/server-pure/mixins/spec.templater.js
@@ -1,39 +1,57 @@
+var fs        = require('fs');
+var cache     = require('memory-cache');
+var path      = require('path');
 var templater = require('../../../app/server/mixins/templater');
-var path = require('path');
 
 describe('Templater', function () {
 
   describe('loadTemplate', function () {
 
+    var templatePath;
+
     describe('mustache', function () {
 
-      var template;
-
       beforeEach(function () {
-        template = path.resolve(__dirname, './templates/test.mustache.html');
+        templatePath = path.resolve(__dirname, './templates/test.mustache.html');
       });
 
       it('renders the template with data passed', function () {
-        expect(templater.loadTemplate(template, { title: 'foo' }, 'mustache')).toEqual('<p>foo</p>');
+        expect(templater.loadTemplate(templatePath, { title: 'foo' }, 'mustache')).toEqual('<p>foo</p>');
       });
 
     });
+
     describe('underscore', function () {
 
-      var template;
-
       beforeEach(function () {
-        template = path.resolve(__dirname, './templates/test.underscore.html');
+        templatePath = path.resolve(__dirname, './templates/test.underscore.html');
       });
 
       it('renders the template with data passed', function () {
-        expect(templater.loadTemplate(template, { title: 'foo' }, 'underscore')).toEqual('<p>foo</p>');
+        expect(templater.loadTemplate(templatePath, { title: 'foo' }, 'underscore')).toEqual('<p>foo</p>');
       });
 
       it('uses underscore as a template type by default', function () {
-        expect(templater.loadTemplate(template, { title: 'foo' })).toEqual('<p>foo</p>');
+        expect(templater.loadTemplate(templatePath, { title: 'foo' })).toEqual('<p>foo</p>');
       });
 
+    });
+
+    describe('template caching', function () {
+      beforeEach(function() {
+        templatePath = path.resolve(__dirname, './templates/test.underscore.html');
+        templater.loadTemplate(templatePath, { title: 'foo' });
+        spyOn(fs, 'readFileSync');
+        templater.loadTemplate(templatePath, { title: 'foo' });
+      });
+
+      it('does not open the template file', function () {
+        expect(fs.readFileSync.callCount).toEqual(0);
+      });
+
+      it('caches the template', function () {
+        expect(cache.get(templatePath)).toEqual('<p><%= title %></p>');
+      });
     });
 
   });

--- a/spec/server/spec.page_config.js
+++ b/spec/server/spec.page_config.js
@@ -31,6 +31,10 @@ function (PageConfig) {
     });
 
     describe('getGovUkUrl', function () {
+      beforeEach(function () {
+        process.env.GOVUK_WEBSITE_ROOT = 'https://www.gov.uk';
+      });
+
       it('returns the equivalent page location on GOV.UK', function () {
         expect(PageConfig.getGovUkUrl(req)).toEqual('https://www.gov.uk/performance/foo');
       });


### PR DESCRIPTION
Express will cache the result of a call to render() but prior to this
we make a call to `fs.readFileSync` for the mustache or underscore template source.
This means a lot of IO as the static template source is never cached.
This commit adds the memory-cache node module, as this exposes the cache anywhere in the app.
The cached templates are keyed by path. No expiry time was added but this
is possible as a third arg to `cache.put()` if necessary.

Response to a problem found on 2ndline where Spotlight was pinned at 100% CPU and logging the error:

```
Error: EMFILE, too many open files '/.../app/server/templates/module.html'
    at Object.fs.openSync (fs.js:439:18)
    at Object.fs.readFileSync (fs.js:290:15)
    at module.exports.loadTemplate (/.../app/server/mixins/templater.js:19:23)
```