### PR TITLE
Remove ./node_modules/ before npm install on CI

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,6 +3,8 @@ set -e
 
 export GOVUK_WEBSITE_ROOT=https://www.gov.uk
 
+rm -rf ./node_modules/
+
 npm install
 
 npm run test:unit


### PR DESCRIPTION
The `./node_modules/` dependencies need to be refreshed on each build to pull in changes from repos like [Cheapseats](https://github.com/alphagov/cheapseats)