### PR TITLE
Update jquery to version 3.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -263,24 +263,6 @@ module.exports = function (grunt) {
       }
     },
     shell: {
-      // Runs subset of cheapseats tests
-      cheapseats: {
-        options: {
-          failOnError: true,
-          stderr: true,
-          stdout: true
-        },
-        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec --standalone --path --quickrun ./')
-      },
-      // Runs all cheapseats tests
-      cheapseats_full_run: {
-        options: {
-          failOnError: true,
-          stderr: true,
-          stdout: true
-        },
-        command: addArgs('node ./node_modules/cheapseats/index.js --reporter spec --standalone --path ./')
-      },
       nightwatch: {
         command: addArgs('./node_modules/nightwatch/bin/nightwatch')
       },
@@ -381,12 +363,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test:all', [
     'test:unit',
-    'shell:cheapseats',
     'test:functional'
-  ]);
-
-  grunt.registerTask('cheapseats', [
-    'shell:cheapseats'
   ]);
 
   grunt.registerTask('nightwatch', [
@@ -411,10 +388,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test:functional:all', [
     'shell:nightwatch:-e default,chrome,phantomjs'
-  ]);
-
-  grunt.registerTask('cheapseats:unpublished', [
-    'shell:cheapseats:--unpublished'
   ]);
 
   // Default task

--- a/package-lock.json
+++ b/package-lock.json
@@ -2944,9 +2944,9 @@
       }
     },
     "jquery": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.1.tgz",
-      "integrity": "sha1-tuyShZARLr7Wnh5Jy/0AJczWDds="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.0.0.tgz",
+      "integrity": "sha1-laKpVBKRqfgZ4Bb4W6JHEW0D5Ks="
     },
     "jquery-deparam": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-jasmine-node-new": "git+https://github.com/rossjones/grunt-jasmine-node",
     "grunt-sass": "2.0.0",
     "grunt-shell": "2.1.0",
-    "jquery": "1.11.1",
+    "jquery": "~> 3.0.0 ",
     "jquery-deparam": "^0.5.3",
     "jsdom": "^3.1.2",
     "jshint-stylish": "^2.2.1",


### PR DESCRIPTION
Also completes the de-activation of the cheapseats tests so they don't
run when you run ```npm test```