### PR TITLE
don't crash if there's no data to put in the table

### DIFF
--- a/app/extensions/views/table_fallback.js
+++ b/app/extensions/views/table_fallback.js
@@ -15,11 +15,12 @@ function (TableView) {
       this.valueAttr = this.options.valueAttr;
       this.period = this.collection.getPeriod();
 
-      this.collection.models = this.collection.last(6);
-      this.collection.length = this.collection.models.length;
-
-      this.listenTo(this.collection, 'reset add remove', this.render);
-      this.initSort();
+      if (this.collection.models.length > 0) {
+        this.collection.models = this.collection.last(6);
+        this.collection.length = this.collection.models.length;
+        this.listenTo(this.collection, 'reset add remove', this.render);
+        this.initSort();
+      }
     }
 
   });


### PR DESCRIPTION
This stops the app crashing if there's no data to display in the fallback (no-js) tables.

Next, we need to fix the broken layout that is shown in that case, but this will stop the app crashing for now.
