### PR TITLE
Point at the new backdrop URL

### DIFF
--- a/config/config.staging.json
+++ b/config/config.staging.json
@@ -2,7 +2,7 @@
   "assetPath": "/performance/assets/",
   "port": 3057,
   "backdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
-  "externalBackdropUrl": "https://www.staging.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}",
+  "externalBackdropUrl": "https://performance-platform-backdrop-read-staging.cloudapps.digital/data/{{ data-group }}/{{ data-type }}",
   "stagecraftUrl": "https://performance-platform-stagecraft-staging.cloudapps.digital",
   "screenshotTargetUrl": "http://localhost:3057",
   "screenshotServiceUrl": "http://localhost:3060",


### PR DESCRIPTION
Tells spotlight to look at the new backdrop hosted in the staging
environment.