### PR TITLE
Rate limits specific user agents

### DIFF
--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -25,7 +25,7 @@ module.exports = {
     (function () {
       // The number of milliseconds in one day
       var oneDay = 86400000;
-      var scrapers = /^Pcore-HTTP.*/i
+      var scrapers = /^Pcore-HTTP.*|.*360Spider.*/i
 
       app.set('environment', environment);
       app.set('requirePath', requireBaseUrl || '/app/');
@@ -40,9 +40,8 @@ module.exports = {
       app.use(compression());
 
       var limiter = new rateLimit({
-        // Skip rate-limiting if the user-agent doesn't match our scraper
-        // regex, otherwise limit-away!
-
+        // Rate-limit all requests from clients where the user-agent matches
+        // our scraper regex above.
         skip: function(req, res) {
           var source = req.headers['user-agent'] || "";
           return !source.match(scrapers);

--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -40,15 +40,21 @@ module.exports = {
       app.use(compression());
 
       var limiter = new rateLimit({
-        // Rate-limit all requests from clients where the user-agent matches
-        // our scraper regex above.
+        // Returning false will increment the counter
         skip: function(req, res) {
+          // Ignore 'assets' URLs
+          if (req.originalUrl.indexOf('assets') !== -1) {
+            return true;
+          }
+
+          // Rate-limit all requests from clients where the user-agent matches our scraper regex above.
           var source = req.headers['user-agent'] || "";
           return !source.match(scrapers);
         },
         windowMs: 60 * 1000, // 1 minute
         max: 60, // limit each IP to 60 requests per minute if skip: returns false
         delayMs: 0, // disable delaying
+        skipFailedRequests: true, //  when true failed requests (response status >= 400) won't be counted
         message: "Too many requests from this IP. Please get in touch if you require the raw data.",
       });
 

--- a/app/appBuilder.js
+++ b/app/appBuilder.js
@@ -25,7 +25,7 @@ module.exports = {
     (function () {
       // The number of milliseconds in one day
       var oneDay = 86400000;
-      var scrapers = /^Pcore-HTTP.*|.*360Spider.*/i
+      var scrapers = /^Pcore-HTTP.*|.*360Spider.*/i;
 
       app.set('environment', environment);
       app.set('requirePath', requireBaseUrl || '/app/');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "d3": "3.3.7",
     "errorhandler": "1.5.0",
     "express": "4.15.4",
+    "express-rate-limit": "^2.9.0",
     "glob": "7.0.3",
     "govuk_frontend_toolkit": "4.9.1",
     "govuk_template_mustache": "0.12.0",


### PR DESCRIPTION
As we are getting lots of impolite requests from specific user agents
(yes, I'm looking at you Pcore-HTTP) we should rate-limit them to
something more reasonable than 30 r/s.

This may not solve the problem (they could change user-agent) but
the same problems with identifying requests exists using other things
such as IP.

We __could__ also rate-limit everyone, but that seems like it might
be wasteful of server resources.