### PR TITLE
Stop showing CSV links on individual graph pages

### DIFF
--- a/app/client/views/json-summary.js
+++ b/app/client/views/json-summary.js
@@ -12,8 +12,7 @@ define([
 
       var url = this.collection.url();
       var urlJson = url+'&format=json';
-      var urlCSV = url + '&format=csv';
-      this.$el.html( $('<a href="' + urlJson + '">JSON</a> | <a href="' + urlCSV + '">CSV</a>') );
+      this.$el.html( $('<a href="' + urlJson + '">JSON</a>') );
 
       return this;
     }

--- a/app/server/templates/module.html
+++ b/app/server/templates/module.html
@@ -37,7 +37,7 @@
 <aside class="more-info download" role="complementary">
   <h2 id="download">Download the data</h2>
   <ul>
-    <li class="json-summary"><a href="<%= jsonUrl %>">JSON</a> | <a href="<%= csvUrl %>">CSV</a></li>
+    <li class="json-summary"><a href="<%= jsonUrl %>">JSON</a></li>
   </ul>
 </aside>
 

--- a/app/server/views/module.js
+++ b/app/server/views/module.js
@@ -59,7 +59,6 @@ module.exports = View.extend(templater).extend({
   templateContext: function () {
     if (this.collection) {
       this.jsonUrl = this.collection.externalUrl() + "&format=json";
-      this.csvUrl = this.collection.externalUrl() + "&format=csv";
     }
     return _.extend(
       View.prototype.templateContext.call(this),

--- a/spec/client/views/spec.json-summary.js
+++ b/spec/client/views/spec.json-summary.js
@@ -12,7 +12,7 @@ function (JsonSummary, Model, Collection, $) {
 
     beforeEach(function () {
       $el = $('<li class="json-summary"></li>');
-      $el.html('<a href="url&format=json">JSON</a> | <a href="url&format=csv">CSV</a>');
+      $el.html('<a href="url&format=json">JSON</a>');
       view = new JsonSummary({
         el: $el,
         model: model,
@@ -27,9 +27,8 @@ function (JsonSummary, Model, Collection, $) {
         expect(view.$el.prop('tagName')).toEqual('LI');
         var $links = view.$el.find('a');
 
-        expect($links.length).toEqual(2);
+        expect($links.length).toEqual(1);
         expect($links.first().attr('href')).toEqual('newUrl&format=json');
-        expect($links.last().attr('href')).toEqual('newUrl&format=csv');
       });
 
     });

--- a/spec/server-pure/views/spec.module.js
+++ b/spec/server-pure/views/spec.module.js
@@ -88,7 +88,7 @@ describe('ModuleView', function () {
     model.get('parent').set('page-type', 'module');
     moduleView.render();
     expect(moduleView.$('aside.more-info.download ul li').length).toEqual(1);
-    expect(moduleView.$('aside.more-info.download ul li:eq(0) a').text()).toEqual('JSONCSV');
+    expect(moduleView.$('aside.more-info.download ul li:eq(0) a').text()).toEqual('JSON');
   });
 
   it('renders a table when hasTable is true and there are axes on the collection', function () {


### PR DESCRIPTION
Pretty straightforward change. There used to be a JSON link and a CSV link, but now we just have the JSON one. It's still possible to get the original CSV response back if you use the JSON url and then change the query parameter. More detail in the actual commit, which I will include below for completeness.

```
Some of our CSVs are having formatting issues, which leaves us with
several options:

1. fix the formatting issue through backdrop
2. fix the formatting issue by returning CSVs in spotlight
3. remove the CSV links
4. do nothing -- leave everything as it is

We decided that (1) doesn't really solve the problem and that (2)
would be too hard for something we don't really know if people
care about at all.

Going with (3) until we have a compelling reason not to.

//

Note that it is still possible to get the CSV response -- all we
are doing is hiding the link. To get the CSV response instead
of the JSON one:
- copy the JSON link
- change where it says "format=json" to "format=csv"
- ta-da! same as before

```