### PR TITLE
Fix link updating behaviour

### DIFF
--- a/app/client/views/json-summary.js
+++ b/app/client/views/json-summary.js
@@ -13,13 +13,7 @@ define([
       var url = this.collection.url();
       var urlJson = url+'&format=json';
       var urlCSV = url + '&format=csv';
-      var $newEl;
-      var $oldEl = this.$el;
-
-      $newEl = $('<a href="' + urlJson + '">JSON</a> | <a href="' + urlCSV + '">CSV</a>');
-
-      this.setElement($newEl);
-      $oldEl.replaceWith($newEl);
+      this.$el.html( $('<a href="' + urlJson + '">JSON</a> | <a href="' + urlCSV + '">CSV</a>') );
 
       return this;
     }

--- a/spec/client/views/spec.json-summary.js
+++ b/spec/client/views/spec.json-summary.js
@@ -12,7 +12,7 @@ function (JsonSummary, Model, Collection, $) {
 
     beforeEach(function () {
       $el = $('<li class="json-summary"></li>');
-      $el.html('<a href="<jsonUrl>">JSON</a> | <a href="<csvUrl>">CSV</a>');
+      $el.html('<a href="url&format=json">JSON</a> | <a href="url&format=csv">CSV</a>');
       view = new JsonSummary({
         el: $el,
         model: model,
@@ -23,10 +23,13 @@ function (JsonSummary, Model, Collection, $) {
     describe('render', function () {
       it('should update element to add new url assigned', function () {
         spyOn(collection, 'url').and.returnValue('newUrl');
-        var $oldEl = view.$el;
         view.render();
-        expect($oldEl).not.toEqual(view.$el);
-        expect(view.$el.attr('href')).toContain('newUrl');
+        expect(view.$el.prop('tagName')).toEqual('LI');
+        var $links = view.$el.find('a');
+
+        expect($links.length).toEqual(2);
+        expect($links.first().attr('href')).toEqual('newUrl&format=json');
+        expect($links.last().attr('href')).toEqual('newUrl&format=csv');
       });
 
     });


### PR DESCRIPTION
The previous code was:
1. removing the `<li>` element and replacing it with `<a>` elements
2. adding more `<a>` elements without removing the past ones

This meant that on some pages, where it was possible to filter data in the visualisation, modifying the filters would result in a bunch of links being appended one after another without cleaning up the previous links.
(for example)[https://www.gov.uk/performance/check-driving-information/volumetrics]

This new behaviour works as intended, the code is simpler and the tests are useful.