### PR TITLE
Re-enable jshint tests for node 6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -368,6 +368,7 @@ module.exports = function (grunt) {
     'sass:development',
     'digest',
     'jasmine_node',
+    'jshint'
   ]);
 
   grunt.registerTask('test:all', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,7 @@ module.exports = function (grunt) {
         src: ['app/client/**/*.js', 'spec/client/**/*.js'],
         options: {
           reporter: require('jshint-stylish'),
+          reporterOutput: "",
           jshintrc: true,
           config: './node_modules/performanceplatform-js-style-configs/.jshintrc-browser.json'
         }
@@ -149,6 +150,7 @@ module.exports = function (grunt) {
           '!app/client/**/*.js', '!spec/client/**/*.js'],
         options: {
           reporter: require('jshint-stylish'),
+          reporterOutput: "",
           jshintrc: true,
           config: './node_modules/performanceplatform-js-style-configs/.jshintrc-node.json'
         }

--- a/app/extensions/views/table.js
+++ b/app/extensions/views/table.js
@@ -49,13 +49,13 @@ function (View, Formatters) {
       cls += (this.options.hideHeader === true) ? ' table-no-header' : '';
       caption = (this.options.caption) ? '<caption class="visuallyhidden">' + this.options.caption + '</caption>' : '';
       this.$el.append('<table class="' + cls + '">' + caption + '</table>');
-      this.$table = this.$('table')
+      this.$table = this.$('table');
     },
 
     render: function () {
       this.prepareTable();
-      this.$table.append(this.renderHead())
-      this.$table.append(this.renderBody())
+      this.$table.append(this.renderHead());
+      this.$table.append(this.renderBody());
     },
 
     renderHead: function () {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-contrib-concat": "0.5.1",
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-jasmine": "0.5.2",
-    "grunt-contrib-jshint": "0.11.0",
+    "grunt-contrib-jshint": "1.1.0",
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-watch": "0.6.1",
     "grunt-digest": "0.1.2",

--- a/spec/server-pure/helpers.js
+++ b/spec/server-pure/helpers.js
@@ -1,7 +1,7 @@
 var requirejs = require('requirejs');
 var path = require('path');
 
-var jquery = require('jquery')(require('jsdom').jsdom().defaultView)
+var jquery = require('jquery')(require('jsdom').jsdom().defaultView);
 
 require('backbone').$ = jquery;
 

--- a/spec/shared/extensions/views/spec.table.js
+++ b/spec/shared/extensions/views/spec.table.js
@@ -8,7 +8,7 @@ define([
 ],
 function (Table, View, Collection, Backbone, $, jsdom) {
 
-  var $ = $(jsdom.jsdom().defaultView);
+  $ = $(jsdom.jsdom().defaultView);
 
   describe('Table', function () {
     it('inherits from View', function () {


### PR DESCRIPTION
[In a past commit](https://github.com/alphagov/spotlight/commit/0a9039c30071c5d1c56b41f3383fa7b499367f03), I removed a couple of test commands that were failing.

This pull request:
- fixes the configuration so that `grunt jshint` will run properly again
- fixes the linting errors that crept in somehow (_oops_)