### PR TITLE
make manifests match reality

### DIFF
--- a/manifest.production.yml
+++ b/manifest.production.yml
@@ -2,7 +2,7 @@
 services:
   - logit-ssl-drain
 applications:
-  - name: performance-platform-spotlight
+  - name: performance-platform-spotlight-production
     memory: 1G
     instances: 6
     buildpack: nodejs_buildpack

--- a/manifest.staging.yml
+++ b/manifest.staging.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: performance-platform-spotlight
+  - name: performance-platform-spotlight-staging
     memory: 1G
     instances: 2
     buildpack: nodejs_buildpack


### PR DESCRIPTION
The manifests for spotlight set one name for the app, but
etc/deploy.sh overrides this to a different name.

This is confusing and has left us with multiple copies of spotlight
running, bound to the same route.

To avoid this footgun in future, I think we should have the manifests
use the actual app name that we actually deploy.  I hope this is not a
controversial opinion.