### PR TITLE
Update to nearest Node version supported by PaaS

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/alphagov/spotlight.git"
   },
   "engines": {
-    "node": "6.12.2"
+    "node": "6.13.1"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
This is what happens with the old version:
```Downloaded app package (113.9M)
-----> Nodejs Buildpack version 1.6.22
-----> Installing binaries
       engines.node (package.json): 6.12.2
       engines.npm (package.json): unspecified (use default)
       **ERROR** Unable to install node: no match found for 6.12.2 in [9.9.0 8.10.0 6.13.1 4.8.7 8.11.1 6.14.1 4.9.1 9.11.1]
Failed to compile droplet: Failed to run all supply scripts: exit status 14
Exit status 223
```