### PR TITLE
add download form to export historical data

### DIFF
--- a/app/server/templates/module.html
+++ b/app/server/templates/module.html
@@ -37,8 +37,55 @@
 <aside class="more-info download" role="complementary">
   <h2 id="download">Download the data</h2>
   <ul>
-    <li class="json-summary"><a href="<%= jsonUrl %>">JSON</a></li>
+    <li>Historical data is available for download in CSV or JSON formats. You should be able to open CSV formatted data for viewing in spreadsheet software like Microsoft Excel or Google Sheets.</li>
   </ul>
+  <form class="download-data" method="get" action="<%= downloadUrl %>">
+    <% _.each(downloadParams, function(v, k){ %>
+	  <input type="hidden" name="<%= k %>" value="<%= v %>" />
+    <% }) %>
+    <label>From</label>
+    <select class="download-start-at" name="start_at">
+      <% _.times(6, function(i){ %>
+        <% year = (new Date()).getFullYear() - i + 1 %>
+        <option value="<%= year %>-01-01T00:00:00Z">January <%= year %></option>
+        <option value="<%= year %>-02-01T00:00:00Z">February <%= year %></option>
+        <option value="<%= year %>-03-01T00:00:00Z">March <%= year %></option>
+        <option value="<%= year %>-04-01T00:00:00Z">April <%= year %></option>
+        <option value="<%= year %>-05-01T00:00:00Z">May <%= year %></option>
+        <option value="<%= year %>-06-01T00:00:00Z">June <%= year %></option>
+        <option value="<%= year %>-07-01T00:00:00Z">July <%= year %></option>
+        <option value="<%= year %>-08-01T00:00:00Z">August <%= year %></option>
+        <option value="<%= year %>-09-01T00:00:00Z">September <%= year %></option>
+        <option value="<%= year %>-10-01T00:00:00Z">October <%= year %></option>
+        <option value="<%= year %>-11-01T00:00:00Z">November <%= year %></option>
+        <option value="<%= year %>-12-01T00:00:00Z">December <%= year %></option>
+      <% }) %>
+    </select>
+    <label>to</label>
+    <select class="download-end-at" name="end_at">
+      <% _.times(6, function(i){ %>
+        <% year = (new Date()).getFullYear() - i + 1 %>
+        <option value="<%= year %>-01-01T00:00:00Z">January <%= year %></option>
+        <option value="<%= year %>-02-01T00:00:00Z">February <%= year %></option>
+        <option value="<%= year %>-03-01T00:00:00Z">March <%= year %></option>
+        <option value="<%= year %>-04-01T00:00:00Z">April <%= year %></option>
+        <option value="<%= year %>-05-01T00:00:00Z">May <%= year %></option>
+        <option value="<%= year %>-06-01T00:00:00Z">June <%= year %></option>
+        <option value="<%= year %>-07-01T00:00:00Z">July <%= year %></option>
+        <option value="<%= year %>-08-01T00:00:00Z">August <%= year %></option>
+        <option value="<%= year %>-09-01T00:00:00Z">September <%= year %></option>
+        <option value="<%= year %>-10-01T00:00:00Z">October <%= year %></option>
+        <option value="<%= year %>-11-01T00:00:00Z">November <%= year %></option>
+        <option value="<%= year %>-12-01T00:00:00Z">December <%= year %></option>
+      <% }) %>
+    </select>
+    <label>in format</label>
+    <select class="download-format" name="format">
+      <option value="csv">CSV</option>
+      <option value="json">JSON</option>
+    </select>
+    <input class="download-submit" type="submit" value="Download" />
+  </form>
 </aside>
 
 

--- a/spec/server-pure/views/spec.module.js
+++ b/spec/server-pure/views/spec.module.js
@@ -88,7 +88,7 @@ describe('ModuleView', function () {
     model.get('parent').set('page-type', 'module');
     moduleView.render();
     expect(moduleView.$('aside.more-info.download ul li').length).toEqual(1);
-    expect(moduleView.$('aside.more-info.download ul li:eq(0) a').text()).toEqual('JSON');
+    expect(moduleView.$('aside.more-info.download form').length).toEqual(1);
   });
 
   it('renders a table when hasTable is true and there are axes on the collection', function () {

--- a/styles/common/filteredlist.scss
+++ b/styles/common/filteredlist.scss
@@ -67,6 +67,68 @@
     }
   }
 
+  form.download-data {
+
+    label {
+      display: block;
+      font-weight: bold;
+    }
+
+    input {
+      margin: 0;
+      width: 100%;
+      padding: .4em .5em;
+      position:relative;
+      top: 0;
+    }
+    ::-webkit-input-placeholder {
+      color: $grey-1;
+    }
+
+    :-moz-placeholder { /* Firefox 18- */
+      color: $grey-1;
+    }
+
+    ::-moz-placeholder {  /* Firefox 19+ */
+      color: $grey-1;
+    }
+
+    :-ms-input-placeholder {
+      color: $grey-1;
+    }
+
+
+    input {
+      @include core-16;
+    }
+
+    select {
+      @include core-16;
+      background: $white;
+      line-height: 1.8;
+      width: 100%;
+
+      @include media(desktop) {
+        @include appearance(none);
+        @include box-shadow(1px 1px 1px $white);
+        @include border-radius(4px);
+        background: $grey-3 file-url('images/dropdown-arrow-small.png') no-repeat right center;
+        border: 1px solid $border-colour;
+        padding: 0.2em 25px 0.2em 0.4em;
+      }
+    }
+    select::-ms-expand {
+      display: none;
+    }
+
+    input.download-submit {
+      @include button;
+      margin-top: 1em;
+      width: auto;
+	  display:block;
+    }
+  }
+
   section.filtered-list {
     padding: 1em 0 0 0;
     margin-top: 0;


### PR DESCRIPTION
## What

displays a small HTML form to select a start/end month/year and file
format, that when submitted requests an export of the data for the
current page for the given time range.

## Why

without the graph functionality, it is not easy to fetch the historical
data that is available for the various service dashboards, having a form
makes this more discoverable.

The addition of the CSV format, lowers the bar to who might be able to
consume the data, since it is more readily supported by common
spreadsheet tools.

## Screenshot

![Screen Shot 2019-12-23 at 14 06 18](https://user-images.githubusercontent.com/45921/71362582-65b27780-258e-11ea-850b-78410da0d366.png)

## After merge

* ⚠️ Remember to merge to `staging` and `production` branches to deploy