### PR TITLE
Update PaaS settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 env:
   global:
-    - GOVUK_WEBSITE_ROOT_STAGING=https://www-origin.integration.publishing.service.gov.uk
+    - GOVUK_WEBSITE_ROOT_STAGING=https://www-origin.staging.publishing.service.gov.uk
     - GOVUK_WEBSITE_ROOT_PRODUCTION=https://www.gov.uk
     - PAAS_USER=pp-deploy@digital.cabinet-office.gov.uk
     - PAAS_SERVICE=performance-platform-spotlight

--- a/config/config.production.json
+++ b/config/config.production.json
@@ -3,7 +3,7 @@
   "port": 3057,
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
-  "stagecraftUrl": "https://stagecraft-production.cloudapps.digital",
+  "stagecraftUrl": "https://performance-platform-stagecraft-production.cloudapps.digital",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
   "clientRequiresCors": true,

--- a/config/config.staging.json
+++ b/config/config.staging.json
@@ -3,7 +3,7 @@
   "port": 3057,
   "backdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
-  "stagecraftUrl": "https://stagecraft-staging.cloudapps.digital",
+  "stagecraftUrl": "https://performance-platform-stagecraft-staging.cloudapps.digital",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",
   "clientRequiresCors": true,


### PR DESCRIPTION
- Correct domain setting for GOV UK (staging
- Change domain setting for Stagecraft on PaaS (Stagecraft domain has been changed to make it consistent with other Performance Platform apps deployed to PaaS)