### PR TITLE
Add banner with deprecation message

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,13 +194,6 @@ module.exports = function (grunt) {
     },
     // Copies templates and assets from external modules and dirs
     copy: {
-      govuk_template: {
-        src: 'node_modules/govuk_template_mustache/views/layouts/govuk_template.html',
-        dest: 'app/server/templates/page-components/',
-        expand: true,
-        flatten: true,
-        filter: 'isFile'
-      },
       govuk_assets: {
         files: [
           {
@@ -328,7 +321,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build:common', [
     'copy:vendor',
-    'copy:govuk_template',
     'clean',
     'copy:assets'
   ]);
@@ -351,7 +343,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test:unit', [
     'copy:vendor',
-    'copy:govuk_template',
     'clean',
     'copy:assets',
     'sass:development',

--- a/app/server/templates/page-components/deprecation_message.html
+++ b/app/server/templates/page-components/deprecation_message.html
@@ -1,5 +1,5 @@
 <!-- <header role="banner" class="with-proposition"> -->
     <p>GDS is deprecating the Performance Platform effective from 15 March 2021.</p> 
     <p>The historical data will be made available via the <a href="https://www.nationalarchives.gov.uk/">National Archives</a> in late March 2021.</p> 
-    <p>Future Performance data hosted by services will be available via <a href="https://data.gov.uk/"></a>data.gov.uk.</a></p>
+    <p>Future Performance data hosted by services will be available via <a href="https://data.gov.uk/">data.gov.uk.</a></p>
 <!-- </header> -->

--- a/app/server/templates/page-components/deprecation_message.html
+++ b/app/server/templates/page-components/deprecation_message.html
@@ -1,5 +1,7 @@
-<!-- <header role="banner" class="with-proposition"> -->
-    <p>GDS is deprecating the Performance Platform effective from 15 March 2021.</p> 
+    <!-- <p>GDS is deprecating the Performance Platform effective from 15 March 2021.</p> 
     <p>The historical data will be made available via the <a href="https://www.nationalarchives.gov.uk/">National Archives</a> in late March 2021.</p> 
-    <p>Future Performance data hosted by services will be available via <a href="https://data.gov.uk/">data.gov.uk.</a></p>
-<!-- </header> -->
+    <p>Future Performance data hosted by services will be available via <a href="https://data.gov.uk/">data.gov.uk.</a></p> -->
+
+GDS is deprecating the Performance Platform effective from 15 March 2021.
+The historical data will be made available via the <a href="https://www.nationalarchives.gov.uk/">National Archives</a> in late March 2021. 
+Future Performance data hosted by services will be available via <a href="https://data.gov.uk/">data.gov.uk.</a>

--- a/app/server/templates/page-components/deprecation_message.html
+++ b/app/server/templates/page-components/deprecation_message.html
@@ -1,0 +1,5 @@
+<!-- <header role="banner" class="with-proposition"> -->
+    <p>GDS is deprecating the Performance Platform effective from 15 March 2021.</p> 
+    <p>The historical data will be made available via the <a href="https://www.nationalarchives.gov.uk/">National Archives</a> in late March 2021.</p> 
+    <p>Future Performance data hosted by services will be available via <a href="https://data.gov.uk/"></a>data.gov.uk.</a></p>
+<!-- </header> -->

--- a/app/server/templates/page-components/govuk_template.html
+++ b/app/server/templates/page-components/govuk_template.html
@@ -78,7 +78,17 @@
     </div>
     <!--end global-cookie-message-->
 
-    
+    <div id="deprecation-message">
+      <div class="outer-block">
+        <div class="inner-block">
+          
+          {{{ deprecationMessage }}}
+          
+        </div>
+      </div>
+    </div>
+    <!--end deprecation-message-->
+   
     <header role="banner" id="global-header" class="{{{ headerClass }}}">
       <div class="header-wrapper">
         <div class="header-global">

--- a/app/server/templates/page-components/govuk_template.html
+++ b/app/server/templates/page-components/govuk_template.html
@@ -78,14 +78,10 @@
     </div>
     <!--end global-cookie-message-->
 
-    <div id="deprecation-message">
-      <div class="outer-block">
-        <div class="inner-block">
-          
-          {{{ deprecationMessage }}}
-          
-        </div>
-      </div>
+    <div id="deprecation-message" class="phase-banner">
+    
+      {{{ deprecationMessage }}}
+              
     </div>
     <!--end deprecation-message-->
    

--- a/app/server/views/govuk.js
+++ b/app/server/views/govuk.js
@@ -16,6 +16,7 @@ var footerTopTemplate = pr('../templates/page-components/footer_top.html');
 var footerLinksTemplate = pr('../templates/page-components/footer_links.html');
 var reportAProblemTemplate = pr('../templates/page-components/report_a_problem.html');
 var cookieMessageTemplate = pr('../templates/page-components/cookie_message.html');
+var deprecationMessageTemplate = pr('../templates/page-components/deprecation_message.html');
 var contentTemplate = pr('../templates/page-components/content.html');
 
 
@@ -88,6 +89,7 @@ module.exports = View.extend(templater).extend({
         htmlLang: 'en',
         propositionHeader: this.loadTemplate(navigationTemplate, 'mustache'),
         cookieMessage: this.loadTemplate(cookieMessageTemplate, 'mustache'),
+        deprecationMessage: this.loadTemplate(deprecationMessageTemplate, 'mustache'),
         footerTop: this.loadTemplate(footerTopTemplate, 'mustache'),
         footerSupportLinks: this.loadTemplate(footerLinksTemplate, 'mustache'),
         content: this.loadTemplate(contentTemplate, {

--- a/manifest.sandbox.yml
+++ b/manifest.sandbox.yml
@@ -1,0 +1,15 @@
+---
+applications:
+  - name: performance-platform-spotlight-sandbox
+    memory: 1G
+    buildpack: "https://github.com/alphagov/spotlight/releases/download/oldjs_buildpack/nodejs_buildpack-cached-cflinuxfs3-v1.6.48.zip"
+    instances: 2
+    command: "npm run build:production && node app/server"
+    stack: cflinuxfs3
+    routes:
+    - route: performance-platform-spotlight-sandbox.apps.internal
+    - route: performance-platform-spotlight-sandbox.cloudapps.digital
+    env:
+      NODE_VERSION: "6.17.1"
+      NODE_ENV: production
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk

--- a/styles/common/raw.scss
+++ b/styles/common/raw.scss
@@ -1,7 +1,6 @@
 body.raw {
   #skiplink-container,
   #global-cookie-message,
-  #deprecation-message,
   #global-header-bar .header-bar,
   #global-header,
   #footer,
@@ -49,4 +48,13 @@ body.raw {
       display: table-row-group;
     }
   }
+}
+
+#deprecation-message {
+  display: block;
+  max-width: 990px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/styles/common/raw.scss
+++ b/styles/common/raw.scss
@@ -1,6 +1,7 @@
 body.raw {
   #skiplink-container,
   #global-cookie-message,
+  #deprecation-message,
   #global-header-bar .header-bar,
   #global-header,
   #footer,


### PR DESCRIPTION
Add banner to local copy of govuk_template and prevent its replacement with the npm module version by grunt during build tasks.