### PR TITLE
Wait for collection to exist before building tab interface

### DIFF
--- a/app/client/views/json-summary.js
+++ b/app/client/views/json-summary.js
@@ -5,23 +5,23 @@ define([
 
     initialize: function () {
 
-        this.listenTo(this.collection, 'reset add remove', this.render);
+      this.listenTo(this.collection, 'reset add remove', this.render);
     },
 
-    render: function(){
+    render: function() {
 
-        var url = this.collection.url();
-        var urlJson = url+'&format=json';
-        var urlCSV = url + '&format=csv';
-        var $newEl;
-        var $oldEl = this.$el;
+      var url = this.collection.url();
+      var urlJson = url+'&format=json';
+      var urlCSV = url + '&format=csv';
+      var $newEl;
+      var $oldEl = this.$el;
 
-        $newEl = $('<a href="' + urlJson + '">JSON</a> | <a href="' + urlCSV + '">CSV</a>');
+      $newEl = $('<a href="' + urlJson + '">JSON</a> | <a href="' + urlCSV + '">CSV</a>');
 
-        this.setElement($newEl);
-        $oldEl.replaceWith($newEl);
+      this.setElement($newEl);
+      $oldEl.replaceWith($newEl);
 
-        return this;
+      return this;
     }
 
  });

--- a/app/client/views/module.js
+++ b/app/client/views/module.js
@@ -24,9 +24,11 @@ define([
             view: this.datePickerClass
           };
         }
-        views['.json-summary'] = {
-            view: JsonSummary
-        };
+        if (this.collection) {
+          views['.json-summary'] = {
+              view: JsonSummary
+          };
+        }
       }
       return _.extend(ModuleView.prototype.views.apply(this, arguments), views);
     }


### PR DESCRIPTION
Resolves [this issue](https://github.com/alphagov/spotlight/issues/1048) by waiting until a collection has been returned before trying to manipulate it.