### PR TITLE
Removed `spec-retry` reporter from cheapseats

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -270,7 +270,7 @@ module.exports = function (grunt) {
           stderr: true,
           stdout: true
         },
-        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec-retry --standalone --path --quickrun ./')
+        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec --standalone --path --quickrun ./')
       },
       // Runs all cheapseats tests
       cheapseats_full_run: {
@@ -279,7 +279,7 @@ module.exports = function (grunt) {
           stderr: true,
           stdout: true
         },
-        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec-retry --standalone --path ./')
+        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec --standalone --path ./')
       },
       nightwatch: {
         command: addArgs('./node_modules/nightwatch/bin/nightwatch')


### PR DESCRIPTION
Updated a bunch of npm libraries in cheapseats to get the tests running again on travis.

A side-effect of this is that we can't use the mocha `spec-retry` reporter.
Wasn't helping us anyway, so good riddance.