### PR TITLE
Fixes the path used for asset delivery

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -38,7 +38,9 @@ module.exports = {
       app.set('bigScreenBaseURL', global.config.bigScreenBaseURL);
       app.use(morgan('dev'));
       app.use(compression());
-      app.use('/spotlight', express.static(path.join(rootDir, 'public'), { maxAge: oneDay }));
+
+      // Serve static files from the configured assetPath.
+      app.use(global.config.assetPath, express.static(path.join(rootDir, 'public'), { maxAge: oneDay }));
     }());
 
     if (environment === 'development') {

--- a/config/config.development.json
+++ b/config/config.development.json
@@ -1,5 +1,5 @@
 {
-  "assetPath": "/spotlight/",
+  "assetPath": "/performance/assets/",
   "port": 3057,
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",

--- a/config/config.production.json
+++ b/config/config.production.json
@@ -1,5 +1,5 @@
 {
-  "assetPath": "/spotlight/",
+  "assetPath": "/performance/assets/",
   "port": 3057,
   "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",

--- a/config/config.staging.json
+++ b/config/config.staging.json
@@ -1,5 +1,5 @@
 {
-  "assetPath": "/spotlight/",
+  "assetPath": "/performance/assets/",
   "port": 3057,
   "backdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
   "externalBackdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",


### PR DESCRIPTION
Replaces the hard-coded asset path to use the one that is configured.
Even though the config specified /spotlight/ the router enforced the
use of that path making sure config changes had little effect.

Changed config to serve assets through /performance/assets/ to make prod
configuration easier.