### PR TITLE
return to old-style buildpacks

### DIFF
--- a/manifest.production.yml
+++ b/manifest.production.yml
@@ -5,8 +5,7 @@ applications:
   - name: performance-platform-spotlight-production
     memory: 1G
     instances: 6
-    buildpacks:
-      - "https://github.com/alphagov/spotlight/releases/download/oldjs_buildpack/nodejs_buildpack-cached-cflinuxfs3-v1.6.48.zip"
+    buildpack: "https://github.com/alphagov/spotlight/releases/download/oldjs_buildpack/nodejs_buildpack-cached-cflinuxfs3-v1.6.48.zip"
     command: "npm run build:production && node app/server"
     stack: cflinuxfs3
     no-route: true # temp disable while in maintainance

--- a/manifest.staging.yml
+++ b/manifest.staging.yml
@@ -2,8 +2,7 @@
 applications:
   - name: performance-platform-spotlight-staging
     memory: 1G
-    buildpacks:
-      - "https://github.com/alphagov/spotlight/releases/download/oldjs_buildpack/nodejs_buildpack-cached-cflinuxfs3-v1.6.48.zip"
+    buildpack: "https://github.com/alphagov/spotlight/releases/download/oldjs_buildpack/nodejs_buildpack-cached-cflinuxfs3-v1.6.48.zip"
     instances: 2
     command: "npm run build:production && node app/server"
     stack: cflinuxfs3


### PR DESCRIPTION
use `buildpack` over `buildpacks` since blue-green plugin does not
understand the new manifest syntax.